### PR TITLE
Fixed analyse_freenrg...

### DIFF
--- a/corelib/src/libs/SireUnits/convert.cpp
+++ b/corelib/src/libs/SireUnits/convert.cpp
@@ -246,7 +246,7 @@ namespace SireUnits
 
                 strings->insert(DimensionKey(kcal), QPair<double, QString>(kcal, "kcal"));
 
-                strings->insert(DimensionKey(kelvin), QPair<double, QString>(kelvin, "°K"));
+                strings->insert(DimensionKey(kelvin), QPair<double, QString>(kelvin, "K"));
 
                 strings->insert(DimensionKey(degree), QPair<double, QString>(degree, "°"));
 

--- a/wrapper/python/scripts/analyse_freenrg.py
+++ b/wrapper/python/scripts/analyse_freenrg.py
@@ -7,6 +7,7 @@ import warnings
 
 try:
     import sire
+
     sire.use_old_api()
 except ImportError:
     pass
@@ -113,106 +114,179 @@ def processFreeEnergies(nrgs, FILE):
     return name, convergence, pmf
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser(description="Analyse free energy files to calculate "
-                                                 "free energies, PMFs and to view convergence.",
-                                     epilog="analyse_freenrg is built using Sire and is distributed "
-                                            "under the GPL. For more information please visit "
-                                            "http://sire.openbiosim.org/analyse_freenrg",
-                                     prog="analyse_freenrg")
-    parser.add_argument('--description', action="store_true",
-                        help="Print a complete description of this program.")
+    parser = argparse.ArgumentParser(
+        description="Analyse free energy files to calculate "
+        "free energies, PMFs and to view convergence.",
+        epilog="analyse_freenrg is built using Sire and is distributed "
+        "under the GPL. For more information please visit "
+        "http://sire.openbiosim.org/analyse_freenrg",
+        prog="analyse_freenrg",
+    )
+    parser.add_argument(
+        "--description",
+        action="store_true",
+        help="Print a complete description of this program.",
+    )
 
-    parser.add_argument('--author', action="store_true",
-                        help="Get information about the authors of this script.")
+    parser.add_argument(
+        "--author",
+        action="store_true",
+        help="Get information about the authors of this script.",
+    )
 
-    parser.add_argument('--version', action="store_true",
-                        help="Get version information about this script.")
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Get version information about this script.",
+    )
 
-    parser.add_argument('-i', '--input', nargs=1,
-                        help="Supply the name of the Sire Streamed Save (.s3) file containing the "
-                             "free energies to be analysed.")
+    parser.add_argument(
+        "-i",
+        "--input",
+        nargs=1,
+        help="Supply the name of the Sire Streamed Save (.s3) file containing the "
+        "free energies to be analysed.",
+    )
 
-    parser.add_argument('-g', '--gradients', nargs='*',
-                        help="Supply the name of the Sire Streamed gradients (.s3) files containing the "
-                             "gradients to be analysed.")
+    parser.add_argument(
+        "-g",
+        "--gradients",
+        nargs="*",
+        help="Supply the name of the Sire Streamed gradients (.s3) files containing the "
+        "gradients to be analysed.",
+    )
 
-    parser.add_argument('-o', '--output', nargs=1,
-                        help="""Supply the name of the file in which to write the output.""")
+    parser.add_argument(
+        "-o",
+        "--output",
+        nargs=1,
+        help="""Supply the name of the file in which to write the output.""",
+    )
 
-    parser.add_argument('-r', '--range', nargs=2,
-                        help="Supply the range of iterations over which to average. "
-                             "By default, this will be over the last 60 percent of iterations.")
+    parser.add_argument(
+        "-r",
+        "--range",
+        nargs=2,
+        help="Supply the range of iterations over which to average. "
+        "By default, this will be over the last 60 percent of iterations.",
+    )
 
-    parser.add_argument('-p', '--percent', nargs=1,
-                        help="Supply the percentage of iterations over which to average. By default "
-                             "the average will be over the last 60 percent of iterations.")
+    parser.add_argument(
+        "-p",
+        "--percent",
+        nargs=1,
+        help="Supply the percentage of iterations over which to average. By default "
+        "the average will be over the last 60 percent of iterations.",
+    )
 
     sys.stdout.write("\n")
 
-    subparser = parser.add_subparsers(description="Analyse free energy files to calculate "
-                                                  "free energies, PMFs and to view convergence.",
-                                      prog="analyse_freenrg")
-    parser_mbar = subparser.add_parser('mbar')
+    subparser = parser.add_subparsers(
+        description="Analyse free energy files to calculate "
+        "free energies, PMFs and to view convergence.",
+        prog="analyse_freenrg",
+    )
+    parser_mbar = subparser.add_parser("mbar")
 
-    parser_mbar.add_argument('--description', action="store_true",
-                             help="Print a complete description of this program.")
+    parser_mbar.add_argument(
+        "--description",
+        action="store_true",
+        help="Print a complete description of this program.",
+    )
 
-    parser_mbar.add_argument('--author', action="store_true",
-                             help="Get information about the authors of this script.")
+    parser_mbar.add_argument(
+        "--author",
+        action="store_true",
+        help="Get information about the authors of this script.",
+    )
 
-    parser_mbar.add_argument('--version', action="store_true",
-                             help="Get version information about this script.")
+    parser_mbar.add_argument(
+        "--version",
+        action="store_true",
+        help="Get version information about this script.",
+    )
 
-    parser_mbar.add_argument('-i', '--input', nargs='*',
-                             help="Supply the name of the Sire simulation.dat files containing "
-                                  "gradients and perturbed energies to be analysed. Valid options are: "
-                                  "'simfile1.dat, simfile2.dat', or 'simfile1.dat simfile2.dat', or "
-                                  "wildcard arguments 'lambda*/simfile.dat'")
+    parser_mbar.add_argument(
+        "-i",
+        "--input",
+        nargs="*",
+        help="Supply the name of the Sire simulation.dat files containing "
+        "gradients and perturbed energies to be analysed. Valid options are: "
+        "'simfile1.dat, simfile2.dat', or 'simfile1.dat simfile2.dat', or "
+        "wildcard arguments 'lambda*/simfile.dat'",
+    )
 
-    parser_mbar.add_argument('-o', '--output',
-                             help="""Supply the name of the file in which to write the output.""")
+    parser_mbar.add_argument(
+        "-o",
+        "--output",
+        help="""Supply the name of the file in which to write the output.""",
+    )
 
-    parser_mbar.add_argument('-p', '--percent', type=float,
-                             help="Supply the percentage of iterations over which to average. By default "
-                                  "the average will be over the last 60 percent of iterations.")
-    parser_mbar.add_argument('--discard', type=int,
-                             help="Number of saved simulation snapshots that should be discarded at the beginning of a trajectory.")
+    parser_mbar.add_argument(
+        "-p",
+        "--percent",
+        type=float,
+        help="Supply the percentage of iterations over which to average. By default "
+        "the average will be over the last 60 percent of iterations.",
+    )
+    parser_mbar.add_argument(
+        "--discard",
+        type=int,
+        help="Number of saved simulation snapshots that should be discarded at the beginning of a trajectory.",
+    )
 
-    parser_mbar.add_argument('--lam', type=float, nargs='*',
-                             help="lambda array")
+    parser_mbar.add_argument(
+        "--lam", type=float, nargs="*", help="lambda array"
+    )
 
-    parser_mbar.add_argument('--temperature', type=float,
-                             help="Temperature at which the simulation was run in Kelvin.")
+    parser_mbar.add_argument(
+        "--temperature",
+        type=float,
+        help="Temperature at which the simulation was run in Kelvin.",
+    )
 
-    parser_mbar.add_argument('--subsampling', action="store_true",
-                             help="Subsampling of data according to statistical inefficiency should be done.")
+    parser_mbar.add_argument(
+        "--subsampling",
+        action="store_true",
+        help="Subsampling of data according to statistical inefficiency should be done.",
+    )
 
-    parser_mbar.add_argument('--overlap', action="store_true",
-                             help="Compute the overlap matrix")
+    parser_mbar.add_argument(
+        "--overlap", action="store_true", help="Compute the overlap matrix"
+    )
 
     args, unknown = parser.parse_known_args()
 
     if len(sys.argv) < 2:
         parser.print_help()
-        print("\nPlease supply the name of the .s3 file(s) containing the free energies/gradients to be analysed.")
+        print(
+            "\nPlease supply the name of the .s3 file(s) containing the free energies/gradients to be analysed."
+        )
         sys.exit(1)
 
     ##########################################
     #         Free energy with s3 files      #
     ##########################################
-    if sys.argv[1] != 'mbar':
+    if sys.argv[1] != "mbar":
         for u in unknown:
-            mbar_list = ['--temperature', '--subsampling', '--lam', '--overlap']
+            mbar_list = [
+                "--temperature",
+                "--subsampling",
+                "--lam",
+                "--overlap",
+            ]
             if u in mbar_list:
                 parser_mbar.print_help()
-                print ('analyse_freenrg: error: mbar command argument: %s ' % u)
-                print ('Try adding the mabr command option')
+                print("analyse_freenrg: error: mbar command argument: %s " % u)
+                print("Try adding the mabr command option")
                 sys.exit(1)
             else:
                 parser_mbar.print_help()
-                print ('analyse_freenrg: error: unrecognized arguments: %s ' % u)
+                print(
+                    "analyse_freenrg: error: unrecognized arguments: %s " % u
+                )
                 sys.exit(1)
 
         must_exit = False
@@ -222,14 +296,22 @@ if __name__ == '__main__':
             must_exit = True
 
         if args.author:
-            print("\nanalyse_freenrg was written by Christopher Woods (C) 2014")
+            print(
+                "\nanalyse_freenrg was written by Christopher Woods (C) 2014"
+            )
             print("It is based on the analysis tools in Sire.Analysis")
             must_exit = True
 
         if args.version:
-            print("analyse_freenrg -- from Sire release version <%s>" % Sire.__version__)
-            print("This particular release can be downloaded here: "
-                  "https://github.com/openbiosim/sire/releases/tag/v%s" % Sire.__version__)
+            print(
+                "analyse_freenrg -- from Sire release version <%s>"
+                % Sire.__version__
+            )
+            print(
+                "This particular release can be downloaded here: "
+                "https://github.com/openbiosim/sire/releases/tag/v%s"
+                % Sire.__version__
+            )
             must_exit = True
 
         if must_exit:
@@ -273,11 +355,13 @@ if __name__ == '__main__':
         if not input_file:
             if gradient_files:
                 input_file = gradient_files
-                print (input_file)
+                print(input_file)
 
         if not input_file:
             parser.print_help()
-            print("\nPlease supply the name of the .s3 file(s) containing the free energies/gradients to be analysed.")
+            print(
+                "\nPlease supply the name of the .s3 file(s) containing the free energies/gradients to be analysed."
+            )
             sys.exit(-1)
 
         if output_file:
@@ -289,7 +373,10 @@ if __name__ == '__main__':
 
         # input_file = os.path.realpath(input_file)
 
-        FILE.write("# Analysing free energies contained in file(s) \"%s\"\n" % input_file)
+        FILE.write(
+            '# Analysing free energies contained in file(s) "%s"\n'
+            % input_file
+        )
 
         num_inputfiles = len(input_file)
 
@@ -383,7 +470,9 @@ if __name__ == '__main__':
         try:
             p = ap.AFigure()
             strt = int(len(x) / 10)
-            conv_plot = p.plot(numpy.array(x[strt:]), numpy.array(y[strt:]), ".")
+            conv_plot = p.plot(
+                numpy.array(x[strt:]), numpy.array(y[strt:]), "."
+            )
             FILE.write("\nPlot of free energy versus iteration\n")
             FILE.write(conv_plot + "\n\n")
         except Exception as e:
@@ -399,14 +488,20 @@ if __name__ == '__main__':
 
             for value in result[2].values():
                 FILE.write(
-                    "%s  %s  %s  %s\n" % (
-                        value.x(), value.y(), value.y() + value.yMaxError(), value.y() - value.yMaxError()))
+                    "%s  %s  %s  %s\n"
+                    % (
+                        value.x(),
+                        value.y(),
+                        value.y() + value.yMaxError(),
+                        value.y() - value.yMaxError(),
+                    )
+                )
                 x.append(value.x())
                 y.append(value.y())
 
             try:
                 p = ap.AFigure()
-                pmf_plot = p.plot(numpy.array(x), numpy.array(y), '_o')
+                pmf_plot = p.plot(numpy.array(x), numpy.array(y), "_o")
                 FILE.write("\nPMF Plot of free energy versus lambda\n")
                 FILE.write(pmf_plot + "\n\n")
             except:
@@ -416,10 +511,18 @@ if __name__ == '__main__':
 
         for result in results:
             FILE.write(
-                "# %s = %s +/- %s kcal mol-1" % (result[0], result[2].deltaG(), result[2].values()[-1].yMaxError()))
+                "# %s = %s +/- %s kcal mol-1"
+                % (
+                    result[0],
+                    result[2].deltaG(),
+                    result[2].values()[-1].yMaxError(),
+                )
+            )
 
             try:
-                FILE.write(" (quadrature = %s kcal mol-1)" % result[2].quadrature())
+                FILE.write(
+                    " (quadrature = %s kcal mol-1)" % result[2].quadrature()
+                )
             except:
                 pass
 
@@ -429,29 +532,41 @@ if __name__ == '__main__':
             cmd = "rm freenrgs.s3"
             os.system(cmd)
 
-
     else:
         from Sire.Tools.FreeEnergyAnalysis import FreeEnergies
         from Sire.Tools.FreeEnergyAnalysis import SubSample
 
-        if len(unknown)>0:
+        if len(unknown) > 0:
             parser_mbar.print_help()
-            print ('analyse_freenrg: error: unrecognized arguments: %s ' % unknown[0])
+            print(
+                "analyse_freenrg: error: unrecognized arguments: %s "
+                % unknown[0]
+            )
             sys.exit(1)
 
         must_exit = False
         # MBAR is true and we run and MBAR analysis
-        print('Simulation data is analysed using the python module pymbar')
-        print('----------------------------------------------------------')
+        print("Simulation data is analysed using the python module pymbar")
+        print("----------------------------------------------------------")
 
         if args.author:
-            print("\nanalyse_freenrg mbar was written by Antonia Mey (C) 2015-2017")
-            print("It is based on the pymbar analysis scripts (https://github.com/choderalab/pymbar)")
+            print(
+                "\nanalyse_freenrg mbar was written by Antonia Mey (C) 2015-2017"
+            )
+            print(
+                "It is based on the pymbar analysis scripts (https://github.com/choderalab/pymbar)"
+            )
             must_exit = True
         if args.version:
-            print("analyse_freenrg mbar -- from Sire release version <%s>" % Sire.__version__)
-            print("This particular release can be downloaded here: "
-                  "https://github.com/openbiosim/sire/releases/tag/v%s" % Sire.__version__)
+            print(
+                "analyse_freenrg mbar -- from Sire release version <%s>"
+                % Sire.__version__
+            )
+            print(
+                "This particular release can be downloaded here: "
+                "https://github.com/openbiosim/sire/releases/tag/v%s"
+                % Sire.__version__
+            )
             must_exit = True
         if args.description:
             print("%s\n" % description_mbar)
@@ -462,8 +577,10 @@ if __name__ == '__main__':
         input_files = args.input
         output_file = args.output
         if args.percent and args.discard:
-            print ("Please choose either to discard a number of frames with the discard option or a certain percentage of all trajectories with "
-                   "the percent option.")
+            print(
+                "Please choose either to discard a number of frames with the discard option or a certain percentage of all trajectories with "
+                "the percent option."
+            )
             sys.exit(-1)
         if args.percent:
             percentage = args.percent
@@ -475,6 +592,7 @@ if __name__ == '__main__':
         else:
             discard = None
 
+        # temperature in kelvin
         T = args.temperature
 
         # boolean arguemtns
@@ -485,15 +603,17 @@ if __name__ == '__main__':
             parser_mbar.print_help()
             print(
                 "\nPlease supply the name of the simulation file/s containing the reduced perturbed energies/gradients "
-                "to be analysed.")
+                "to be analysed."
+            )
             sys.exit(-1)
-        if input_files[0].endswith('.s3'):
+        if input_files[0].endswith(".s3"):
             parser_mbar.print_help()
             print(
                 "\nInvalid file format for MBAR analysis. Please supply the names of the simulation.dat file/s "
-                "containing the reduced perturbed energies/gradients to be analysed.")
+                "containing the reduced perturbed energies/gradients to be analysed."
+            )
             sys.exit(-1)
-        elif '*' in input_files[0]:
+        elif "*" in input_files[0]:
             input_files = glob.glob(input_files[0])
             input_files.sort()
 
@@ -504,13 +624,20 @@ if __name__ == '__main__':
             print("# Writing all output to stdout")
             FILE = sys.stdout.buffer
 
-        FILE.write(bytes("# Analysing data contained in file(s) %s\n" % input_files, "UTF-8"))
+        FILE.write(
+            bytes(
+                "# Analysing data contained in file(s) %s\n" % input_files,
+                "UTF-8",
+            )
+        )
 
         # sanity checking of other input parameters:
         # processing lambda values
         lamvals = None
         if not args.lam:
-            print ("#Lambda array was not given, trying to infer lambda values from simulation files...")
+            print(
+                "#Lambda array was not given, trying to infer lambda values from simulation files..."
+            )
         else:
             lamvals = numpy.array(args.lam)
         lam = None
@@ -519,34 +646,47 @@ if __name__ == '__main__':
         else:
             T_previous = T
         for f in input_files:
-            print ('working on input file %s' % f)
+            print("working on input file %s" % f)
             # Compressed file
-            if f.endswith('.bz2'):
+            if f.endswith(".bz2"):
                 bz_file = bz2.BZ2File(f)
                 for line in bz_file:
-                    if line.startswith(b'#Alchemical'):
+                    if line.startswith(b"#Alchemical"):
                         if lamvals is None:
-                            lamvals = (line.split(b'(')[-1].split(b')')[0].split(b','))
+                            lamvals = (
+                                line.split(b"(")[-1].split(b")")[0].split(b",")
+                            )
                             lamvals = numpy.array([float(i) for i in lamvals])
                             lam = lamvals
 
                         else:
-                            lam = (line.split(b'(')[-1].split(b')')[0].split(b','))
+                            lam = (
+                                line.split(b"(")[-1].split(b")")[0].split(b",")
+                            )
                             lam = numpy.array([float(i) for i in lam])
-                    elif line.startswith(b'#Generating temperature'):
+                    elif line.startswith(b"#Generating temperature"):
                         temp = line.split()[3]
-                        unit = line.split()[4]
-                        if unit == b'C':
-                            T = float(temp)+273
+
+                        try:
+                            unit = line.split()[4]
+                        except Exception:
+                            # this was a °C or °K (not that °K is correct!)
+                            temp, unit = temp.split("°")
+
+                        if unit == b"C":
+                            T = float(temp) + 273
                         else:
                             T = float(temp)
                         if T_previous is None:
                             T_previous = T
                             continue
                         else:
-                            if T_previous !=T:
-                                print ('Generating temperature is %.2f and does not match with other temperature given %.2f, '
-                                       'please make sure all simulations are run at the same temperature' %(T, T_previous))
+                            if T_previous != T:
+                                print(
+                                    "Generating temperature is %.2f and does not match with other temperature given %.2f, "
+                                    "please make sure all simulations are run at the same temperature"
+                                    % (T, T_previous)
+                                )
                                 sys.exit(-1)
                             else:
                                 T_previous = T
@@ -554,37 +694,50 @@ if __name__ == '__main__':
             # Normal file
             else:
                 for line in open(f):
-                    if line.startswith('#Alchemical'):
+                    if line.startswith("#Alchemical"):
                         if lamvals is None:
-                            lamvals = (line.split('(')[-1].split(')')[0].split(','))
+                            lamvals = (
+                                line.split("(")[-1].split(")")[0].split(",")
+                            )
                             lamvals = numpy.array([float(i) for i in lamvals])
                             lam = lamvals
 
                         else:
-                            lam = (line.split('(')[-1].split(')')[0].split(','))
+                            lam = line.split("(")[-1].split(")")[0].split(",")
                             lam = numpy.array([float(i) for i in lam])
-                    elif line.startswith('#Generating temperature'):
+                    elif line.startswith("#Generating temperature"):
                         temp = line.split()[3]
-                        unit = line.split()[4]
-                        if unit == 'C':
-                            T = float(temp)+273
+
+                        try:
+                            unit = line.split()[4]
+                        except Exception:
+                            # this was a °C or °K (not that °K is correct!)
+                            temp, unit = temp.split("°")
+
+                        if unit == "C":
+                            T = float(temp) + 273
                         else:
                             T = float(temp)
                         if T_previous is None:
                             T_previous = T
                             continue
                         else:
-                            if T_previous !=T:
-                                print ('Generating temperature is %.2f and does not match with other temperature given %.2f, '
-                                       'please make sure all simulations are run at the same temperature' %(T, T_previous))
+                            if T_previous != T:
+                                print(
+                                    "Generating temperature is %.2f and does not match with other temperature given %.2f, "
+                                    "please make sure all simulations are run at the same temperature"
+                                    % (T, T_previous)
+                                )
                                 sys.exit(-1)
                             else:
                                 T_previous = T
                         break
             if not numpy.array_equal(lam, lamvals):
-                print ("Lambda arrays do not match! Make sure your input data is consistent")
-                print (lam)
-                print (lamvals)
+                print(
+                    "Lambda arrays do not match! Make sure your input data is consistent"
+                )
+                print(lam)
+                print(lamvals)
                 sys.exit(-1)
 
         # We will load all the data now
@@ -593,12 +746,12 @@ if __name__ == '__main__':
             for f in input_files:
                 data.append(numpy.loadtxt(f))
         else:
-            print ('Loading data and discarding %d frames' %discard)
+            print("Loading data and discarding %d frames" % discard)
             for f in input_files:
                 data.append(numpy.loadtxt(f, skiprows=discard))
 
         # N_k is the number of samples at generating thermodynamic state (lambda) k
-        N_k = numpy.zeros(shape=lamvals.shape[0], dtype='int32')
+        N_k = numpy.zeros(shape=lamvals.shape[0], dtype="int32")
         for k in range(0, lamvals.shape[0]):
             N_k[k] = data[k].shape[0]
 
@@ -607,34 +760,55 @@ if __name__ == '__main__':
         energies_kn = numpy.zeros(shape=(lamvals.shape[0], max_sample))
 
         for k in range(0, N_k.shape[0]):
-            grad_kn[k, 0:N_k[k]] = data[k][:, 2]  # get the gradient information
-            energies_kn[k, 0:N_k[k]] = data[k][:, 1]  # get the potential energies from the file.
+            grad_kn[k, 0 : N_k[k]] = data[k][
+                :, 2
+            ]  # get the gradient information
+            energies_kn[k, 0 : N_k[k]] = data[k][
+                :, 1
+            ]  # get the potential energies from the file.
 
         # Are the reduced perturbed potential energies generated at thermodynamic state k evaluated at state l, over
         # all n samples. This information is contained as is in the simulation file.
-        u_kln = numpy.zeros(shape=(lamvals.shape[0], lamvals.shape[0], max_sample))
+        u_kln = numpy.zeros(
+            shape=(lamvals.shape[0], lamvals.shape[0], max_sample)
+        )
         for k in range(0, lamvals.shape[0]):
-            u_kln[k, :, 0:N_k[k]] = data[k][:, 5:].transpose()
+            u_kln[k, :, 0 : N_k[k]] = data[k][:, 5:].transpose()
 
         # now we use the subsampling information to subsample the data.
-        subsample_obj = SubSample(grad_kn, energies_kn, u_kln, N_k, percentage=percentage, subsample=subsampling)
+        subsample_obj = SubSample(
+            grad_kn,
+            energies_kn,
+            u_kln,
+            N_k,
+            percentage=percentage,
+            subsample=subsampling,
+        )
         subsample_obj.subsample_energies()
         subsample_obj.subsample_gradients()
 
-        free_energy_obj = FreeEnergies(subsample_obj.u_kln, subsample_obj.N_k_energies, lamvals,
-                                       subsample_obj.gradients_kn)
-        print ('#running mbar ====================================================')
+        free_energy_obj = FreeEnergies(
+            subsample_obj.u_kln,
+            subsample_obj.N_k_energies,
+            lamvals,
+            subsample_obj.gradients_kn,
+        )
+        print(
+            "#running mbar ===================================================="
+        )
         free_energy_obj.run_mbar(test_overlap)
-        print ('#running mbar done ===============================================')
+        print(
+            "#running mbar done ==============================================="
+        )
         free_energy_obj.run_ti()
 
-        ti_warn_msg = ''
-        mbar_warn_msg = ''
-        if subsample_obj.gradients_kn.shape[1]<50:
-            ti_warn_msg = ' #WARNING SUBSAMPLING GRADIENTS RESULTED IN LESS THAN 50 SAMPLES, CONSIDER RERUN WITHOUT SUBSAMPLE OPTION'
+        ti_warn_msg = ""
+        mbar_warn_msg = ""
+        if subsample_obj.gradients_kn.shape[1] < 50:
+            ti_warn_msg = " #WARNING SUBSAMPLING GRADIENTS RESULTED IN LESS THAN 50 SAMPLES, CONSIDER RERUN WITHOUT SUBSAMPLE OPTION"
 
-        if subsample_obj.u_kln.shape[2]<50:
-            mbar_warn_msg = ' #WARNING SUBSAMPLING ENERGIES RESULTED IN LESS THAN 50 SAMPLES, CONSIDER RERUN WITHOUT SUBSAMPLE OPTION'
+        if subsample_obj.u_kln.shape[2] < 50:
+            mbar_warn_msg = " #WARNING SUBSAMPLING ENERGIES RESULTED IN LESS THAN 50 SAMPLES, CONSIDER RERUN WITHOUT SUBSAMPLE OPTION"
 
         if not subsampling:
             ti_warn_msg = " #WARNING SUBSAMPLING DISABLED, CONSIDER RERUN WITH SUBSAMPLING OPTION"
@@ -642,54 +816,74 @@ if __name__ == '__main__':
 
         if test_overlap:
             M = free_energy_obj.overlap_matrix
-            diag_elements = numpy.array([numpy.diag(M, k=1), numpy.diag(M, k=-1)])
+            diag_elements = numpy.array(
+                [numpy.diag(M, k=1), numpy.diag(M, k=-1)]
+            )
             if numpy.min(diag_elements) < 0.03:
                 warnings.warn(
-                    'Off diagonal elements of the overlap matrix are smaller than 0.03! Your free energy estimate is '
-                    'not reliable!')
-            FILE.write(bytes('#Overlap matrix\n', "UTF-8"))
-            numpy.savetxt(FILE, M, fmt='%.4f')
+                    "Off diagonal elements of the overlap matrix are smaller than 0.03! Your free energy estimate is "
+                    "not reliable!"
+                )
+            FILE.write(bytes("#Overlap matrix\n", "UTF-8"))
+            numpy.savetxt(FILE, M, fmt="%.4f")
 
         # mbar DG for neighbouring lambda
         pairwise_F = free_energy_obj.pairwise_F
-        pairwise_F[:, 2] = pairwise_F[:, 2] * T * k_boltz
-        pairwise_F[:, 3] = pairwise_F[:, 3] * T * k_boltz
-        FILE.write(bytes('#DG from neighbouring lambda in kcal/mol\n', "UTF-8"))
-        numpy.savetxt(FILE, pairwise_F, fmt=['%.4f', '%.4f', '%.4f', '%.4f'])
+        pairwise_F[:, 2] = pairwise_F[:, 2] * T * k_boltz.value()
+        pairwise_F[:, 3] = pairwise_F[:, 3] * T * k_boltz.value()
+        FILE.write(
+            bytes("#DG from neighbouring lambda in kcal/mol\n", "UTF-8")
+        )
+        numpy.savetxt(FILE, pairwise_F, fmt=["%.4f", "%.4f", "%.4f", "%.4f"])
 
         # mbar pmf
         pmf_mbar = free_energy_obj.pmf_mbar
-        pmf_mbar[:, 1] = pmf_mbar[:, 1] * T * k_boltz
-        pmf_mbar[:, 2] = pmf_mbar[:, 2] * T * k_boltz
-        FILE.write(bytes('#PMF from MBAR in kcal/mol\n', "UTF-8"))
-        numpy.savetxt(FILE, pmf_mbar, fmt=['%.4f', '%.4f', '%.4f'])
+        pmf_mbar[:, 1] = pmf_mbar[:, 1] * T * k_boltz.value()
+        pmf_mbar[:, 2] = pmf_mbar[:, 2] * T * k_boltz.value()
+        FILE.write(bytes("#PMF from MBAR in kcal/mol\n", "UTF-8"))
+        numpy.savetxt(FILE, pmf_mbar, fmt=["%.4f", "%.4f", "%.4f"])
 
         # ti mean gradients and std.
         grad_mean = numpy.mean(subsample_obj.gradients_kn, axis=1)
         grad_std = numpy.std(subsample_obj.gradients_kn, axis=1)
-        grad_mean = grad_mean * T * k_boltz
-        grad_std = grad_std * T * k_boltz
-        FILE.write(bytes('#TI average gradients and standard deviation in kcal/mol\n', "UTF-8"))
+        grad_mean = grad_mean * T * k_boltz.value()
+        grad_std = grad_std * T * k_boltz.value()
+        FILE.write(
+            bytes(
+                "#TI average gradients and standard deviation in kcal/mol\n",
+                "UTF-8",
+            )
+        )
         grad_data = numpy.column_stack((lamvals, grad_mean, grad_std))
-        numpy.savetxt(FILE, grad_data, fmt=['%.4f', '%.4f', '%.4f'])
+        numpy.savetxt(FILE, grad_data, fmt=["%.4f", "%.4f", "%.4f"])
 
         # TI pmf
         pmf_ti = free_energy_obj.pmf_ti
-        pmf_ti[:, 1] = pmf_ti[:, 1] * T * k_boltz
-        FILE.write(bytes('#PMF from TI in kcal/mol\n', "UTF-8"))
-        numpy.savetxt(FILE, pmf_ti, fmt=['%.4f', '%.4f'])
+        pmf_ti[:, 1] = pmf_ti[:, 1] * T * k_boltz.value()
+        FILE.write(bytes("#PMF from TI in kcal/mol\n", "UTF-8"))
+        numpy.savetxt(FILE, pmf_ti, fmt=["%.4f", "%.4f"])
 
         df_mbar_kcal = free_energy_obj.deltaF_mbar
         df_mbar_kJ = free_energy_obj.deltaF_mbar
         df_ti_kcal = free_energy_obj.deltaF_ti
         dDf_mbar_kcal = free_energy_obj.errorF_mbar
         dDf_mbar_kJ = free_energy_obj.errorF_mbar
-        df_mbar_kcal = df_mbar_kcal * T * k_boltz
-        dDf_mbar_kcal = dDf_mbar_kcal * T * k_boltz
-        df_ti_kcal = free_energy_obj.deltaF_ti * T * k_boltz
+        df_mbar_kcal = df_mbar_kcal * T * k_boltz.value()
+        dDf_mbar_kcal = dDf_mbar_kcal * T * k_boltz.value()
+        df_ti_kcal = free_energy_obj.deltaF_ti * T * k_boltz.value()
         FILE.write(
-            bytes("#MBAR free energy difference in kcal/mol: \n%f, %f %s\n" % (df_mbar_kcal, dDf_mbar_kcal, mbar_warn_msg), "UTF-8"))
-        FILE.write(bytes("#TI free energy difference in kcal/mol: \n%f %s \n" % (df_ti_kcal, ti_warn_msg), "UTF-8"))
-
+            bytes(
+                "#MBAR free energy difference in kcal/mol: \n%f, %f %s\n"
+                % (df_mbar_kcal, dDf_mbar_kcal, mbar_warn_msg),
+                "UTF-8",
+            )
+        )
+        FILE.write(
+            bytes(
+                "#TI free energy difference in kcal/mol: \n%f %s \n"
+                % (df_ti_kcal, ti_warn_msg),
+                "UTF-8",
+            )
+        )
 
         FILE.close()


### PR DESCRIPTION
so that it uses `k_boltz.value()` and so that it can cope with `value°unit` temperatures as well as `value unit` temperatures.

The diff is bigger as the script has also been autoformatted using black.

The main fix is changing

```
temp = line.split()[3]
unit = line.split()[4]
```

into

```
temp = line.split()[3]

try:
    unit = line.split()[4]
except Exception:
    # this was a °C or °K (not that °K is correct!)
    temp, unit = temp.split("°")
```

The other change is having kelvin print out as `value K` rather `value°K` - it is not correct to use the degree sign for kelvin (my mistake)

# Is this pull request to fix a bug, or to introduce new functionality?

Fix a bug

This pull request fixes issue #6 

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@lohedges

## Any additional context of information?

(you can also attach files by dragging & dropping)
