### PR TITLE
Use stack inspection to check if function is called from BioSimSpace sandpit

### DIFF
--- a/src/sire/convert/__init__.py
+++ b/src/sire/convert/__init__.py
@@ -68,8 +68,7 @@ def to(obj, format: str = "sire", map=None):
         return to_openmm(obj, map=map)
     else:
         raise ValueError(
-            f"Cannot convert {obj} as the format '{format}' is "
-            "not recognised."
+            f"Cannot convert {obj} as the format '{format}' is " "not recognised."
         )
 
 
@@ -245,21 +244,21 @@ def sire_to_biosimspace(obj, map=None):
 
     global _BSS
 
-    if _BSS is None:
-        # are we using the sandbox or vanilla BSS?
-        if "BioSimSpace.Sandpit" in sys.modules:
-            sandpit = None
-            for key in sys.modules.keys():
-                if key.startswith("BioSimSpace.Sandpit."):
-                    sandpit = ".".join(key.split(".")[0:3])
-                    break
+    import inspect
 
-            if sandpit is not None:
-                _BSS = sys.modules[sandpit]
-            else:
-                _BSS = sys.modules["BioSimSpace"]
-        else:
-            _BSS = sys.modules["BioSimSpace"]
+    # Try to inspect the stack to work out the file from which this
+    # function was called.
+    try:
+        filename = inspect.stack()[3].filename
+    except:
+        filename = None
+
+    # Was this function called from a BioSmSpace Sandpit?
+    if filename and "Sandpit" in filename:
+        sandpit = "BioSimSpace.Sandpit." + filename.split("Sandpit")[1].split("/")[1]
+        _BSS = sys.modules[sandpit]
+    else:
+        _BSS = sys.modules["BioSimSpace"]
 
     obj = _to_selectormol(obj)
 

--- a/src/sire/convert/__init__.py
+++ b/src/sire/convert/__init__.py
@@ -244,18 +244,19 @@ def sire_to_biosimspace(obj, map=None):
 
     global _BSS
 
-    import inspect
-
-    # Try to inspect the stack to work out the file from which this
+    # Try to inspect the stack to work out the module from which this
     # function was called.
     try:
-        filename = inspect.stack()[3].filename
+        frame = sys._getframe()
+        for frame_idx in range(0, 3):
+            frame = frame.f_back
+        module = frame.f_globals["__name__"]
     except:
-        filename = None
+        module = None
 
     # Was this function called from a BioSmSpace Sandpit?
-    if filename and "Sandpit" in filename:
-        sandpit = "BioSimSpace.Sandpit." + filename.split("Sandpit")[1].split("/")[1]
+    if module and module.startswith("BioSimSpace.Sandpit."):
+        sandpit = ".".join(module.split(".")[0:3])
         _BSS = sys.modules[sandpit]
     else:
         _BSS = sys.modules["BioSimSpace"]


### PR DESCRIPTION
## This is to fix a bug

Apologies for not spotting this issue. This PR fixes conversion to `BioSimSpace` objects when multiple namespaces are active, as is the case when running `BioSimSpace` tests using `pytest`. In this case both vanilla `BioSimSpace` and `BioSimSpace.Sandpit.Exscientia` are present in `sys.modules`, so calling `sire.convert` functions from regular `BioSimSpace` will return objects of the incorrect type, i.e. those from the Exscientia sandpit. This fixes the issue by using stack inspection to determine the file from which the convert function was called, then working out the sandpit from the file name. (The only thing that I'm not sure of is whether the logic works on Windows, i.e. do the file names use back slashes?) I've also changed things so that the global `_BSS` attribute is updated on each function call. This means things will work if a user changes between sandpits when working interactively, for example.

## Checklist

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]