### PR TITLE
This fixes the ring dihedral issue for the Amber prmtop parser.

### DIFF
--- a/corelib/src/libs/SireIO/amberprm.cpp
+++ b/corelib/src/libs/SireIO/amberprm.cpp
@@ -2949,7 +2949,14 @@ QStringList toLines(const QVector<AmberParams> &params, const Space &space, int 
             {
                 // NB14 must be computed only the first dihedral found that has this pair,
                 // otherwise we would risk Amber double-counting this parameter
-                const QPair<qint64, qint64> nb14pair(dihs[i], dihs[i + 3]);
+                QPair<qint64, qint64> nb14pair(dihs[i], dihs[i + 3]);
+
+                if (dihs[i] > dihs[i + 3])
+                {
+                    // must ensure a consistent ordering, so that we catch
+                    // A-*-*-B and B-*-*-A
+                    nb14pair = QPair<qint64, qint64>(dihs[i + 3], dihs[i]);
+                }
 
                 if (seen_dihedrals.contains(nb14pair))
                 {

--- a/corelib/src/libs/SireIO/biosimspace.cpp
+++ b/corelib/src/libs/SireIO/biosimspace.cpp
@@ -210,7 +210,7 @@ namespace SireIO
         // Copy across all properties that are unique to the original molecule.
         for (const auto &prop : molecule.propertyKeys())
         {
-            if (not molecule.hasProperty(prop))
+            if (not water.hasProperty(prop))
             {
                 edit_mol = edit_mol.setProperty(prop, molecule.property(prop)).molecule();
             }
@@ -432,7 +432,7 @@ namespace SireIO
         // Copy across all properties that are unique to the original molecule.
         for (const auto &prop : molecule.propertyKeys())
         {
-            if (not molecule.hasProperty(prop))
+            if (not water.hasProperty(prop))
             {
                 edit_mol = edit_mol.setProperty(prop, molecule.property(prop)).molecule();
             }

--- a/corelib/src/libs/SireMol/atomselection.cpp
+++ b/corelib/src/libs/SireMol/atomselection.cpp
@@ -105,6 +105,17 @@ QDataStream &operator>>(QDataStream &ds, AtomSelection &selection)
     else
         throw version_error(v, "1,2", r_selection, CODELOC);
 
+    // go through and make sure that the residues are selected
+    if (not(selection.selectedAll() or selection.selectedNone()))
+    {
+        const auto &molinfo = selection.d.read();
+
+        for (const auto &atom : selection.selectedAtoms())
+        {
+            selection.selected_residues.insert(molinfo.parentResidue(atom));
+        }
+    }
+
     return ds;
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,13 +7,22 @@ def pytest_addoption(parser):
         "--runslow", action="store_true", default=False, help="run slow tests"
     )
     parser.addoption(
-        "--runveryslow", action="store_true", default=False, help="run slow and veryslow tests"
+        "--runveryslow",
+        action="store_true",
+        default=False,
+        help="run slow and veryslow tests",
     )
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "slow: mark tests as slow to run (takes more than a couple of seconds")
-    config.addinivalue_line("markers", "veryslow: mark tests as veryslow to run (takes more than 5-10 seconds to run")
+    config.addinivalue_line(
+        "markers",
+        "slow: mark tests as slow to run (takes more than a couple of seconds",
+    )
+    config.addinivalue_line(
+        "markers",
+        "veryslow: mark tests as veryslow to run (takes more than 5-10 seconds to run",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -22,7 +31,7 @@ def pytest_collection_modifyitems(config, items):
 
     if config.getoption("--runslow"):
         runslow = True
-    
+
     if config.getoption("--runveryslow"):
         runslow = True
         runveryslow = True
@@ -34,7 +43,9 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(skip_slow)
 
     if not runveryslow:
-        skip_veryslow = pytest.mark.skip(reason="need --runveryslow option to run")
+        skip_veryslow = pytest.mark.skip(
+            reason="need --runveryslow option to run"
+        )
         for item in items:
             if "veryslow" in item.keywords:
                 item.add_marker(skip_veryslow)
@@ -78,3 +89,10 @@ def neura_mols():
 @pytest.fixture(scope="session")
 def excluded_mols():
     return sr.load_test_files("excluded.rst7", "excluded.prm7")
+
+
+@pytest.fixture(scope="session")
+def openmm_interchange_mols():
+    return sr.load_test_files(
+        "openmm_interchange.rst7", "openmm_interchange.prm7"
+    )

--- a/tests/io/test_prmtop.py
+++ b/tests/io/test_prmtop.py
@@ -1,0 +1,98 @@
+import sire as sr
+
+import pytest
+
+
+def test_reverse_dihedral(tmpdir, openmm_interchange_mols):
+    mols = openmm_interchange_mols
+
+    dir = tmpdir.mkdir("test_reverse_dihedral")
+
+    f = sr.save(mols, dir.join("output"), format=["PRM7", "RST7"])
+
+    # have to manually check that have written the two dihedrals between
+    # atoms 2 and 5 (6 and 15) with only one having a 1-4 term, and the
+    # other term ignored
+    lines = open(f[0]).readlines()
+
+    start = None
+
+    for i, line in enumerate(lines):
+        if line.find("%FLAG DIHEDRALS_WITHOUT_HYDROGEN") != -1:
+            start = i + 2
+
+    assert start is not None
+
+    included = 0
+    ignored = 0
+
+    while True:
+        line = lines[start]
+
+        if line.startswith("%"):
+            break
+
+        start += 1
+
+        atoms = line.split()
+        [a, b, c, d] = [int(x) for x in atoms[0:4]]
+
+        if (a == 6 and d == 15) or (a == 15 and d == 6):
+            if c < 0:
+                ignored += 1
+            elif c > 0:
+                included += 1
+
+        try:
+            [a, b, c, d] = [int(x) for x in atoms[5:9]]
+
+            if (a == 6 and d == 15) or (a == 15 and d == 6):
+                if c < 0:
+                    ignored += 1
+                elif c > 0:
+                    included += 1
+        except Exception as e:
+            # this was the last line
+            pass
+
+    assert included == 1
+    assert ignored == 1
+
+    mols2 = sr.load(f)
+
+    assert mols.energy().value() == pytest.approx(mols2.energy().value(), 1e-3)
+
+    f = sr.save(mols, dir.join("output2"), format=["GroTop", "Gro87"])
+
+    mols3 = sr.load(f, show_warnings=False)
+
+    assert mols.energy().value() == pytest.approx(mols3.energy().value(), 1e-3)
+
+    # manually check that the 2-5 pair appears only once
+    lines = open(f[0]).readlines()
+
+    start = None
+
+    for i, line in enumerate(lines):
+        if line.find("[ pairs ]") != -1:
+            start = i + 2
+            break
+
+    assert start is not None
+
+    included = 0
+
+    while True:
+        line = lines[start]
+        start += 1
+
+        atoms = line.split()
+        if len(atoms) == 0:
+            break
+
+        [a, b] = [int(x) for x in atoms[0:2]]
+
+        if (a == 2 and b == 5) or (a == 5 and b == 2):
+            included += 1
+
+    assert included == 1

--- a/tests/stream/test_partial_selection.py
+++ b/tests/stream/test_partial_selection.py
@@ -1,0 +1,37 @@
+import sire as sr
+
+import pytest
+
+
+def test_partial_selection(tmpdir, ala_mols):
+    mols = ala_mols
+
+    mol = mols[0]
+
+    res = mol.residues()[0]
+
+    assert res.selection().num_selected_residues() == 1
+
+    dir = tmpdir.mkdir("test_partial_selection")
+
+    s3file = str(dir.join("output.s3"))
+
+    s3 = sr.legacy.Stream.save(res, s3file)
+
+    res2 = sr.legacy.Stream.load(s3file)
+
+    assert res2.selection().num_selected_residues() == 1
+    assert res2.residue().number() == res.residue().number()
+
+    res = sr.legacy.Mol.PartialMolecule(res)
+
+    assert res.selection().num_selected_residues() == 1
+
+    s3file = str(dir.join("output2.s3"))
+
+    s3 = sr.legacy.Stream.save(res, s3file)
+
+    res2 = sr.legacy.Stream.load(s3file)
+
+    assert res2.selection().num_selected_residues() == 1
+    assert res2.residue().number() == res.residue().number()

--- a/wrapper/Stream/__init__.py
+++ b/wrapper/Stream/__init__.py
@@ -1,41 +1,46 @@
-
 from ._Stream import *
 
 import sys
 
 _pvt_load = load
 
-_pvt_modules = { "SireAnalysis" : "sire.legacy.Analysis",
-                 "SireBase"     : "sire.legacy.Base",
-                 "SireCAS"      : "sire.legacy.CAS",
-                 "SireCluster"  : "sire.legacy.Cluster",
-                 "SireError"    : "sire.legacy.Error",
-                 "SireFF"       : "sire.legacy.FF",
-                 "SireID"       : "sire.legacy.ID",
-                 "SireIO"       : "sire.legacy.IO",
-                 "SireMM"       : "sire.legacy.MM",
-                 "SireMaths"    : "sire.legacy.Maths",
-                 "SireMol"      : "sire.legacy.Mol",
-                 "SireMove"     : "sire.legacy.Move",
-                 "SireSystem"   : "sire.legacy.System",
-                 "SireUnits"    : "sire.legacy.Units",
-                 "SireVol"      : "sire.legacy.Vol",
-                 "Squire"       : "sire.legacy.Squire",
-                 "Soiree"       : "sire.legacy.Analysis"  # Soiree was renamed as Analysis
-                }
+_pvt_modules = {
+    "SireAnalysis": "sire.legacy.Analysis",
+    "SireBase": "sire.legacy.Base",
+    "SireCAS": "sire.legacy.CAS",
+    "SireCluster": "sire.legacy.Cluster",
+    "SireError": "sire.legacy.Error",
+    "SireFF": "sire.legacy.FF",
+    "SireID": "sire.legacy.ID",
+    "SireIO": "sire.legacy.IO",
+    "SireMM": "sire.legacy.MM",
+    "SireMaths": "sire.legacy.Maths",
+    "SireMol": "sire.legacy.Mol",
+    "SireMove": "sire.legacy.Move",
+    "SireSystem": "sire.legacy.System",
+    "SireUnits": "sire.legacy.Units",
+    "SireVol": "sire.legacy.Vol",
+    "Squire": "sire.legacy.Squire",
+    "Soiree": "sire.legacy.Analysis",  # Soiree was renamed as Analysis
+}
+
 
 def _pvt_loadLibrary(lib):
-
     lib = str(lib)
 
     if lib in _pvt_modules:
-        __import__( _pvt_modules[lib] )
+        __import__(_pvt_modules[lib])
+
 
 def load(data):
     header = getDataHeader(data)
 
-    for lib in header.requiredLibraries():
+    try:
+        libs = header.requiredLibraries()
+    except Exception:
+        libs = header.required_libraries()
+
+    for lib in libs:
         _pvt_loadLibrary(lib)
 
     return _pvt_load(data)
-


### PR DESCRIPTION
Dihedrals in rings will now have their 1-4 term bit set to ignore, even if they are not listed with the same order in the prmtop file

(e.g. A-*-*-B will be tested against A-*-*-B and B-*-*-A)

## If this is to fix a bug...

This pull request fixes issue reported privately.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@lohedges

## Any additional context of information?

This doesn't change the energies or the validity (per se) of previous prmtop files produced using sire. The issue is that highly strict prmtop parsers may fail if they strictly require only one 1-4 term per pair of atoms, and they don't check that any subsequent terms are, in fact, equal.