### PR TITLE
Fix preservation of unique properties when updating water topology.

### DIFF
--- a/corelib/src/libs/SireIO/biosimspace.cpp
+++ b/corelib/src/libs/SireIO/biosimspace.cpp
@@ -210,7 +210,7 @@ namespace SireIO
         // Copy across all properties that are unique to the original molecule.
         for (const auto &prop : molecule.propertyKeys())
         {
-            if (not molecule.hasProperty(prop))
+            if (not water.hasProperty(prop))
             {
                 edit_mol = edit_mol.setProperty(prop, molecule.property(prop)).molecule();
             }
@@ -432,7 +432,7 @@ namespace SireIO
         // Copy across all properties that are unique to the original molecule.
         for (const auto &prop : molecule.propertyKeys())
         {
-            if (not molecule.hasProperty(prop))
+            if (not water.hasProperty(prop))
             {
                 edit_mol = edit_mol.setProperty(prop, molecule.property(prop)).molecule();
             }


### PR DESCRIPTION
This pull request fixes [this](https://github.com/michellab/BioSimSpace/issues/247) issue. When changing the water topology of a system we need to preserve all molecular properties that are unique to the original molecules, e.g. they might have additional properties to the loaded water template, such as velocities. While there was logic to check for such properties, I was comparing against the _wrong_ molecule when deciding whether to add them.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods