### PR TITLE
Removing blas from the list of requirements - it isn't used any more?

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 boost
 gsl
 lazy_import
-libcblas
 libnetcdf
 openmm
 qt


### PR DESCRIPTION
## If this is to fix a bug...

This pull request is to check whether or not we need to include blas in the list of requirements. It shouldn't be there, so this should build and pass tests.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@lohedges
