### PR TITLE
Fix BLAS requirement.

### DIFF
--- a/recipes/sire/template.yaml
+++ b/recipes/sire/template.yaml
@@ -19,11 +19,11 @@ requirements:
   host:
     SIRE_RUN_REQUIREMENTS
     SIRE_BSS_REQUIREMENTS
-    openblas
+    - openblas
   run:
     SIRE_RUN_REQUIREMENTS
-    libblas * *openblas
-    openblas
+    - libblas * *openblas
+    - openblas
 
 test:
   script_env:

--- a/recipes/sire/template.yaml
+++ b/recipes/sire/template.yaml
@@ -19,8 +19,11 @@ requirements:
   host:
     SIRE_RUN_REQUIREMENTS
     SIRE_BSS_REQUIREMENTS
+    openblas
   run:
     SIRE_RUN_REQUIREMENTS
+    libblas * *openblas
+    openblas
 
 test:
   script_env:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 boost
 gsl
 lazy_import
-libcblas
 libnetcdf
 openmm
 qt


### PR DESCRIPTION
This PR updates the BLAS conda requirement to ensure that the `openblas` implementation is available at run time. We depend on BLAS via the `gsl` package, which is found and linked against in the correct way using CMake, i.e. using `gsl-config --libs` to generate the linker flags, which are, e.g.:

```
gsl-config --libs
-L/home/lester/.conda/envs/openbiosim/lib -lgsl -lgslcblas -lm
```

This issue is that in a conda environment, `libgslcblas` is a symlink:

```
ls -l ~/.conda/envs/openbiosim/lib/libgslcblas.so
lrwxrwxrwx 1 lester lester 13 Feb  1 14:33 /home/lester/.conda/envs/openbiosim/lib/libgslcblas.so -> libcblas.so.3
```

In addition, this itself is another symlink!

```
ls -l ~/.conda/envs/openbiosim/lib/libcblas.so.3
lrwxrwxrwx 1 lester lester 23 Feb  1 14:33 /home/lester/.conda/envs/openbiosim/lib/libcblas.so.3 -> libopenblasp-r0.3.21.so
```

As such, we indirectly end up linking against `libopenblas`, where only `libcblas` is specified in the requirements. (Which is what was suggested by conda-forge maintainers when using `gsl`.)

Hopefully this will address the issue, since `openblas` is available on all platforms that we support. Note that I've left the run requirement as:

```
libblas * *openblas
```

not

```
libcblas * *openblas
```

I am assuming that the correct `libcblas` will always be pulled in via `gsl` and we are merely specifying the BLAS implementation to use at run-time. If this is wrong, then we can update it.

Note that the BLAS implementation is now entirely specified in the `meta.yaml` file used for the conda-recipe. The `requirements.txt` file just lists `gsl`, which will pull in `libblas` and `libcblas`, as required.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods 