### PR TITLE
Fix atom numbering in PDB when there are multiple molecules

### DIFF
--- a/corelib/src/libs/SireIO/pdb2.h
+++ b/corelib/src/libs/SireIO/pdb2.h
@@ -267,8 +267,8 @@ namespace SireIO
         void assertSane() const;
         void parseLines(const PropertyMap &map);
 
-        void parseMolecule(const SireMol::MoleculeView &sire_mol, QVector<QString> &atom_lines, QStringList &errors,
-                           const SireBase::PropertyMap &map = SireBase::PropertyMap());
+        int parseMolecule(const SireMol::MoleculeView &sire_mol, QVector<QString> &atom_lines, QStringList &errors,
+                          const SireBase::PropertyMap &map = SireBase::PropertyMap(), int offset=0);
 
         SireMol::Molecule updateMolecule(const SireMol::Molecule &sire_mol, QVector<bool> &used_atoms,
                                          const SireBase::PropertyMap &map = SireBase::PropertyMap()) const;

--- a/wrapper/Tools/OpenMMMD.py
+++ b/wrapper/Tools/OpenMMMD.py
@@ -536,7 +536,7 @@ def writeSystemData(system, moves, Trajectory, block, softcore_lambda=False):
                 )
 
     # Write a PDB coordinate file each cycle.
-    pdb = Sire.IO.PDB2(system)
+    pdb = Sire.IO.PDB2(system, {"use_atom_numbers" : Sire.Base.wrap(True)})
     pdb.writeToFile("latest.pdb")
 
     moves_file = open("moves.dat", "w")


### PR DESCRIPTION
This pull request fixes issue #23 and [biosimspace#17](https://github.com/OpenBioSim/biosimspace/issues/17), allowing a PDB file to be used to re-map output coordinates from SOMD to those in the original system.

Note that I've cancelled CI in case you want to combine with the other PR, e.g. having tested locally.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods