### PR TITLE
Add special handling for AtomRadii property type.

### DIFF
--- a/wrapper/Mol/__init__.py
+++ b/wrapper/Mol/__init__.py
@@ -139,10 +139,16 @@ def _set_property(molview, key, property):
                 from ..Units import mod_electron
 
                 value = mod_electron
+
             elif orig_typename.endswith("Masses"):
                 from ..Units import g_per_mol
 
                 value = g_per_mol
+
+            elif orig_typename.endswith("Radii"):
+                from ..Units import angstrom
+
+                value = angstrom
 
             if value is not None:
                 (typename, value) = __get_typename__(value)


### PR DESCRIPTION
This pull request is related to [openbiosim/biosimspace#23](https://github.com/OpenBioSim/biosimspace/issues/23), adding special handling for `AtomRadii` properties, allowing zero values to be set in an existing property container. (Are there other properties that require special handling that are also missed?)

(Feel free to cancel the CI and combine with any other imminent PR if preferred.)

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods 