### PR TITLE
Remove watchdog requirement.

### DIFF
--- a/requirements_bss.txt
+++ b/requirements_bss.txt
@@ -29,7 +29,6 @@ pygtail
 pypdb
 pyyaml
 rdkit
-watchdog
 
 # The below are packages that aren't available on all
 # platforms/OSs and so need to be conditionally included


### PR DESCRIPTION
This PR is related to [OpenBioSIm/biosimspace#27](https://github.com/OpenBioSim/biosimspace/pull/27) and removes the `watchdog` package from the list of BioSimSpace requirements. This is not needed prior to merging the other PR, so feel free to combine this with the OpenMM work if you like.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods