### PR TITLE
Remove global ignore warnings filter.

### DIFF
--- a/src/sire/__init__.py
+++ b/src/sire/__init__.py
@@ -613,10 +613,11 @@ if "SIRE_NO_LAZY_IMPORT" not in _os.environ:
 
         _lazy_import.logging.disable(_lazy_import.logging.DEBUG)
 
-        # ignore warnings, as a lot are printed from the frozenlib
-        import warnings
+        # Previously needed to filter to remove excessive warnings
+        # from 'frozen importlib' when lazy loading.
+        #import warnings
+        #warnings.filterwarnings("ignore")
 
-        warnings.filterwarnings("ignore")
         _can_lazy_import = True
 
     except Exception as e:


### PR DESCRIPTION
This PR removes the global ignore warnings filter from Sire, which was previously used to suppress warnings when lazy loading modules. This has been tested on Linux, macOS, and Windows, where no warnings were seen. I've commented out the filter and added some context. This might be useful if we need to think about re-instating a similar filter should the warnings re-appear. (Perhaps filtering by the message, or module from which they arise.)

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods