### PR TITLE
Check version against existing installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,28 @@ import shutil
 import glob
 
 try:
+    # Check to see if Sire is already installed in this environment
+    # and store the version.
+    import sire as sr
+
+    curver = sr.__version__
+except ImportError:
+    curver = None
+
+# If Sire is already installed, see if the version number has changed.
+if curver:
+    with open("version.txt", "r") as f:
+        ver = f.readline().strip()
+
+    # Abort if the versions differ.
+    if curver != ver:
+        raise EnvironmentError(
+            f"This environment already contains an install of Sire version {curver}. "
+            "Please delete the installation or create a new environment before "
+            f"installing version {ver}. Also remove old build directories from 'build'."
+        )
+
+try:
     # Find out how much memory we have in total.
     # The wrappers need 4 GB per core to compile
     import psutil
@@ -300,9 +322,7 @@ def conda_install(dependencies, install_bss_reqs=False):
 
     if not _is_conda_prepped:
         if install_bss_reqs:
-            cmd = (
-                "%s config --prepend channels openbiosim/label/dev" % conda_exe
-            )
+            cmd = "%s config --prepend channels openbiosim/label/dev" % conda_exe
             print("Activating openbiosim channel channel using: '%s'" % cmd)
             status = subprocess.run(cmd.split())
             if status.returncode != 0:
@@ -361,9 +381,7 @@ def install_requires(install_bss_reqs=False):
     print(f"Installing requirements for {platform_string}")
 
     if not os.path.exists(conda):
-        print(
-            "\nSire can only be installed into a conda or miniconda environment."
-        )
+        print("\nSire can only be installed into a conda or miniconda environment.")
         print(
             "Please install conda, miniconda, miniforge or similar, then "
             "activate the conda environment, then rerun this installation "
@@ -390,9 +408,7 @@ def install_requires(install_bss_reqs=False):
             from parse_requirements import parse_requirements
         except ImportError as e:
             print("\n\n[ERROR] ** You need to install pip-requirements-parser")
-            print(
-                "Run `conda install -c conda-forge pip-requirements-parser\n\n"
-            )
+            print("Run `conda install -c conda-forge pip-requirements-parser\n\n")
             raise e
 
     reqs = parse_requirements("requirements_host.txt")
@@ -449,10 +465,7 @@ def _get_build_ext():
         else:
             ext = ""
 
-        return (
-            os.path.basename(conda_base.replace(" ", "_").replace(".", "_"))
-            + ext
-        )
+        return os.path.basename(conda_base.replace(" ", "_").replace(".", "_")) + ext
 
 
 def _get_bin_dir():
@@ -501,12 +514,8 @@ def build(ncores: int = 1, npycores: int = 1, coredefs=[], pydefs=[]):
         print(f"{CC} => {CC_bin}")
 
         if CXX_bin is None or CC_bin is None:
-            print(
-                "Cannot find the compilers requested by conda-build in the PATH"
-            )
-            print(
-                "Please check that the compilers are installed and available."
-            )
+            print("Cannot find the compilers requested by conda-build in the PATH")
+            print("Please check that the compilers are installed and available.")
             sys.exit(-1)
 
         # use the full paths, in case CMake struggles
@@ -637,9 +646,7 @@ def build(ncores: int = 1, npycores: int = 1, coredefs=[], pydefs=[]):
     # Compile and install, as need to install to compile the wrappers
     make_args = make_cmd(ncores, True)
 
-    print(
-        'NOW RUNNING "%s" --build . --target %s' % (cmake, " ".join(make_args))
-    )
+    print('NOW RUNNING "%s" --build . --target %s' % (cmake, " ".join(make_args)))
     sys.stdout.flush()
     status = subprocess.run([cmake, "--build", ".", "--target", *make_args])
 
@@ -703,9 +710,7 @@ def build(ncores: int = 1, npycores: int = 1, coredefs=[], pydefs=[]):
     # Just compile the wrappers
     make_args = make_cmd(npycores, False)
 
-    print(
-        'NOW RUNNING "%s" --build . --target %s' % (cmake, " ".join(make_args))
-    )
+    print('NOW RUNNING "%s" --build . --target %s' % (cmake, " ".join(make_args)))
     sys.stdout.flush()
     status = subprocess.run([cmake, "--build", ".", "--target", *make_args])
 
@@ -778,9 +783,7 @@ def install_module(ncores: int = 1):
     make_args = make_cmd(ncores, True)
 
     # Now that cmake has run, we can compile and install wrapper
-    print(
-        'NOW RUNNING "%s" --build . --target %s' % (cmake, " ".join(make_args))
-    )
+    print('NOW RUNNING "%s" --build . --target %s' % (cmake, " ".join(make_args)))
     sys.stdout.flush()
     status = subprocess.run([cmake, "--build", ".", "--target", *make_args])
 
@@ -820,9 +823,7 @@ def install(ncores: int = 1, npycores: int = 1):
     # Now install the wrappers
     make_args = make_cmd(npycores, True)
 
-    print(
-        'NOW RUNNING "%s" --build . --target %s' % (cmake, " ".join(make_args))
-    )
+    print('NOW RUNNING "%s" --build . --target %s' % (cmake, " ".join(make_args)))
     sys.stdout.flush()
     status = subprocess.run([cmake, "--build", ".", "--target", *make_args])
 


### PR DESCRIPTION
This PR introduces some simple logic to the `setup.py` script to check the version of any existing Sire installation in the build environment against the one in `version.txt`. If the versions differ, the an exception is raised along with a message telling the user to clean the old installation first. Feel free adjust the exception message to make it more informative. Perhaps we want a short message and a URL pointing to some more detailed instructions on the website? Also feel free to combine this with any other feature branch.

(Note that some of the diff are changes from `black`.)

## Checklist:

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods