### PR TITLE
Combined all fixes

### DIFF
--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -1,21 +1,15 @@
-name: Release Main
+name: Release Devel
 
 # Note that push and pull-request builds are automatically
 # now skipped by GitHub if
 # [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
 # are in the commit message. We don't need to check for this ourselves.
 
-# Only allow this action to run on a manual run.
-# We should specify when run whether or not we want
-# to upload the packages at the end. We may not want to,
-# as we need to wait for a major or patch release
 on:
   workflow_dispatch:
-    inputs:
-      upload_packages:
-        description: "Upload packages to anaconda (yes/no)?"
-        required: true
-        default: "no"
+  push:
+    branches: [devel]
+
 jobs:
   build:
     name: build (${{ matrix.python-version }}, ${{ matrix.platform.name }})
@@ -29,6 +23,13 @@ jobs:
           - { name: "windows", os: "windows-latest", shell: "pwsh" }
           - { name: "linux", os: "ubuntu-latest", shell: "bash -l {0}" }
           - { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
+        exclude:
+          # Exclude all but the latest Python from all
+          # but Linux
+          - os: macos-latest
+            python-version: ["3.8", "3.9"]
+          - os: windows-latest
+            python-version: ["3.8", "3.9"]
     environment:
       name: sire-build
     defaults:
@@ -54,8 +55,9 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
       #
-      - name: Clone the main branch (push to main)
-        run: git clone -b ${{ github.head_ref }} --single-branch https://github.com/${{ env.REPO }}
+      - name: Clone the devel branch (push to devel)
+        run: git clone https://github.com/${{ env.REPO }}
+        if: github.event_name != 'pull_request'
       #
       - name: Setup Conda
         run: mamba install -y -c conda-forge boa anaconda-client packaging=21 pip-requirements-parser
@@ -70,9 +72,9 @@ jobs:
         run: conda mambabuild -c conda-forge -c openbiosim/label/dev ${{ github.workspace }}/sire/recipes/sire
       #
       - name: Upload Conda package
-        # maybe add logic here to tag the packages as 'main'?
+        # Maybe add the logic here that this is a dev package?
         run: python ${{ github.workspace }}/sire/actions/upload_package.py
         env:
           SRC_DIR: ${{ github.workspace }}/sire
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-        if: github.event.inputs.upload_packages == 'yes'
+        if: github.event_name != 'pull_request'

--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -26,13 +26,15 @@ jobs:
         exclude:
           # Exclude all but the latest Python from all
           # but Linux
-          - platform.os: macos-latest
+          - platform:
+              { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
             python-version: "3.8"
-          - platform.os: windows-latest
+          - platform: { name: "windows", os: "windows-latest", shell: "pwsh" }
             python-version: "3.8"
-          - platform.os: macos-latest
+          - platform:
+              { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
             python-version: "3.9"
-          - platform.os: windows-latest
+          - platform: { name: "windows", os: "windows-latest", shell: "pwsh" }
             python-version: "3.9"
     environment:
       name: sire-build

--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -18,18 +18,14 @@ jobs:
       max-parallel: 9
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
         platform:
           - { name: "windows", os: "windows-latest", shell: "pwsh" }
           - { name: "linux", os: "ubuntu-latest", shell: "bash -l {0}" }
           - { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
-        exclude:
-          # Exclude all but the latest Python from all
-          # but Linux
-          - platform.os: macos-latest
-            python-version: ["3.8", "3.9"]
-          - platform.os: windows-latest
-            python-version: ["3.8", "3.9"]
+        python-version:
+          - ["3.10"]
+          - ["3.8", "3.9", "3.10"]
+          - ["3.10"]
     environment:
       name: sire-build
     defaults:

--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -18,14 +18,22 @@ jobs:
       max-parallel: 9
       fail-fast: false
       matrix:
+        python-version: ["3.8", "3.9", "3.10"]
         platform:
           - { name: "windows", os: "windows-latest", shell: "pwsh" }
           - { name: "linux", os: "ubuntu-latest", shell: "bash -l {0}" }
           - { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
-        python-version:
-          - ["3.10"]
-          - ["3.8", "3.9", "3.10"]
-          - ["3.10"]
+        exclude:
+          # Exclude all but the latest Python from all
+          # but Linux
+          - platform.os: macos-latest
+            python-version: "3.8"
+          - platform.os: windows-latest
+            python-version: "3.8"
+          - platform.os: macos-latest
+            python-version: "3.9"
+          - platform.os: windows-latest
+            python-version: "3.9"
     environment:
       name: sire-build
     defaults:

--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -26,9 +26,9 @@ jobs:
         exclude:
           # Exclude all but the latest Python from all
           # but Linux
-          - os: macos-latest
+          - platform.os: macos-latest
             python-version: ["3.8", "3.9"]
-          - os: windows-latest
+          - platform.os: windows-latest
             python-version: ["3.8", "3.9"]
     environment:
       name: sire-build

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,13 +25,15 @@ jobs:
         exclude:
           # Exclude all but the latest Python from all
           # but Linux
-          - platform.os: macos-latest
+          - platform:
+              { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
             python-version: "3.8"
-          - platform.os: windows-latest
+          - platform: { name: "windows", os: "windows-latest", shell: "pwsh" }
             python-version: "3.8"
-          - platform.os: macos-latest
+          - platform:
+              { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
             python-version: "3.9"
-          - platform.os: windows-latest
+          - platform: { name: "windows", os: "windows-latest", shell: "pwsh" }
             python-version: "3.9"
     environment:
       name: sire-build

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,21 +1,14 @@
-name: Release Main
+name: Pull-Request
 
 # Note that push and pull-request builds are automatically
 # now skipped by GitHub if
 # [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
 # are in the commit message. We don't need to check for this ourselves.
 
-# Only allow this action to run on a manual run.
-# We should specify when run whether or not we want
-# to upload the packages at the end. We may not want to,
-# as we need to wait for a major or patch release
 on:
-  workflow_dispatch:
-    inputs:
-      upload_packages:
-        description: "Upload packages to anaconda (yes/no)?"
-        required: true
-        default: "no"
+  pull_request:
+    branches: [devel]
+
 jobs:
   build:
     name: build (${{ matrix.python-version }}, ${{ matrix.platform.name }})
@@ -29,6 +22,13 @@ jobs:
           - { name: "windows", os: "windows-latest", shell: "pwsh" }
           - { name: "linux", os: "ubuntu-latest", shell: "bash -l {0}" }
           - { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
+        exclude:
+          # Exclude all but the latest Python from all
+          # but Linux
+          - os: macos-latest
+            python-version: ["3.8", "3.9"]
+          - os: windows-latest
+            python-version: ["3.8", "3.9"]
     environment:
       name: sire-build
     defaults:
@@ -54,7 +54,7 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
       #
-      - name: Clone the main branch (push to main)
+      - name: Clone the feature branch (pull request to devel)
         run: git clone -b ${{ github.head_ref }} --single-branch https://github.com/${{ env.REPO }}
       #
       - name: Setup Conda
@@ -68,11 +68,3 @@ jobs:
       #
       - name: Build Conda package using mamba build
         run: conda mambabuild -c conda-forge -c openbiosim/label/dev ${{ github.workspace }}/sire/recipes/sire
-      #
-      - name: Upload Conda package
-        # maybe add logic here to tag the packages as 'main'?
-        run: python ${{ github.workspace }}/sire/actions/upload_package.py
-        env:
-          SRC_DIR: ${{ github.workspace }}/sire
-          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-        if: github.event.inputs.upload_packages == 'yes'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,18 +17,14 @@ jobs:
       max-parallel: 9
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
         platform:
           - { name: "windows", os: "windows-latest", shell: "pwsh" }
           - { name: "linux", os: "ubuntu-latest", shell: "bash -l {0}" }
           - { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
-        exclude:
-          # Exclude all but the latest Python from all
-          # but Linux
-          - platform.os: macos-latest
-            python-version: ["3.8", "3.9"]
-          - platform.os: windows-latest
-            python-version: ["3.8", "3.9"]
+        python-version:
+          - ["3.10"]
+          - ["3.8", "3.9", "3.10"]
+          - ["3.10"]
     environment:
       name: sire-build
     defaults:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,9 +25,9 @@ jobs:
         exclude:
           # Exclude all but the latest Python from all
           # but Linux
-          - os: macos-latest
+          - platform.os: macos-latest
             python-version: ["3.8", "3.9"]
-          - os: windows-latest
+          - platform.os: windows-latest
             python-version: ["3.8", "3.9"]
     environment:
       name: sire-build

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,14 +17,22 @@ jobs:
       max-parallel: 9
       fail-fast: false
       matrix:
+        python-version: ["3.8", "3.9", "3.10"]
         platform:
           - { name: "windows", os: "windows-latest", shell: "pwsh" }
           - { name: "linux", os: "ubuntu-latest", shell: "bash -l {0}" }
           - { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
-        python-version:
-          - ["3.10"]
-          - ["3.8", "3.9", "3.10"]
-          - ["3.10"]
+        exclude:
+          # Exclude all but the latest Python from all
+          # but Linux
+          - platform.os: macos-latest
+            python-version: "3.8"
+          - platform.os: windows-latest
+            python-version: "3.8"
+          - platform.os: macos-latest
+            python-version: "3.9"
+          - platform.os: windows-latest
+            python-version: "3.9"
     environment:
       name: sire-build
     defaults:

--- a/corelib/src/libs/SireBase/properties.h
+++ b/corelib/src/libs/SireBase/properties.h
@@ -43,9 +43,6 @@ namespace SireBase
 SIREBASE_EXPORT QDataStream &operator<<(QDataStream &, const SireBase::Properties &);
 SIREBASE_EXPORT QDataStream &operator>>(QDataStream &, SireBase::Properties &);
 
-SIREBASE_EXPORT XMLStream &operator<<(XMLStream &, const SireBase::Properties &);
-SIREBASE_EXPORT XMLStream &operator>>(XMLStream &, SireBase::Properties &);
-
 SIREBASE_EXPORT QTextStream &operator<<(QTextStream &, const SireBase::Properties &);
 
 namespace SireBase
@@ -69,9 +66,6 @@ namespace SireBase
 
         friend SIREBASE_EXPORT QDataStream & ::operator<<(QDataStream &, const Properties &);
         friend SIREBASE_EXPORT QDataStream & ::operator>>(QDataStream &, Properties &);
-
-        friend SIREBASE_EXPORT XMLStream & ::operator<<(XMLStream &, const Properties &);
-        friend SIREBASE_EXPORT XMLStream & ::operator>>(XMLStream &, Properties &);
 
         friend class detail::PropertiesData; // so can call private constructor
 

--- a/corelib/src/libs/SireIO/amberprm.cpp
+++ b/corelib/src/libs/SireIO/amberprm.cpp
@@ -313,8 +313,7 @@ void AmberPrm::rebuildBADIndicies()
 
     // now index the connectivity - find the start index and number of bonds/angles/dihedrals
     // for each molecule
-    // if (usesParallel())
-    if (false)
+    if (usesParallel())
     {
         tbb::parallel_invoke(
             [&]()
@@ -438,8 +437,7 @@ void AmberPrm::rebuildLJParameters()
         }
     };
 
-    // if (usesParallel())
-    if (false)
+    if (usesParallel())
     {
         tbb::parallel_for(tbb::blocked_range<int>(0, ntypes), [&](tbb::blocked_range<int> r)
                           {
@@ -720,8 +718,7 @@ void AmberPrm::rebuildAfterReload()
     // first need to create the map of all of the atom numbers in each molecule
     this->rebuildMolNumToAtomNums();
 
-    // if (usesParallel())
-    if (false)
+    if (usesParallel())
     {
         tbb::parallel_invoke(
             // now we have to build the LJ parameters (Amber stores them weirdly!)
@@ -937,8 +934,7 @@ double AmberPrm::processAllFlags()
         }
     };
 
-    // if (usesParallel())
-    if (false)
+    if (usesParallel())
     {
         tbb::parallel_for(tbb::blocked_range<int>(0, flags.count()), [&](tbb::blocked_range<int> r)
                           {
@@ -3292,8 +3288,7 @@ AmberPrm::AmberPrm(const System &system, const PropertyMap &map) : ConcretePrope
     // generate the AmberParams object for each molecule in the system
     QVector<AmberParams> params(molnums.count());
 
-    // if (usesParallel())
-    if (false)
+    if (usesParallel())
     {
         tbb::parallel_for(tbb::blocked_range<int>(0, molnums.count()), [&](const tbb::blocked_range<int> r)
                           {
@@ -3327,8 +3322,8 @@ AmberPrm::AmberPrm(const System &system, const PropertyMap &map) : ConcretePrope
     int num_dummies = system.search("element Xx").count();
 
     // now convert these into text lines that can be written as the file
-    // QStringList lines = ::toLines(params, space, this->usesParallel(), &errors);
-    QStringList lines = ::toLines(params, space, num_dummies, false, &errors);
+    QStringList lines = ::toLines(params, space, num_dummies,
+                                  this->usesParallel(), &errors);
 
     if (not errors.isEmpty())
     {
@@ -3584,8 +3579,7 @@ QVector<int> AmberPrm::getAtomIndexToMolIndex() const
 
     const int nmols = molnum_to_atomnums.count() - 1; // 1 indexed
 
-    // if (usesParallel())
-    if (false)
+    if (usesParallel())
     {
         tbb::parallel_for(tbb::blocked_range<int>(0, nmols), [&](tbb::blocked_range<int> r)
                           {
@@ -4115,8 +4109,7 @@ AmberParams AmberPrm::getAmberParams(int molidx, const MoleculeInfoData &molinfo
     AmberParams params(molinfo);
 
     // assign all of the parameters
-    // if (usesParallel())
-    if (false)
+    if (usesParallel())
     {
         AmberParams atoms, bonds, angles, dihedrals, excluded;
 
@@ -4331,8 +4324,7 @@ System AmberPrm::startSystem(const PropertyMap &map) const
     QVector<Molecule> mols(nmols);
     Molecule *mols_array = mols.data();
 
-    // if (usesParallel())
-    if (false)
+    if (usesParallel())
     {
         tbb::parallel_for(tbb::blocked_range<int>(0, nmols), [&](tbb::blocked_range<int> r)
                           {

--- a/corelib/src/libs/SireIO/charmmpsf.cpp
+++ b/corelib/src/libs/SireIO/charmmpsf.cpp
@@ -2649,7 +2649,7 @@ SireMol::Molecule CharmmPSF::parameteriseMolecule(int imol, const SireMol::Molec
         // ...and Urey-Bradley, if present.
         if (has_ub)
         {
-            edit_mol.setProperty(map["urey_bradley"], ub_funcs);
+            edit_mol.setProperty(map["urey-bradley"], ub_funcs);
         }
     }
 
@@ -3049,7 +3049,7 @@ void CharmmPSF::parseMolecule(int imol, const SireMol::Molecule &sire_mol, QVect
     // Get the required properties.
     const auto bond_funcs = getProperty<TwoAtomFunctions>(map["bond"], moldata, &has_bonds);
     const auto angle_funcs = getProperty<ThreeAtomFunctions>(map["angle"], moldata, &has_angles);
-    const auto ub_funcs = getProperty<TwoAtomFunctions>(map["urey_bradley"], moldata, &has_ubs);
+    const auto ub_funcs = getProperty<TwoAtomFunctions>(map["urey-bradley"], moldata, &has_ubs);
     const auto dihedral_funcs = getProperty<FourAtomFunctions>(map["dihedral"], moldata, &has_dihedrals);
     const auto improper_funcs = getProperty<FourAtomFunctions>(map["improper"], moldata, &has_impropers);
 

--- a/corelib/src/libs/SireIO/protoms.h
+++ b/corelib/src/libs/SireIO/protoms.h
@@ -221,7 +221,7 @@ namespace SireIO
         /** Return the name of the property that will contain the
             Urey-Bradley parameters
 
-            default == "Urey-Bradley"
+            default == "urey-bradley"
         */
         const PropertyName &ureyBradley() const
         {

--- a/corelib/src/libs/SireMM/gromacsparams.h
+++ b/corelib/src/libs/SireMM/gromacsparams.h
@@ -235,6 +235,8 @@ namespace SireMM
         GromacsAngle(int function_type, const QList<double> &params);
 
         GromacsAngle(const SireCAS::Expression &angle, const SireCAS::Symbol &theta);
+        GromacsAngle(const SireCAS::Expression &angle, const SireCAS::Symbol &theta,
+                     const SireCAS::Expression &ub, const SireCAS::Symbol &r);
 
         GromacsAngle(const GromacsAngle &other);
 
@@ -320,7 +322,9 @@ namespace SireMM
         GromacsDihedral(const SireCAS::Expression &dihedral, const SireCAS::Symbol &phi);
 
         static QList<GromacsDihedral> construct(const SireCAS::Expression &dihedral, const SireCAS::Symbol &phi);
-        static QList<GromacsDihedral> constructImproper(const SireCAS::Expression &dihedral, const SireCAS::Symbol &phi);
+        static QList<GromacsDihedral> constructImproper(const SireCAS::Expression &dihedral,
+                                                        const SireCAS::Symbol &phi,
+                                                        const SireCAS::Symbol &theta);
 
         GromacsDihedral(const GromacsDihedral &other);
 

--- a/corelib/src/libs/SireMM/internalff.cpp
+++ b/corelib/src/libs/SireMM/internalff.cpp
@@ -85,7 +85,7 @@ PropertyName BondParameterName::bond_param("bond", Property::null());
 PropertyName AngleParameterName::angle_param("angle", Property::null());
 PropertyName DihedralParameterName::dihedral_param("dihedral", Property::null());
 PropertyName ImproperParameterName::improper_param("improper", Property::null());
-PropertyName UreyBradleyParameterName::ub_param("Urey-Bradley", Property::null());
+PropertyName UreyBradleyParameterName::ub_param("urey-bradley", Property::null());
 PropertyName StretchStretchParameterName::ss_param("stretch-stretch", Property::null());
 PropertyName StretchBendParameterName::sb_param("stretch-bend", Property::null());
 PropertyName BendBendParameterName::bb_param("bend-bend", Property::null());

--- a/corelib/src/libs/SireMol/findmcs.cpp
+++ b/corelib/src/libs/SireMol/findmcs.cpp
@@ -28,6 +28,8 @@
 #include <QDataStream>
 #include <QElapsedTimer>
 
+#include "sireglobal.h"
+
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/corelib/src/libs/sireglobal.h
+++ b/corelib/src/libs/sireglobal.h
@@ -4,8 +4,8 @@
 /** This file contains some global macros that are used
     to improve the portability of the code. */
 
-//include qglobal.h - this includes all of the definitions
-//that are needed for these macros
+// include qglobal.h - this includes all of the definitions
+// that are needed for these macros
 #include <qconfig.h>
 #include <qglobal.h>
 
@@ -17,109 +17,117 @@
 #include <QSet>
 #include <QVector>
 
+#if __cplusplus >= 201703L
+// Need to define this with C++17 so that
+// boost::hash does not use std::unary_function
+// (which was deprecated in C++11 and removed in C++17)
+// See https://github.com/boostorg/container_hash/issues/22
+#define BOOST_NO_CXX98_FUNCTION_BASE 1
+#endif
+
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    // Newer Qt moves QString::SkipEmptyParts to the Qt namespace,
-    // and deprecates the functions that use the QString value.
-    // However, Qt < 5.14 doesn't have SkipEmptyParts defined in
-    // the Qt namespace, so we need to do this here
-    namespace Qt
-    {
-        const auto SkipEmptyParts = QString::SkipEmptyParts;
-    }
+// Newer Qt moves QString::SkipEmptyParts to the Qt namespace,
+// and deprecates the functions that use the QString value.
+// However, Qt < 5.14 doesn't have SkipEmptyParts defined in
+// the Qt namespace, so we need to do this here
+namespace Qt
+{
+    const auto SkipEmptyParts = QString::SkipEmptyParts;
+}
 
-    // Older Qt also uses a now deprecated way to initialise QSets
-    template<class T>
-    inline QSet<T> convert_to_qset(const QList<T> &l)
-    {
-        return l.toSet();
-    }
+// Older Qt also uses a now deprecated way to initialise QSets
+template <class T>
+inline QSet<T> convert_to_qset(const QList<T> &l)
+{
+    return l.toSet();
+}
 
-    template<class T>
-    inline QSet<T> convert_to_qset(const QVector<T> &v)
-    {
-        return v.toList().toSet();
-    }
+template <class T>
+inline QSet<T> convert_to_qset(const QVector<T> &v)
+{
+    return v.toList().toSet();
+}
 
-    template<class T>
-    inline QList<T> convert_to_qlist(const QVector<T> &v)
-    {
-        return v.toList();
-    }
+template <class T>
+inline QList<T> convert_to_qlist(const QVector<T> &v)
+{
+    return v.toList();
+}
 
-    template<class T>
-    inline QList<T> convert_to_qlist(const QSet<T> &s)
-    {
-        return s.toList();
-    }
+template <class T>
+inline QList<T> convert_to_qlist(const QSet<T> &s)
+{
+    return s.toList();
+}
 #else
-    //Newer Qt also has a different way of initialising QSet!
-    template<class T>
-    inline QSet<T> convert_to_qset(const QList<T> &l)
-    {
-        return QSet<T>(l.begin(), l.end());
-    }
+// Newer Qt also has a different way of initialising QSet!
+template <class T>
+inline QSet<T> convert_to_qset(const QList<T> &l)
+{
+    return QSet<T>(l.begin(), l.end());
+}
 
-    template<class T>
-    inline QSet<T> convert_to_qset(const QVector<T> &v)
-    {
-        return QSet<T>(v.begin(), v.end());
-    }
+template <class T>
+inline QSet<T> convert_to_qset(const QVector<T> &v)
+{
+    return QSet<T>(v.begin(), v.end());
+}
 
-    template<class T>
-    inline QList<T> convert_to_qlist(const QVector<T> &v)
-    {
-        return QList<T>(v.begin(), v.end());
-    }
+template <class T>
+inline QList<T> convert_to_qlist(const QVector<T> &v)
+{
+    return QList<T>(v.begin(), v.end());
+}
 
-    template<class T>
-    inline QList<T> convert_to_qlist(const QSet<T> &s)
-    {
-        return QList<T>(s.begin(), s.end());
-    }
+template <class T>
+inline QList<T> convert_to_qlist(const QSet<T> &s)
+{
+    return QList<T>(s.begin(), s.end());
+}
 #endif
 
 #include <boost/current_function.hpp>
-//macro used to return the current file and line as a QString
+// macro used to return the current file and line as a QString
 #ifdef CODELOC
 #undef CODELOC
 #endif
 
 #define CODELOC QString("FILE: %1, LINE: %2, FUNCTION: %3").arg(__FILE__).arg(__LINE__).arg(BOOST_CURRENT_FUNCTION)
 
-//copy the QT_BEGIN_HEADER and QT_END_HEADER
-//to SIRE_BEGIN_HEADER and SIRE_END_HEADER. This
-//will allow me to change their definition at some
-//future point in time without having to mess with
-//Qt
+// copy the QT_BEGIN_HEADER and QT_END_HEADER
+// to SIRE_BEGIN_HEADER and SIRE_END_HEADER. This
+// will allow me to change their definition at some
+// future point in time without having to mess with
+// Qt
 #define SIRE_BEGIN_HEADER QT_BEGIN_HEADER
 #define SIRE_END_HEADER QT_END_HEADER
 
-//create keywords that control whether classes or functions are
-//exposed to a scripting language
-#define SIRE_EXPOSE_FUNCTION(f)  /* Exposing function #1 */
-#define SIRE_EXPOSE_CLASS(c)     /* Exposing class #1 */
-#define SIRE_EXPOSE_ALIAS(c,a)   /* Exposing class #1 as alias #2 */
-#define SIRE_EXPOSE_PROPERTY(c,a)  /* Exposing property #1 of base class #2 */
-#define SIRE_EXPOSE_ATOM_PROPERTY(c,a) /* Exposing atom property #1 with alias #2 */
-#define SIRE_EXPOSE_CUTGROUP_PROPERTY(c,a) /* Exposing CutGroup property #1 with alias #2 */
-#define SIRE_EXPOSE_RESIDUE_PROPERTY(c,a) /* Exposing residue property #1 with alias #2 */
-#define SIRE_EXPOSE_CHAIN_PROPERTY(c,a) /* Exposing chain property #1 with alias #2 */
-#define SIRE_EXPOSE_SEGMENT_PROPERTY(c,a) /* Exposing segment property #1 with alias #2 */
-#define SIRE_EXPOSE_BEAD_PROPERTY(c,a)  /* Exposing bead property #1 with alias #2 */
+// create keywords that control whether classes or functions are
+// exposed to a scripting language
+#define SIRE_EXPOSE_FUNCTION(f)             /* Exposing function #1 */
+#define SIRE_EXPOSE_CLASS(c)                /* Exposing class #1 */
+#define SIRE_EXPOSE_ALIAS(c, a)             /* Exposing class #1 as alias #2 */
+#define SIRE_EXPOSE_PROPERTY(c, a)          /* Exposing property #1 of base class #2 */
+#define SIRE_EXPOSE_ATOM_PROPERTY(c, a)     /* Exposing atom property #1 with alias #2 */
+#define SIRE_EXPOSE_CUTGROUP_PROPERTY(c, a) /* Exposing CutGroup property #1 with alias #2 */
+#define SIRE_EXPOSE_RESIDUE_PROPERTY(c, a)  /* Exposing residue property #1 with alias #2 */
+#define SIRE_EXPOSE_CHAIN_PROPERTY(c, a)    /* Exposing chain property #1 with alias #2 */
+#define SIRE_EXPOSE_SEGMENT_PROPERTY(c, a)  /* Exposing segment property #1 with alias #2 */
+#define SIRE_EXPOSE_BEAD_PROPERTY(c, a)     /* Exposing bead property #1 with alias #2 */
 
 #ifdef _WIN32
 #define SIRE_EXPORT __declspec(dllexport)
 #define SIRE_IMPORT __declspec(dllimport)
 #else
-//create the keyword used to export a symbol - this
-//is a copy of Q_DECL_EXPORT, which will definitely
-//be set to the correct value
+// create the keyword used to export a symbol - this
+// is a copy of Q_DECL_EXPORT, which will definitely
+// be set to the correct value
 #ifndef SIRE_NO_VISIBILITY_AVAILABLE
 #define SIRE_EXPORT Q_DECL_EXPORT
 
-//create the keyword to import a symbol - this is copied
-//from Q_DECL_IMPORT, which will definitely be set to
-//the correct value
+// create the keyword to import a symbol - this is copied
+// from Q_DECL_IMPORT, which will definitely be set to
+// the correct value
 #define SIRE_IMPORT Q_DECL_IMPORT
 #else
 #define SIRE_EXPORT
@@ -127,16 +135,16 @@
 #endif
 #endif
 
-//create the keyword to fix symbol visibility problems for out-of-line
-//template functions
+// create the keyword to fix symbol visibility problems for out-of-line
+// template functions
 #define SIRE_OUTOFLINE_TEMPLATE Q_OUTOFLINE_TEMPLATE
 
-//do the same for inline template functions
+// do the same for inline template functions
 #define SIRE_INLINE_TEMPLATE Q_INLINE_TEMPLATE
 
-//Sire is much more picky about what the compiler can support
-//than Qt - use the results of the Qt portability tests
-//to check that the C++ compiler is up to scratch
+// Sire is much more picky about what the compiler can support
+// than Qt - use the results of the Qt portability tests
+// to check that the C++ compiler is up to scratch
 
 #ifdef Q_BROKEN_TEMPLATE_SPECIALIZATION
 #error Sire requires a C++ compiler that can handle templates in \
@@ -193,77 +201,77 @@
     @author Christopher Woods
 */
 #ifdef QT_POINTER_SIZE
-  #if QT_POINTER_SIZE == 4
+#if QT_POINTER_SIZE == 4
 
-    // Functions used if we have 32bit pointers
-    SIRE_ALWAYS_INLINE qint32 toInt(const void *ptr)
-    {
-        return qint32(ptr);
-    }
+// Functions used if we have 32bit pointers
+SIRE_ALWAYS_INLINE qint32 toInt(const void *ptr)
+{
+    return qint32(ptr);
+}
 
-    SIRE_ALWAYS_INLINE quint32 toUInt(const void *ptr)
-    {
-        return quint32(ptr);
-    }
+SIRE_ALWAYS_INLINE quint32 toUInt(const void *ptr)
+{
+    return quint32(ptr);
+}
 
-    SIRE_ALWAYS_INLINE qint32 toInt32(const void *ptr)
-    {
-        return toInt(ptr);
-    }
+SIRE_ALWAYS_INLINE qint32 toInt32(const void *ptr)
+{
+    return toInt(ptr);
+}
 
-    SIRE_ALWAYS_INLINE quint32 toUInt32(const void *ptr)
-    {
-        return toUInt(ptr);
-    }
+SIRE_ALWAYS_INLINE quint32 toUInt32(const void *ptr)
+{
+    return toUInt(ptr);
+}
 
-    SIRE_ALWAYS_INLINE qint64 toInt64(const void *ptr)
-    {
-        return qint64( toInt(ptr) );
-    }
+SIRE_ALWAYS_INLINE qint64 toInt64(const void *ptr)
+{
+    return qint64(toInt(ptr));
+}
 
-    SIRE_ALWAYS_INLINE quint64 toUInt64(const void *ptr)
-    {
-        return quint64( toUInt(ptr) );
-    }
+SIRE_ALWAYS_INLINE quint64 toUInt64(const void *ptr)
+{
+    return quint64(toUInt(ptr));
+}
 
-  #elif QT_POINTER_SIZE == 8
+#elif QT_POINTER_SIZE == 8
 
-    // Functions used if we have 64bit pointers
-    SIRE_ALWAYS_INLINE qint64 toInt(const void *ptr)
-    {
-        return qint64(ptr);
-    }
+// Functions used if we have 64bit pointers
+SIRE_ALWAYS_INLINE qint64 toInt(const void *ptr)
+{
+    return qint64(ptr);
+}
 
-    SIRE_ALWAYS_INLINE quint64 toUInt(const void *ptr)
-    {
-        return quint64(ptr);
-    }
+SIRE_ALWAYS_INLINE quint64 toUInt(const void *ptr)
+{
+    return quint64(ptr);
+}
 
-    SIRE_ALWAYS_INLINE qint32 toInt32(const void *ptr)
-    {
-        return qint32( toInt(ptr) );
-    }
+SIRE_ALWAYS_INLINE qint32 toInt32(const void *ptr)
+{
+    return qint32(toInt(ptr));
+}
 
-    SIRE_ALWAYS_INLINE quint32 toUInt32(const void *ptr)
-    {
-        return qint32( toUInt(ptr) );
-    }
+SIRE_ALWAYS_INLINE quint32 toUInt32(const void *ptr)
+{
+    return qint32(toUInt(ptr));
+}
 
-    SIRE_ALWAYS_INLINE qint64 toInt64(const void *ptr)
-    {
-        return toInt(ptr);
-    }
+SIRE_ALWAYS_INLINE qint64 toInt64(const void *ptr)
+{
+    return toInt(ptr);
+}
 
-    SIRE_ALWAYS_INLINE quint64 toUInt64(const void *ptr)
-    {
-        return toUInt(ptr);
-    }
+SIRE_ALWAYS_INLINE quint64 toUInt64(const void *ptr)
+{
+    return toUInt(ptr);
+}
 
-  #else
-    #fatal Invalid QT_POINTER_SIZE value stored!
-  #endif
 #else
-  #fatal No QT_POINTER_SIZE macro defined!
+#fatal Invalid QT_POINTER_SIZE value stored !
+#endif
+#else
+#fatal No QT_POINTER_SIZE macro defined !
 #endif
 
 // MSVC does not support the #warning preprocessor directive
@@ -273,8 +281,8 @@
 #define WARNING(desc) message(__FILE__ "(" STRINGIZE(__LINE__) ") : Warning: " #desc)
 #endif
 
-//I now define seperate SIRE_EXPORT macros for each of the different Sire libraries.
-// SIREANALYSIS_EXPORT definitions
+// I now define seperate SIRE_EXPORT macros for each of the different Sire libraries.
+//  SIREANALYSIS_EXPORT definitions
 #ifdef _WIN32
 #ifdef SIREANALYSIS_BUILD
 #define SIREANALYSIS_EXPORT SIRE_EXPORT
@@ -491,181 +499,185 @@
 #endif
 // SQUIRE_EXPORT end definitions
 
-//Add functions that are used to register all public
-//types (this allows them to be streamed to a binary file and
-//created dynamically)
+// Add functions that are used to register all public
+// types (this allows them to be streamed to a binary file and
+// created dynamically)
 #include <QMetaType>
 
 namespace Sire
 {
-typedef quint32 MagicID;
+    typedef quint32 MagicID;
 
-SIRESTREAM_EXPORT MagicID getMagic(const char *type_name);
+    SIRESTREAM_EXPORT MagicID getMagic(const char *type_name);
 
-/** Enum used to register with only the magic ID */
-enum MagicOnlyEnum{ MAGIC_ONLY = 1 };
-/** Enum used to register without using the streaming operators */
-enum NoStreamEnum{ NO_STREAM = 2 };
-/** Enum used to register a class without a root class */
-enum NoRootEnum{ NO_ROOT = 3 };
-
-class RegisterMetaTypeBase
-{
-public:
-    RegisterMetaTypeBase(MagicID magic, const char *type_name, int ID)
-          : magicid(magic), typnam(type_name), id(ID)
-    {}
-
-    ~RegisterMetaTypeBase()
-    {}
-
-    MagicID magicID() const
+    /** Enum used to register with only the magic ID */
+    enum MagicOnlyEnum
     {
-        return magicid;
+        MAGIC_ONLY = 1
+    };
+    /** Enum used to register without using the streaming operators */
+    enum NoStreamEnum
+    {
+        NO_STREAM = 2
+    };
+    /** Enum used to register a class without a root class */
+    enum NoRootEnum
+    {
+        NO_ROOT = 3
+    };
+
+    class RegisterMetaTypeBase
+    {
+    public:
+        RegisterMetaTypeBase(MagicID magic, const char *type_name, int ID)
+            : magicid(magic), typnam(type_name), id(ID)
+        {
+        }
+
+        ~RegisterMetaTypeBase()
+        {
+        }
+
+        MagicID magicID() const
+        {
+            return magicid;
+        }
+
+        const char *typeName() const
+        {
+            return typnam;
+        }
+
+        QString typeNameString() const
+        {
+            return QLatin1String(typnam);
+        }
+
+        int ID() const
+        {
+            return id;
+        }
+
+    private:
+        MagicID magicid;
+        const char *typnam;
+        int id;
+    };
+
+    namespace detail
+    {
+        SIREERROR_EXPORT const QHash<QString, QSet<QString>> branchClasses();
+        SIREERROR_EXPORT const QHash<QString, QSet<QString>> leafClasses();
+        SIREERROR_EXPORT const QSet<QString> rootlessClasses();
+        SIREERROR_EXPORT void registerLeaf(const QString &type_name, const char *root_class);
+        SIREERROR_EXPORT void registerBranch(const QString &type_name, const char *root_class);
+        SIREERROR_EXPORT void registerRootless(const QString &type_name);
     }
 
-    const char* typeName() const
+    /** This is used to register the type 'T' - this
+        needs to be called once for each public type.
+
+        @author Christopher Woods
+    */
+    template <class T>
+    class RegisterMetaType : public RegisterMetaTypeBase
     {
-        return typnam;
-    }
+    public:
+        /** Use this constructor to register a concrete class */
+        RegisterMetaType()
+            : RegisterMetaTypeBase(getMagic(QMetaType::typeName(qMetaTypeId<T>())),
+                                   QMetaType::typeName(qMetaTypeId<T>()),
+                                   qMetaTypeId<T>())
+        {
+            qRegisterMetaType<T>(this->typeName());
+            qRegisterMetaTypeStreamOperators<T>(this->typeName());
+            detail::registerLeaf(this->typeNameString(), T::ROOT::typeName());
+        }
 
-    QString typeNameString() const
-    {
-        return QLatin1String(typnam);
-    }
+        /** Use this constructor to register a concrete class with no root */
+        RegisterMetaType(NoRootEnum)
+            : RegisterMetaTypeBase(getMagic(QMetaType::typeName(qMetaTypeId<T>())),
+                                   QMetaType::typeName(qMetaTypeId<T>()),
+                                   qMetaTypeId<T>())
+        {
+            qRegisterMetaType<T>(this->typeName());
+            qRegisterMetaTypeStreamOperators<T>(this->typeName());
+            detail::registerRootless(this->typeNameString());
+        }
 
-    int ID() const
-    {
-        return id;
-    }
+        /** Use this construct to register a pure-virtual class */
+        RegisterMetaType(MagicOnlyEnum, const char *type_name)
+            : RegisterMetaTypeBase(getMagic(type_name), type_name, 0)
+        {
+            detail::registerBranch(this->typeNameString(), T::ROOT::typeName());
+        }
 
-private:
-    MagicID magicid;
-    const char *typnam;
-    int id;
-};
+        /** Use this construct to register a pure-virtual class with no registered root */
+        RegisterMetaType(MagicOnlyEnum, NoRootEnum, const char *type_name)
+            : RegisterMetaTypeBase(getMagic(type_name), type_name, 0)
+        {
+            detail::registerRootless(this->typeNameString());
+        }
 
-namespace detail
-{
-    SIREERROR_EXPORT const QHash< QString, QSet<QString> > branchClasses();
-    SIREERROR_EXPORT const QHash< QString, QSet<QString> > leafClasses();
-    SIREERROR_EXPORT const QSet<QString> rootlessClasses();
-    SIREERROR_EXPORT void registerLeaf(const QString &type_name, const char *root_class);
-    SIREERROR_EXPORT void registerBranch(const QString &type_name, const char *root_class);
-    SIREERROR_EXPORT void registerRootless(const QString &type_name);
-}
+        /** Use this constructor to register a class that cannot be streamed */
+        RegisterMetaType(NoStreamEnum)
+            : RegisterMetaTypeBase(getMagic(QMetaType::typeName(qMetaTypeId<T>())),
+                                   QMetaType::typeName(qMetaTypeId<T>()),
+                                   qMetaTypeId<T>())
+        {
+            qRegisterMetaType<T>(this->typeName());
+            detail::registerLeaf(this->typeNameString(), T::ROOT::typeName());
+        }
 
-/** This is used to register the type 'T' - this
-    needs to be called once for each public type.
+        /** Use this constructor to register a class that cannot be streamed
+            and that has no registered root */
+        RegisterMetaType(NoStreamEnum, NoRootEnum)
+            : RegisterMetaTypeBase(getMagic(QMetaType::typeName(qMetaTypeId<T>())),
+                                   QMetaType::typeName(qMetaTypeId<T>()),
+                                   qMetaTypeId<T>())
+        {
+            qRegisterMetaType<T>(this->typeName());
+            detail::registerRootless(this->typeNameString());
+        }
 
-    @author Christopher Woods
-*/
-template<class T>
-class RegisterMetaType : public RegisterMetaTypeBase
-{
-public:
-
-    /** Use this constructor to register a concrete class */
-    RegisterMetaType()
-        : RegisterMetaTypeBase( getMagic( QMetaType::typeName( qMetaTypeId<T>() ) ),
-                                QMetaType::typeName( qMetaTypeId<T>() ),
-                                qMetaTypeId<T>() )
-    {
-        qRegisterMetaType<T>(this->typeName());
-        qRegisterMetaTypeStreamOperators<T>(this->typeName());
-        detail::registerLeaf(this->typeNameString(), T::ROOT::typeName());
-    }
-
-    /** Use this constructor to register a concrete class with no root */
-    RegisterMetaType(NoRootEnum )
-        : RegisterMetaTypeBase( getMagic( QMetaType::typeName( qMetaTypeId<T>() ) ),
-                                QMetaType::typeName( qMetaTypeId<T>() ),
-                                qMetaTypeId<T>() )
-    {
-        qRegisterMetaType<T>(this->typeName());
-        qRegisterMetaTypeStreamOperators<T>(this->typeName());
-        detail::registerRootless(this->typeNameString());
-    }
-
-    /** Use this construct to register a pure-virtual class */
-    RegisterMetaType(MagicOnlyEnum, const char *type_name)
-        : RegisterMetaTypeBase( getMagic(type_name), type_name, 0 )
-    {
-        detail::registerBranch(this->typeNameString(), T::ROOT::typeName());
-    }
-
-    /** Use this construct to register a pure-virtual class with no registered root */
-    RegisterMetaType(MagicOnlyEnum, NoRootEnum, const char *type_name)
-        : RegisterMetaTypeBase( getMagic(type_name), type_name, 0 )
-    {
-        detail::registerRootless(this->typeNameString());
-    }
-
-    /** Use this constructor to register a class that cannot be streamed */
-    RegisterMetaType(NoStreamEnum )
-        : RegisterMetaTypeBase( getMagic( QMetaType::typeName( qMetaTypeId<T>() ) ),
-                                QMetaType::typeName( qMetaTypeId<T>() ),
-                                qMetaTypeId<T>() )
-    {
-        qRegisterMetaType<T>(this->typeName());
-        detail::registerLeaf(this->typeNameString(), T::ROOT::typeName());
-    }
-
-    /** Use this constructor to register a class that cannot be streamed
-        and that has no registered root */
-    RegisterMetaType(NoStreamEnum, NoRootEnum )
-        : RegisterMetaTypeBase( getMagic( QMetaType::typeName( qMetaTypeId<T>() ) ),
-                                QMetaType::typeName( qMetaTypeId<T>() ),
-                                qMetaTypeId<T>() )
-    {
-        qRegisterMetaType<T>(this->typeName());
-        detail::registerRootless(this->typeNameString());
-    }
-
-    /** Destructor */
-    ~RegisterMetaType()
-    {}
-};
+        /** Destructor */
+        ~RegisterMetaType()
+        {
+        }
+    };
 
 } // namespace Sire
 
-namespace SireStream
-{
-class XMLStream; // This class is used to stream objects to and from XML files
-
-} // namespace SireStream
-
-using Sire::RegisterMetaTypeBase;
-using Sire::RegisterMetaType;
-using Sire::MAGIC_ONLY;
-using Sire::NO_STREAM;
-using Sire::NO_ROOT;
-using Sire::MagicID;
 using Sire::getMagic;
-using SireStream::XMLStream;
+using Sire::MAGIC_ONLY;
+using Sire::MagicID;
+using Sire::NO_ROOT;
+using Sire::NO_STREAM;
+using Sire::RegisterMetaType;
+using Sire::RegisterMetaTypeBase;
 
 class QDataStream;
 class QTextStream;
 
-#else  // else #ifdef __cplusplus
+#else // else #ifdef __cplusplus
 
-//copied directly from qglobal.h /////////////////
+// copied directly from qglobal.h /////////////////
 #ifndef Q_DECL_EXPORT
-#  ifdef Q_OS_WIN
-#    define Q_DECL_EXPORT __declspec(dllexport)
-#  elif defined(QT_VISIBILITY_AVAILABLE)
-#    define Q_DECL_EXPORT __attribute__((visibility("default")))
-#  endif
-#  ifndef Q_DECL_EXPORT
-#    define Q_DECL_EXPORT
-#  endif
+#ifdef Q_OS_WIN
+#define Q_DECL_EXPORT __declspec(dllexport)
+#elif defined(QT_VISIBILITY_AVAILABLE)
+#define Q_DECL_EXPORT __attribute__((visibility("default")))
+#endif
+#ifndef Q_DECL_EXPORT
+#define Q_DECL_EXPORT
+#endif
 #endif
 #ifndef Q_DECL_IMPORT
-#  ifdef Q_OS_WIN
-#    define Q_DECL_IMPORT __declspec(dllimport)
-#  else
-#    define Q_DECL_IMPORT
-#  endif
+#ifdef Q_OS_WIN
+#define Q_DECL_IMPORT __declspec(dllimport)
+#else
+#define Q_DECL_IMPORT
+#endif
 #endif
 ///////////////////////////////////////////////////
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,28 @@ import shutil
 import glob
 
 try:
+    # Check to see if Sire is already installed in this environment
+    # and store the version.
+    import sire as sr
+
+    curver = sr.__version__
+except ImportError:
+    curver = None
+
+# If Sire is already installed, see if the version number has changed.
+if curver:
+    with open("version.txt", "r") as f:
+        ver = f.readline().strip()
+
+    # Abort if the versions differ.
+    if curver != ver:
+        raise EnvironmentError(
+            f"This environment already contains an install of Sire version {curver}. "
+            "Please delete the installation or create a new environment before "
+            f"installing version {ver}. Also remove old build directories from 'build'."
+        )
+
+try:
     # Find out how much memory we have in total.
     # The wrappers need 4 GB per core to compile
     import psutil
@@ -300,9 +322,7 @@ def conda_install(dependencies, install_bss_reqs=False):
 
     if not _is_conda_prepped:
         if install_bss_reqs:
-            cmd = (
-                "%s config --prepend channels openbiosim/label/dev" % conda_exe
-            )
+            cmd = "%s config --prepend channels openbiosim/label/dev" % conda_exe
             print("Activating openbiosim channel channel using: '%s'" % cmd)
             status = subprocess.run(cmd.split())
             if status.returncode != 0:
@@ -361,9 +381,7 @@ def install_requires(install_bss_reqs=False):
     print(f"Installing requirements for {platform_string}")
 
     if not os.path.exists(conda):
-        print(
-            "\nSire can only be installed into a conda or miniconda environment."
-        )
+        print("\nSire can only be installed into a conda or miniconda environment.")
         print(
             "Please install conda, miniconda, miniforge or similar, then "
             "activate the conda environment, then rerun this installation "
@@ -390,9 +408,7 @@ def install_requires(install_bss_reqs=False):
             from parse_requirements import parse_requirements
         except ImportError as e:
             print("\n\n[ERROR] ** You need to install pip-requirements-parser")
-            print(
-                "Run `conda install -c conda-forge pip-requirements-parser\n\n"
-            )
+            print("Run `conda install -c conda-forge pip-requirements-parser\n\n")
             raise e
 
     reqs = parse_requirements("requirements_host.txt")
@@ -449,10 +465,7 @@ def _get_build_ext():
         else:
             ext = ""
 
-        return (
-            os.path.basename(conda_base.replace(" ", "_").replace(".", "_"))
-            + ext
-        )
+        return os.path.basename(conda_base.replace(" ", "_").replace(".", "_")) + ext
 
 
 def _get_bin_dir():
@@ -501,12 +514,8 @@ def build(ncores: int = 1, npycores: int = 1, coredefs=[], pydefs=[]):
         print(f"{CC} => {CC_bin}")
 
         if CXX_bin is None or CC_bin is None:
-            print(
-                "Cannot find the compilers requested by conda-build in the PATH"
-            )
-            print(
-                "Please check that the compilers are installed and available."
-            )
+            print("Cannot find the compilers requested by conda-build in the PATH")
+            print("Please check that the compilers are installed and available.")
             sys.exit(-1)
 
         # use the full paths, in case CMake struggles
@@ -637,9 +646,7 @@ def build(ncores: int = 1, npycores: int = 1, coredefs=[], pydefs=[]):
     # Compile and install, as need to install to compile the wrappers
     make_args = make_cmd(ncores, True)
 
-    print(
-        'NOW RUNNING "%s" --build . --target %s' % (cmake, " ".join(make_args))
-    )
+    print('NOW RUNNING "%s" --build . --target %s' % (cmake, " ".join(make_args)))
     sys.stdout.flush()
     status = subprocess.run([cmake, "--build", ".", "--target", *make_args])
 
@@ -703,9 +710,7 @@ def build(ncores: int = 1, npycores: int = 1, coredefs=[], pydefs=[]):
     # Just compile the wrappers
     make_args = make_cmd(npycores, False)
 
-    print(
-        'NOW RUNNING "%s" --build . --target %s' % (cmake, " ".join(make_args))
-    )
+    print('NOW RUNNING "%s" --build . --target %s' % (cmake, " ".join(make_args)))
     sys.stdout.flush()
     status = subprocess.run([cmake, "--build", ".", "--target", *make_args])
 
@@ -778,9 +783,7 @@ def install_module(ncores: int = 1):
     make_args = make_cmd(ncores, True)
 
     # Now that cmake has run, we can compile and install wrapper
-    print(
-        'NOW RUNNING "%s" --build . --target %s' % (cmake, " ".join(make_args))
-    )
+    print('NOW RUNNING "%s" --build . --target %s' % (cmake, " ".join(make_args)))
     sys.stdout.flush()
     status = subprocess.run([cmake, "--build", ".", "--target", *make_args])
 
@@ -820,9 +823,7 @@ def install(ncores: int = 1, npycores: int = 1):
     # Now install the wrappers
     make_args = make_cmd(npycores, True)
 
-    print(
-        'NOW RUNNING "%s" --build . --target %s' % (cmake, " ".join(make_args))
-    )
+    print('NOW RUNNING "%s" --build . --target %s' % (cmake, " ".join(make_args)))
     sys.stdout.flush()
     status = subprocess.run([cmake, "--build", ".", "--target", *make_args])
 

--- a/wrapper/CMakeLists.txt
+++ b/wrapper/CMakeLists.txt
@@ -412,6 +412,12 @@ set (Boost_USE_STATIC_RUNTIME OFF)
 set (Boost_DEBUG ON)  # this gives a nice print out in the cmake list to debug how boost is found and linked
 find_package( Boost 1.7 COMPONENTS python REQUIRED )
 
+# Need to define this with C++17 so that
+# boost::hash does not use std::unary_function
+# (which was deprecated in C++11 and removed in C++17)
+# See https://github.com/boostorg/container_hash/issues/22
+add_definitions( -DBOOST_NO_CXX98_FUNCTION_BASE )
+
 include_directories( ${PYTHON_INCLUDE_DIR} )
 
 message( STATUS "boost::python library ${Boost_LIBRARIES}" )

--- a/wrapper/MM/GromacsAngle.pypp.cpp
+++ b/wrapper/MM/GromacsAngle.pypp.cpp
@@ -51,6 +51,7 @@ void register_GromacsAngle_class(){
         GromacsAngle_exposer.def( bp::init< int, double, bp::optional< double, double, double, double, double > >(( bp::arg("function_type"), bp::arg("k0"), bp::arg("k1")=0, bp::arg("k2")=0, bp::arg("k3")=0, bp::arg("k4")=0, bp::arg("k5")=0 ), "Construct an angle of the specified function type with specified parameters\n(the order should be the same as in the Gromacs Manual, table 5.5)") );
         GromacsAngle_exposer.def( bp::init< int, QList< double > const & >(( bp::arg("function_type"), bp::arg("params") ), "Construct an angle of the specified function type by interpreting the parameter\ndata from the passed list of parameter values. These should be in the\nsame order as in the Gromacs Manual, table 5.5") );
         GromacsAngle_exposer.def( bp::init< SireCAS::Expression const &, SireCAS::Symbol const & >(( bp::arg("angle"), bp::arg("theta") ), "Construct from the passed angle, using theta as the symbol for the theta value") );
+        GromacsAngle_exposer.def( bp::init< SireCAS::Expression const &, SireCAS::Symbol const &, SireCAS::Expression const &, SireCAS::Symbol const & >(( bp::arg("angle"), bp::arg("theta"), bp::arg("ub"), bp::arg("r") ), "Construct from the passed angle plus urey-bradley term") );
         GromacsAngle_exposer.def( bp::init< SireMM::GromacsAngle const & >(( bp::arg("other") ), "Copy constructor") );
         { //::SireMM::GromacsAngle::assertResolved
         

--- a/wrapper/MM/GromacsDihedral.pypp.cpp
+++ b/wrapper/MM/GromacsDihedral.pypp.cpp
@@ -92,13 +92,13 @@ void register_GromacsDihedral_class(){
         }
         { //::SireMM::GromacsDihedral::constructImproper
         
-            typedef ::QList< SireMM::GromacsDihedral > ( *constructImproper_function_type )( ::SireCAS::Expression const &,::SireCAS::Symbol const & );
+            typedef ::QList< SireMM::GromacsDihedral > ( *constructImproper_function_type )( ::SireCAS::Expression const &,::SireCAS::Symbol const &,::SireCAS::Symbol const & );
             constructImproper_function_type constructImproper_function_value( &::SireMM::GromacsDihedral::constructImproper );
             
             GromacsDihedral_exposer.def( 
                 "constructImproper"
                 , constructImproper_function_value
-                , ( bp::arg("dihedral"), bp::arg("phi") )
+                , ( bp::arg("dihedral"), bp::arg("phi"), bp::arg("theta") )
                 , bp::release_gil_policy()
                 , "Construct from the passed improper, using phi as the symbol for the phi value" );
         


### PR DESCRIPTION
## If this is to fix a bug...

This pull request fixes issue #26, plus the slow AmberPrm issue (fix_amberprm_parallel), plus compile issues on MacOS with older boost (fix_mcs_unary_function) plus the version check on compile (feature_version_check) (which I would call a fix rathe than a feature ;-)).

I have also taken the opportunity to update the GitHub actions workflows and split them into three:

1. pr.yaml - for pull requests only. Not manually runnable. Only builds the pull request for the latest python on Windows, Mac and Linux, and only older Pythons on Linux. This should catch everything except for weird errors on older Pythons on non-Linux systems. It saves 4 out of 9 builds per pull request.

2. devel.yaml - for pushes to devel or manual runs only. Only builds the devel branch for the latest python on Windows, Mac and Linux, and only older Pythons on Linux. This will upload the packages automatically to anaconda cloud. This should catch all but the weird errors, saves 4 out of 9 builds per pull request, and will save space on anaconda cloud as now only the latest Python version will be supported on devel for Mac and Windows.

3. main.yaml - only for manual runs, for which you have to say whether or not you want to upload packages to anaconda cloud (yes / no). This runs everything on the main branch. We can use this to test that fixes / releases do build and pass all tests on all supported platforms and versions, and can choose whether or not to upload the packages based on whether or not we are running a release. Eventually I would like to split this into two, with the run creating packages that are held in GitHub Actions as artefacts, and then the second doing the actual upload if we choose to and the artefacts have been created correctly.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@lohedges

## Any additional context of information?

I have tested the loading and saving of the SLipids molecules, but can't add any nice tests until I have added in the code to support the forcefield terms in the internal forcefield. I think the code to support reading/writing is a "fix" and can be in 2023.2.1, while the code to add the internal forcefield terms and make sure that these all work correctly (including in openmm) is a "feature" for 2023.3.0. I don't want to block the fix from going in, so it is good to merge. I will do the feature on a proper feature branch.