### PR TITLE
Added openmmtools as a host requirement

### DIFF
--- a/requirements_bss.txt
+++ b/requirements_bss.txt
@@ -8,6 +8,8 @@
 # commonly installed by users alongside it. Adding them here allows a
 # user to create environments with and without these packages installed.
 
+openmmtools >= 0.21.5
+
 # Both ambertools and gromacs aren't available on ARM64 or Windows
 # We will only require them for Linux x86-64 and Apple x86-64.
 ambertools >= 22 ; sys_platform != "win32" and platform_machine == "x86_64"


### PR DESCRIPTION
This adds in openmmtools as a host dependency of sire, so that it can be installed in addition to all of the BioSimSpace dependencies. This is needed as, currently, the version of libnetcdf pulled in by sire is too new for openmmtools.

[ci skip]