### PR TITLE
fix_42

### DIFF
--- a/corelib/src/libs/SireIO/amberprm.cpp
+++ b/corelib/src/libs/SireIO/amberprm.cpp
@@ -3730,12 +3730,32 @@ MolStructureEditor AmberPrm::getMolStructure(int molidx, const PropertyName &cut
     // the layout of cutgroups, residues and atoms
     MolStructureEditor mol;
 
-    const auto atom_names = this->stringData("ATOM_NAME");
+    auto atom_names = this->stringData("ATOM_NAME");
+
+    while (atom_names.count() < natoms)
+    {
+        // we are missing some atom names - give a default
+        // name of "UNK", which tends to be used for "UNKNOWN" atoms.
+        // see
+        // https://www.rcsb.org/ligand/UNX
+        // for this convention
+        atom_names.append("UNK");
+    }
 
     // locate the residue pointers for this molecule - note that the
     // residue pointers are 1-indexed (i.e. from atom 1 to atom N)
     const auto res_pointers = this->intData("RESIDUE_POINTER");
-    const auto res_names = this->stringData("RESIDUE_LABEL");
+    auto res_names = this->stringData("RESIDUE_LABEL");
+
+    while (res_names.count() < res_pointers.count())
+    {
+        // we are missing some residue names - give a default
+        // name of "UNK", which tends to be used for "UNKNOWN" residues
+        // see
+        // http://www.bmsc.washington.edu/CrystaLinks/man/pdb/part_37.html
+        // for this convention
+        res_names.append("UNK");
+    }
 
     for (int i = 0; i < res_pointers.count(); ++i)
     {

--- a/tests/io/test_nolabel.py
+++ b/tests/io/test_nolabel.py
@@ -1,0 +1,7 @@
+import sire as sr
+
+
+def test_no_label():
+    # try to load these files - they segfault if the label is missing
+    # Need to fix this bug :-)
+    mols = sr.load_test_files("no_label.rst7", "no_label.prm7")


### PR DESCRIPTION
Fixed the segfault when there is no residue label (and also the segfa…ult that would have occured if there was no atom label). Added a unit test to check.

## If this is to fix a bug...

This pull request fixes issue #42

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@lohedges
