### PR TITLE
Feature s3 header

### DIFF
--- a/corelib/src/libs/SireStream/streamdata.cpp
+++ b/corelib/src/libs/SireStream/streamdata.cpp
@@ -392,7 +392,11 @@ namespace SireStream
     SIRESTREAM_EXPORT void setHeaderProperty(const QString &key, const QString &value)
     {
         QMutexLocker lkr(detail::dataMutex());
-        header_properties[key] = value;
+
+        if (value.isEmpty() or value.isNull())
+            header_properties.remove(key);
+        else
+            header_properties[key] = value;
     }
 
     SIRESTREAM_EXPORT QString getHeaderProperty(const QString &key)

--- a/corelib/src/libs/SireStream/streamdata.cpp
+++ b/corelib/src/libs/SireStream/streamdata.cpp
@@ -62,8 +62,8 @@
 
 using namespace SireStream;
 
-using std::shared_ptr;
 using boost::tuple;
+using std::shared_ptr;
 
 namespace SireStream
 {
@@ -377,6 +377,36 @@ namespace SireStream
         }
 
     } // end of namespace detail
+
+    static QHash<QString, QString> header_properties;
+
+    static QHash<QString, QString> getHeaderProperties()
+    {
+        QMutexLocker lkr(detail::dataMutex());
+
+        auto local_props = header_properties;
+
+        return local_props;
+    }
+
+    SIRESTREAM_EXPORT void setHeaderProperty(const QString &key, const QString &value)
+    {
+        QMutexLocker lkr(detail::dataMutex());
+        header_properties[key] = value;
+    }
+
+    SIRESTREAM_EXPORT QString getHeaderProperty(const QString &key)
+    {
+        QMutexLocker lkr(detail::dataMutex());
+
+        auto it = header_properties.constFind(key);
+
+        if (it == header_properties.constEnd())
+            return QByteArray();
+        else
+            return it.value();
+    }
+
 } // end of namespace SireStream
 
 /////////
@@ -388,7 +418,7 @@ QDataStream &operator<<(QDataStream &ds, const FileHeader &header)
 {
     ds << header.version();
 
-    // versions 1 and 2 uses the Qt 4.2 data format
+    // versions 1, 2 and 3 uses the Qt 4.2 data format
     ds.setVersion(QDataStream::Qt_4_2);
 
     QByteArray data;
@@ -396,9 +426,14 @@ QDataStream &operator<<(QDataStream &ds, const FileHeader &header)
 
     ds2.setVersion(QDataStream::Qt_4_2);
 
+    if (header.version() == 3)
+    {
+        ds2 << header.props;
+    }
+
     ds2 << header.created_by << header.created_when << header.created_where << header.system_info;
 
-    if (header.version() == 2)
+    if (header.version() == 2 or header.version() == 3)
         ds2 << header.type_names;
 
     else if (header.version() == 1)
@@ -426,7 +461,27 @@ QDataStream &operator>>(QDataStream &ds, FileHeader &header)
     quint32 version;
     ds >> version;
 
-    if (version == 2)
+    if (version == 3)
+    {
+        // Version 3 uses the Qt 4.2 data format
+        ds.setVersion(QDataStream::Qt_4_2);
+
+        QByteArray data;
+        ds >> data;
+
+        data = qUncompress(data);
+
+        QDataStream ds2(data);
+
+        ds2.setVersion(QDataStream::Qt_4_2);
+
+        ds2 >> header.props >> header.created_by >> header.created_when >> header.created_where >> header.system_info >>
+            header.type_names >> header.build_repository >> header.build_version >> header.required_libraries >>
+            header.system_locale >> header.data_digest >> header.compressed_size >> header.uncompressed_size;
+
+        header.version_number = version;
+    }
+    else if (version == 2)
     {
         // Version 2 uses the Qt 4.2 data format
         ds.setVersion(QDataStream::Qt_4_2);
@@ -445,6 +500,7 @@ QDataStream &operator>>(QDataStream &ds, FileHeader &header)
             header.system_locale >> header.data_digest >> header.compressed_size >> header.uncompressed_size;
 
         header.version_number = version;
+        header.props.clear();
     }
     else if (version == 1)
     {
@@ -470,10 +526,11 @@ QDataStream &operator>>(QDataStream &ds, FileHeader &header)
         header.type_names.append(type_name);
 
         header.version_number = version;
+        header.props.clear();
     }
     else
         throw version_error(QObject::tr("The header version (%1) is not recognised. Only header version "
-                                        "1+2 are supported in this program.")
+                                        "1, 2 and 3 are supported in this program.")
                                 .arg(version),
                             CODELOC);
 
@@ -684,8 +741,12 @@ static const QString &getSystemInfo()
     lines.append("Compiler: Green Hills Optimizing C++ Compiler");
 #endif
 
+#ifdef Q_CC_CLANG
+    lines.append(QString("Compiler: CLANG C++ (%1.%2.%3)").arg(__clang_major__).arg(__clang_minor__).arg(__clang_patchlevel__));
+#else
 #ifdef Q_CC_GNU
     lines.append(QString("Compiler: GNU C++ (%1.%2.%3)").arg(__GNUC__).arg(__GNUC_MINOR__).arg(__GNUC_PATCHLEVEL__));
+#endif
 #endif
 
 #ifdef Q_CC_HIGHC
@@ -804,11 +865,13 @@ FileHeader::FileHeader(const QStringList &typ_names, const QByteArray &compresse
     uncompressed_size = raw_data.count();
 
     system_info = getSystemInfo();
+
+    props = getHeaderProperties();
 }
 
 /** Copy constructor */
 FileHeader::FileHeader(const FileHeader &other)
-    : created_by(other.created_by), created_when(other.created_when), created_where(other.created_where),
+    : props(other.props), created_by(other.created_by), created_when(other.created_when), created_where(other.created_where),
       system_info(other.system_info), type_names(other.type_names), build_repository(other.build_repository),
       build_version(other.build_version), required_libraries(other.required_libraries),
       system_locale(other.system_locale), data_digest(other.data_digest), compressed_size(other.compressed_size),
@@ -826,6 +889,7 @@ FileHeader &FileHeader::operator=(const FileHeader &other)
 {
     if (this != &other)
     {
+        props = other.props;
         created_by = other.created_by;
         created_when = other.created_when;
         created_where = other.created_where;
@@ -867,6 +931,38 @@ QString FileHeader::toString() const
         .arg(double(compressed_size) / 1024.0)
         .arg(double(uncompressed_size) / 1024.0)
         .arg(QLocale::countryToString(system_locale.country()), QLocale::languageToString(system_locale.language()));
+}
+
+/** Return the property associated with the passed key. Raises an exception
+ *  if this property doesn't exist
+ */
+const QString &FileHeader::property(const QString &key) const
+{
+    auto it = this->props.constFind(key);
+
+    if (it == this->props.constEnd())
+        throw SireError::invalid_key(QObject::tr(
+                                         "There is no header property associated with the key '%1'. Available keys are : [ %2 ]")
+                                         .arg(key)
+                                         .arg(this->props.keys().join(", ")),
+                                     CODELOC);
+
+    return it.value();
+}
+
+const QString &FileHeader::property(const QString &key, const QString &default_value) const
+{
+    auto it = this->props.constFind(key);
+
+    if (it == this->props.constEnd())
+        return default_value;
+    else
+        return it.value();
+}
+
+bool FileHeader::hasProperty(const QString &key) const
+{
+    return this->props.contains(key);
 }
 
 /** Return the username of whoever created this data */
@@ -1036,10 +1132,10 @@ void FileHeader::assertNotCorrupted(const QByteArray &compressed_data) const
     is changed only when the file format is completely changed (e.g. we
     move away from using a compressed header, then the compressed object)
 
-    Currently, we only use version 1, which has this format;
+    Currently, we only use version 1, 2 or 3, which has this format;
 
     SIRE_MAGIC_NUMBER  (quint32 = 251785387)
-    VERSION_NUMBER     (quint32 = 2)
+    VERSION_NUMBER     (quint32 = 3)
     QByteArray         (compressed array containing the file header)
     QByteArray         (compressed array containing the saved object)
 
@@ -1049,8 +1145,8 @@ quint32 FileHeader::version() const
 {
     if (version_number == 0)
         // the version has not been set - so use the latest version
-        // available - which is '2' in this case
-        return 2;
+        // available - which is '3' in this case
+        return 3;
     else
         return version_number;
 }
@@ -1093,7 +1189,7 @@ namespace SireStream
         {
             FileHeader header;
 
-            if (header.version() == 1 or header.version() == 2)
+            if (header.version() == 1 or header.version() == 2 or header.version() == 3)
             {
                 int nobjects = objects.count();
 
@@ -1205,7 +1301,7 @@ namespace SireStream
         {
             FileHeader header;
 
-            if (header.version() == 1 or header.version() == 2)
+            if (header.version() == 1 or header.version() == 2 or header.version() == 3)
             {
                 int nobjects = objects.count();
 
@@ -1424,7 +1520,7 @@ namespace SireStream
             return loaded_objects;
         }
 
-        if (header.version() == 1 or header.version() == 2)
+        if (header.version() == 1 or header.version() == 2 or header.version() == 3)
         {
             // read in the binary data containing all of the objects
             QByteArray compressed_data;

--- a/corelib/src/libs/SireStream/streamdata.hpp
+++ b/corelib/src/libs/SireStream/streamdata.hpp
@@ -156,13 +156,19 @@ namespace SireStream
 
         quint32 version() const;
 
+        const QString &property(const QString &key) const;
+        const QString &property(const QString &key, const QString &default_value) const;
+
+        bool hasProperty(const QString &key) const;
+
         void assertCompatible() const;
         void assertNotCorrupted(const QByteArray &compressed_data) const;
 
     private:
-        FileHeader(const QString &type_name, const QByteArray &compressed_data, const QByteArray &raw_data);
-
         FileHeader(const QStringList &type_names, const QByteArray &compressed_data, const QByteArray &raw_data);
+
+        /** Any additional properties stored in the header */
+        QHash<QString, QString> props;
 
         /** The username of the person who created this data */
         QString created_by;
@@ -214,6 +220,9 @@ namespace SireStream
 
     SIRESTREAM_EXPORT quint32 getLibraryVersion(const QString &library);
     SIRESTREAM_EXPORT quint32 getMinimumSupportedVersion(const QString &library);
+
+    SIRESTREAM_EXPORT void setHeaderProperty(const QString &key, const QString &data);
+    SIRESTREAM_EXPORT QString getHeaderProperty(const QString &key);
 
     class SIRESTREAM_EXPORT RegisterLibrary
     {
@@ -317,6 +326,8 @@ namespace SireStream
 SIRE_EXPOSE_FUNCTION(SireStream::getDataHeader)
 SIRE_EXPOSE_FUNCTION(SireStream::getLibraryVersion)
 SIRE_EXPOSE_FUNCTION(SireStream::getMinimumSupportedVersion)
+SIRE_EXPOSE_FUNCTION(SireStream::setHeaderProperty)
+SIRE_EXPOSE_FUNCTION(SireStream::getHeaderProperty)
 
 SIRE_EXPOSE_CLASS(SireStream::FileHeader)
 

--- a/src/sire/stream/__init__.py
+++ b/src/sire/stream/__init__.py
@@ -1,7 +1,113 @@
-__all__ = []
+__all__ = [
+    "save",
+    "load",
+    "get_data_header",
+    "set_header_property",
+    "get_header_property",
+]
 
 from ..legacy import Stream as _Stream
 
 from .. import use_new_api as _use_new_api
 
 _use_new_api()
+
+
+def save(obj, filename=None):
+    """
+    Save the passed object to the sire streamed data format.
+    If 'filename' is passed then the data is written to this file.
+    Otherwise the data is returned as a binary array.
+    """
+    if filename is None:
+        return _Stream.save(obj)
+    else:
+        _Stream.save(obj, filename)
+
+
+def load(data):
+    """
+    Load the passed data from the sire streamed data format.
+    If 'data' is a string, then this will load the appropriate
+    file. Otherwise, it will assume data is a binary array,
+    so will load the data directly from that.
+    """
+    return _Stream.load(data)
+
+
+def get_data_header(data):
+    """
+    Return the header data from the sire streamed data.
+    If 'data' is a string then this is loaded from the
+    appropriate file. Otherwise it will assume data is a
+    binary array and will load directly from that.
+    """
+    try:
+        return _Stream.getDataHeader(data)
+    except AttributeError:
+        pass
+
+    return _Stream.get_data_header(data)
+
+
+def _to_binary(value):
+    """Internal function to creata a binary array from 'value'"""
+    import pickle
+
+    return pickle.dumps(value).hex()
+
+
+def _from_binary(data):
+    """Internal function to create a value from the passed binary data"""
+    import pickle
+
+    return pickle.loads(bytes.fromhex(data))
+
+
+def set_header_property(key, value):
+    """
+    Set the global header value for key 'key' to the passed 'value'.
+    This will write this data into all sire streamed data files that
+    are written from now on.
+    """
+    try:
+        _Stream.setHeaderProperty(key, _to_binary(value))
+        return
+    except AttributeError:
+        pass
+
+    _Stream.set_header_property(key, _to_binary(value))
+
+
+def get_header_property(key):
+    """
+    Return the global header value for the key 'key'. Returns
+    None if no value is set.
+    """
+    try:
+        return _from_binary(_Stream.getHeaderProperty(key))
+    except AttributeError:
+        pass
+
+    return _from_binary(_Stream.get_header_property(key))
+
+
+FileHeader = _Stream.FileHeader
+
+
+def _fix_file_header():
+    FileHeader.__orig__property = FileHeader.property
+
+    def __get_property__(obj, key, default_value=None):
+        try:
+            data = obj.__orig__property(key)
+        except Exception:
+            return default_value
+
+        return _from_binary(data)
+
+    FileHeader.property = __get_property__
+
+
+if not hasattr(FileHeader, "__orig__property"):
+    _fix_file_header()

--- a/src/sire/stream/__init__.py
+++ b/src/sire/stream/__init__.py
@@ -19,6 +19,11 @@ def save(obj, filename=None):
     If 'filename' is passed then the data is written to this file.
     Otherwise the data is returned as a binary array.
     """
+    from ..system import System
+
+    if System.is_system(obj):
+        obj = obj._system
+
     if filename is None:
         return _Stream.save(obj)
     else:
@@ -32,7 +37,14 @@ def load(data):
     file. Otherwise, it will assume data is a binary array,
     so will load the data directly from that.
     """
-    return _Stream.load(data)
+    obj = _Stream.load(data)
+
+    from ..system import System
+
+    if System.is_system(obj):
+        return System(obj)
+    else:
+        return obj
 
 
 def get_data_header(data):
@@ -52,6 +64,9 @@ def get_data_header(data):
 
 def _to_binary(value):
     """Internal function to creata a binary array from 'value'"""
+    if value is None:
+        return ""
+
     import pickle
 
     return pickle.dumps(value).hex()
@@ -59,6 +74,12 @@ def _to_binary(value):
 
 def _from_binary(data):
     """Internal function to create a value from the passed binary data"""
+    if data is None:
+        return None
+
+    elif type(data) is str and len(data) == 0:
+        return None
+
     import pickle
 
     return pickle.loads(bytes.fromhex(data))

--- a/tests/stream/test_partial_selection.py
+++ b/tests/stream/test_partial_selection.py
@@ -16,9 +16,9 @@ def test_partial_selection(tmpdir, ala_mols):
 
     s3file = str(dir.join("output.s3"))
 
-    s3 = sr.legacy.Stream.save(res, s3file)
+    sr.stream.save(res, s3file)
 
-    res2 = sr.legacy.Stream.load(s3file)
+    res2 = sr.stream.load(s3file)
 
     assert res2.selection().num_selected_residues() == 1
     assert res2.residue().number() == res.residue().number()
@@ -29,9 +29,9 @@ def test_partial_selection(tmpdir, ala_mols):
 
     s3file = str(dir.join("output2.s3"))
 
-    s3 = sr.legacy.Stream.save(res, s3file)
+    sr.stream.save(res, s3file)
 
-    res2 = sr.legacy.Stream.load(s3file)
+    res2 = sr.stream.load(s3file)
 
     assert res2.selection().num_selected_residues() == 1
     assert res2.residue().number() == res.residue().number()

--- a/tests/stream/test_stream_header.py
+++ b/tests/stream/test_stream_header.py
@@ -1,0 +1,57 @@
+import sire as sr
+
+import pytest
+
+
+def test_stream_header(tmpdir, ala_mols):
+    mols = ala_mols
+
+    dir = tmpdir.mkdir("test_stream_header")
+
+    s3file = str(dir.join("output.s3"))
+
+    sr.stream.save(mols, s3file)
+
+    m = sr.stream.load(s3file)
+
+    assert mols.num_molecules() == m.num_molecules()
+
+    h = sr.stream.get_data_header(s3file)
+
+    assert not h.has_property("cat")
+
+    assert h.property("cat") is None
+
+    sr.stream.set_header_property("cat", [1, 2, 3, 4, 5, 6])
+    sr.stream.set_header_property("mouse", "hello")
+    sr.stream.set_header_property("fish", 3.141)
+
+    sr.stream.save(mols, s3file)
+
+    h = sr.stream.get_data_header(s3file)
+
+    assert h.property("cat") == [1, 2, 3, 4, 5, 6]
+    assert h.property("mouse") == "hello"
+    assert h.property("fish") == 3.141
+
+    assert h.has_property("cat")
+    assert h.has_property("mouse")
+    assert h.has_property("fish")
+
+    m = sr.stream.load(s3file)
+
+    assert mols.num_molecules() == m.num_molecules()
+
+    sr.stream.set_header_property("cat", None)
+
+    sr.stream.save(mols, s3file)
+
+    h = sr.stream.get_data_header(s3file)
+
+    assert h.property("cat") is None
+    assert h.property("mouse") == "hello"
+    assert h.property("fish") == 3.141
+
+    assert not h.has_property("cat")
+    assert h.has_property("mouse")
+    assert h.has_property("fish")

--- a/wrapper/Stream/FileHeader.pypp.cpp
+++ b/wrapper/Stream/FileHeader.pypp.cpp
@@ -183,6 +183,19 @@ void register_FileHeader_class(){
                 , "Return the digest of the data - this is used to check\nfor any data corruption" );
         
         }
+        { //::SireStream::FileHeader::hasProperty
+        
+            typedef bool ( ::SireStream::FileHeader::*hasProperty_function_type)( ::QString const & ) const;
+            hasProperty_function_type hasProperty_function_value( &::SireStream::FileHeader::hasProperty );
+            
+            FileHeader_exposer.def( 
+                "hasProperty"
+                , hasProperty_function_value
+                , ( bp::arg("key") )
+                , bp::release_gil_policy()
+                , "" );
+        
+        }
         { //::SireStream::FileHeader::locale
         
             typedef ::QLocale const & ( ::SireStream::FileHeader::*locale_function_type)(  ) const;
@@ -205,6 +218,32 @@ void register_FileHeader_class(){
                 , assign_function_value
                 , ( bp::arg("other") )
                 , bp::return_self< >()
+                , "" );
+        
+        }
+        { //::SireStream::FileHeader::property
+        
+            typedef ::QString const & ( ::SireStream::FileHeader::*property_function_type)( ::QString const & ) const;
+            property_function_type property_function_value( &::SireStream::FileHeader::property );
+            
+            FileHeader_exposer.def( 
+                "property"
+                , property_function_value
+                , ( bp::arg("key") )
+                , bp::return_value_policy< bp::copy_const_reference >()
+                , "Return the property associated with the passed key. Raises an exception\n  if this property doesnt exist\n" );
+        
+        }
+        { //::SireStream::FileHeader::property
+        
+            typedef ::QString const & ( ::SireStream::FileHeader::*property_function_type)( ::QString const &,::QString const & ) const;
+            property_function_type property_function_value( &::SireStream::FileHeader::property );
+            
+            FileHeader_exposer.def( 
+                "property"
+                , property_function_value
+                , ( bp::arg("key"), bp::arg("default_value") )
+                , bp::return_value_policy< bp::copy_const_reference >()
                 , "" );
         
         }

--- a/wrapper/Stream/SireStream_registrars.cpp
+++ b/wrapper/Stream/SireStream_registrars.cpp
@@ -3,8 +3,6 @@
 
 #include "SireStream_registrars.h"
 
-
-
 #include "magic_error.h"
 #include "version_error.h"
 

--- a/wrapper/Stream/_Stream_free_functions.pypp.cpp
+++ b/wrapper/Stream/_Stream_free_functions.pypp.cpp
@@ -167,6 +167,86 @@ namespace bp = boost::python;
 
 #include "streamdata.hpp"
 
+#include "SireError/errors.h"
+
+#include "SireStream/errors.h"
+
+#include "SireStream/version_error.h"
+
+#include "registeralternativename.h"
+
+#include "shareddatastream.h"
+
+#include "streamdata.hpp"
+
+#include "tostring.h"
+
+#include <QByteArray>
+
+#include <QDataStream>
+
+#include <QDebug>
+
+#include <QFile>
+
+#include <QList>
+
+#include <QMutex>
+
+#include <QProcess>
+
+#include <QSysInfo>
+
+#include <QtGlobal>
+
+#include <boost/config.hpp>
+
+#include <cstdlib>
+
+#include <memory>
+
+#include "streamdata.hpp"
+
+#include "SireError/errors.h"
+
+#include "SireStream/errors.h"
+
+#include "SireStream/version_error.h"
+
+#include "registeralternativename.h"
+
+#include "shareddatastream.h"
+
+#include "streamdata.hpp"
+
+#include "tostring.h"
+
+#include <QByteArray>
+
+#include <QDataStream>
+
+#include <QDebug>
+
+#include <QFile>
+
+#include <QList>
+
+#include <QMutex>
+
+#include <QProcess>
+
+#include <QSysInfo>
+
+#include <QtGlobal>
+
+#include <boost/config.hpp>
+
+#include <cstdlib>
+
+#include <memory>
+
+#include "streamdata.hpp"
+
 void register_free_functions(){
 
     { //::SireStream::getDataHeader
@@ -195,6 +275,19 @@ void register_free_functions(){
     
     }
 
+    { //::SireStream::getHeaderProperty
+    
+        typedef ::QString ( *getHeaderProperty_function_type )( ::QString const & );
+        getHeaderProperty_function_type getHeaderProperty_function_value( &::SireStream::getHeaderProperty );
+        
+        bp::def( 
+            "getHeaderProperty"
+            , getHeaderProperty_function_value
+            , ( bp::arg("key") )
+            , "" );
+    
+    }
+
     { //::SireStream::getLibraryVersion
     
         typedef ::quint32 ( *getLibraryVersion_function_type )( ::QString const & );
@@ -217,6 +310,19 @@ void register_free_functions(){
             "getMinimumSupportedVersion"
             , getMinimumSupportedVersion_function_value
             , ( bp::arg("library") )
+            , "" );
+    
+    }
+
+    { //::SireStream::setHeaderProperty
+    
+        typedef void ( *setHeaderProperty_function_type )( ::QString const &,::QString const & );
+        setHeaderProperty_function_type setHeaderProperty_function_value( &::SireStream::setHeaderProperty );
+        
+        bp::def( 
+            "setHeaderProperty"
+            , setHeaderProperty_function_value
+            , ( bp::arg("key"), bp::arg("data") )
             , "" );
     
     }


### PR DESCRIPTION
## This introduces new functionality...

Changes proposed in this pull request:

This pull request adds the ability to set set arbitrary metadata that will be added to all s3 files written by sire. I have also exposed the sire.legacy.Stream functions that are useful in sire.stream, fixing some rough edges.

The arbitrary metadata is stored internally in the `FileHeader` object, as a `QHash<QString,QString>`. Any picklable type is pickled and then hex-encoded and passed in as a `QString`. The reverse process occurs when reading a property. The properties are set globally, so that they are saved to any subsequently written s3 file.

The `test_stream_header.py` file shows how to use the API. I have not added anything more than API docs as I don't think this should be widely advertised (it is more to better-support BioSimSpace's stream functionality).

You set a global header property using `sr.stream.set_header_property(key, value)`, and can clear it by setting it to None, e.g. `sr.stream.set_header_property(key, None)`.

As this can be any picklable type, you could create a python metadata object that contains all the extra data you want, and then set a single global header property, e.g. `sr.stream.save_header_property("my_metadata", my_metadata_object)`.

You can then get this data from the loaded `FileHeader`, e.g. via

```
>>> h = sr.stream.get_data_header(s3file)
>>> my_metadata_object = h.property("my_metadata")
```

This will return `None` if the metadata hasn't been set. You can also use `h.has_property("my_metadata")` to query for it.

Note that this increases the global s3 version number from 2 to 3. This means that s3 files written by this version of sire CANNOT be read by earlier versions. But, files written by earlier versions can still be read (it is backwards compatible). s3files from earlier versions of sire don't have any set properties.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [n - as explained above]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@lohedges
