### PR TITLE
Small fixes that make it easier to add atoms to a system

### DIFF
--- a/corelib/src/libs/SireMM/amberparams.cpp
+++ b/corelib/src/libs/SireMM/amberparams.cpp
@@ -2163,7 +2163,7 @@ void guessMasses(AtomMasses &masses, const AtomElements &elements, bool *has_mas
     {
         const CGIdx cg(i);
 
-        for (int j = 0; i < elements.nAtoms(cg); ++j)
+        for (int j = 0; j < elements.nAtoms(cg); ++j)
         {
             const CGAtomIdx idx(cg, Index(j));
 

--- a/corelib/src/libs/SireMM/ljparameter.cpp
+++ b/corelib/src/libs/SireMM/ljparameter.cpp
@@ -79,11 +79,6 @@ LJParameter::LJParameter(const LJParameter &other) : sqrtsig(other.sqrtsig), sqr
 /** Construct a LJParameter that has the specified sigma and epsilon */
 LJParameter::LJParameter(Length s, MolarEnergy e) : sqrtsig(std::sqrt(std::abs(s))), sqrteps(std::sqrt(std::abs(e)))
 {
-    if (SireMaths::isZero(sqrtsig) or SireMaths::isZero(sqrteps))
-    {
-        sqrtsig = 0.0;
-        sqrteps = 0.0;
-    }
 }
 
 /** Destructor */

--- a/corelib/src/libs/SireMol/atomcoords.cpp
+++ b/corelib/src/libs/SireMol/atomcoords.cpp
@@ -335,7 +335,11 @@ AtomProperty<QVariant> AtomProperty<Vector>::toVariant() const
 
 static void assertCanConvert(const QVariant &value)
 {
-    if (not value.canConvert<Vector>())
+    if (value.isNull())
+    {
+        return;
+    }
+    else if (not value.canConvert<Vector>())
     {
         throw SireError::invalid_cast(QObject::tr("Cannot convert an object of type %1 to a SireMaths::Vector, "
                                                   "as is required to allow this object to be part of an "
@@ -358,9 +362,17 @@ static CoordGroup makeCoordGroup(const PackedArray2D<QVariant>::Array &values)
     for (int i = 0; i < nvals; ++i)
     {
         const QVariant &value = values_array[i];
-        assertCanConvert(value);
 
-        tmp_coords[i] = value.value<Vector>();
+        if (value.isNull())
+        {
+            tmp_coords[i] = Vector(0);
+        }
+        else
+        {
+            assertCanConvert(value);
+
+            tmp_coords[i] = value.value<Vector>();
+        }
     }
 
     return CoordGroup(tmp_coords);

--- a/corelib/src/libs/SireMol/molecules.cpp
+++ b/corelib/src/libs/SireMol/molecules.cpp
@@ -431,7 +431,32 @@ bool Molecules::update(const MoleculeData &moldata)
     {
         if (it->data() != moldata)
         {
-            mols.find(moldata.number())->update(moldata);
+            if (it->data().info().UID() != moldata.info().UID())
+            {
+                // the molecule has changed a lot - atoms have been
+                // added or removed - we need to replace, rather than
+                // update the molecule
+                if (it->selectedAll())
+                {
+                    mols[moldata.number()] = ViewsOfMol(moldata);
+                }
+                else
+                    throw SireError::incompatible_error(QObject::tr(
+                                                            "Cannot update molecule %1 because the layout for the new "
+                                                            "version of the molecule (%2) is different and this container "
+                                                            "contains only a subset of the atoms. This is likely "
+                                                            "because the molecule has been edited and the layout of "
+                                                            "atoms, residues etc has been changed. To update this molecule "
+                                                            "you will need to replace it in the container.")
+                                                            .arg(it->toString())
+                                                            .arg(Molecule(moldata).toString()),
+                                                        CODELOC);
+            }
+            else
+            {
+                mols.find(moldata.number())->update(moldata);
+            }
+
             return true;
         }
         else
@@ -1015,8 +1040,9 @@ int Molecules::nFrames(const SireBase::PropertyMap &map) const
         }
     }
 
-    if (nframes < 0)
-        return 0;
+    if (nframes < 1)
+        // there is always at least one frame (the current coordinates)
+        return 1;
     else
         return nframes;
 }

--- a/src/sire/mm/__init__.py
+++ b/src/sire/mm/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "SelectorMBond",
     "SelectorMDihedral",
     "SelectorMImproper",
+    "LJParameter",
 ]
 
 from ..legacy import MM as _MM
@@ -35,6 +36,7 @@ from .. import use_new_api as _use_new_api
 
 _use_new_api()
 
+LJParameter = _MM.LJParameter
 
 Bond = _MM.Bond
 SelectorBond = _MM.SelectorBond

--- a/src/sire/mol/_cursor.py
+++ b/src/sire/mol/_cursor.py
@@ -39,23 +39,24 @@ class _CursorData:
             ).edit()
         except Exception:
             # the molecule doesn't have a connectivity. Create one for it
-            from ..legacy.Mol import CovalentBondHunter
+            if self.molecule.has_property(self.map["coordinates"].source()):
+                from ..legacy.Mol import CovalentBondHunter
 
-            hunter = CovalentBondHunter()
+                hunter = CovalentBondHunter()
 
-            try:
-                connectivity = hunter(self.molecule)
-                self.molecule.set_property(
-                    self.connectivity_property, connectivity
-                )
-                self.connectivity = connectivity.edit()
-            except Exception as e:
-                from ..utils import Console
+                try:
+                    connectivity = hunter(self.molecule, self.map)
+                    self.molecule.set_property(
+                        self.connectivity_property, connectivity
+                    )
+                    self.connectivity = connectivity.edit()
+                except Exception as e:
+                    from ..utils import Console
 
-                Console.warning(
-                    f"Cannot auto-generate a connectivity for {self.molecule}."
-                    f" The error is:\n\n{e}"
-                )
+                    Console.warning(
+                        f"Cannot auto-generate a connectivity for {self.molecule}."
+                        f" The error is:\n\n{e}"
+                    )
 
     def number(self):
         """Return the molnum number of the molecule being edited

--- a/src/sire/system/_system.py
+++ b/src/sire/system/_system.py
@@ -326,29 +326,41 @@ class System:
         """
         return self.molecules().coordinates(*args, **kwargs)
 
-    def space(self):
+    def space(self, map=None):
         """
         Return the space used for this system
         """
         try:
-            return self._system.property("space")
+            if map is None:
+                return self._system.property("space")
+            else:
+                from ..base import create_map
+
+                map = create_map(map)
+                return self._system.property(map["space"])
         except Exception:
             from ..vol import Cartesian
 
             return Cartesian()
 
-    def time(self):
+    def time(self, map=None):
         """
         Return the current system time
         """
         try:
-            return self._system.property("time")
+            if map is None:
+                return self._system.property("time")
+            else:
+                from ..base import create_map
+
+                map = create_map(map)
+                return self._system.property(map["time"])
         except Exception:
             from ..units import picosecond
 
             return 0 * picosecond
 
-    def set_space(self, space):
+    def set_space(self, space, map=None):
         """
         Set the space to be used to hold all of the molecules
         in this system
@@ -362,9 +374,19 @@ class System:
                 f"sire.vol.Cartesian. You cannot use a {type(space)}."
             )
 
-        self._system.set_property("space", space)
+        if map is None:
+            self._system.set_property("space", space)
+        else:
+            from ..base import create_map
 
-    def set_time(self, time):
+            map = create_map(map)
+
+            space_property = map["space"]
+
+            if space_property.has_source():
+                self._system.set_property(space_property.source(), space)
+
+    def set_time(self, time, map=None):
         """
         Set the current time for the system
         """
@@ -372,7 +394,7 @@ class System:
         from ..base import wrap
 
         if time == 0:
-            self._system.set_property("time", wrap(0 * picosecond))
+            time = wrap(0 * picosecond)
         else:
             if not hasattr(time, "has_same_units"):
                 raise TypeError(
@@ -386,7 +408,19 @@ class System:
                     f"cannot use {time}."
                 )
 
-            self._system.set_property("time", wrap(time))
+            time = wrap(time)
+
+        if map is None:
+            self._system.set_property("time", time)
+        else:
+            from ..base import create_map
+
+            map = create_map(map)
+
+            time_property = map["time"]
+
+            if time_property.has_source():
+                self._system.set_property(time_property.source(), time)
 
     def evaluate(self, *args, **kwargs):
         """Return an evaluator for this Systme (or of the matching

--- a/tests/system/test_add_atoms.py
+++ b/tests/system/test_add_atoms.py
@@ -1,0 +1,83 @@
+import pytest
+import sire as sr
+
+
+def test_add_atoms(tmpdir, ala_mols):
+    mols = ala_mols.clone()
+
+    mol = mols[0]
+
+    editor = mol.edit()
+
+    n_to_add = 10
+    natoms = mol.num_atoms()
+
+    for i in range(0, n_to_add):
+        # Add the atom and put it into the first
+        # residue (update as needed if you want
+        # this in a different residue)
+        editor = (
+            editor.add(sr.mol.AtomName("Re"))
+            .renumber(sr.mol.AtomNum(natoms + i + 1))
+            .reparent(sr.mol.ResIdx(0))
+            .molecule()
+        )
+
+    mol = editor.commit()
+
+    # Second, we will set the properties of the
+    # atoms that we have added. We will do this using
+    # the new cursor syntax
+    cursor = mol.cursor()["atomname Re"]
+
+    # This cursor can be used to edit all of the "Re" atoms
+    # at once, or can be indexed to edit them individually
+
+    # We will iterate over them and set some default properties
+    for atom in cursor.atoms():
+        atom["coordinates"] = sr.maths.Vector(0)
+        atom["charge"] = 0 * sr.units.mod_electron
+        atom["element"] = sr.mol.Element(0)
+        atom["mass"] = 0 * sr.units.g_per_mol
+        atom["atomtype"] = "DM"
+
+    # Adding atoms has invalidated the "parameters" property, so
+    # this should be removed
+    cursor = cursor.molecule()
+
+    if "parameters" in cursor:
+        del cursor["parameters"]
+
+    mol = cursor.commit()
+
+    # You can also add bonds to these atoms, e.g.
+    connectivity = mol.property("connectivity").edit()
+
+    # here we connect the first Re atom to the first atom in the molecule...
+    connectivity.connect(mol["atomname Re"][0].index(), mol.atoms()[0].index())
+
+    # also should set a bond potential (even if this is zero)
+    bonds = mol.property("bond")
+    bonds.set(mol["atomname Re"][0].index(), mol.atoms()[0].index(), 0.0)
+
+    mol = (
+        mol.edit()
+        .set_property("connectivity", connectivity.commit())
+        .set_property("bond", bonds)
+        .commit()
+    )
+
+    # Finally(!) we update the system with the new version of this molecule...
+    mols.update(mol)
+
+    # ...then we write this out to a new PRMTOP/RST file
+    d = tmpdir.mkdir("test_add_atoms")
+    f = sr.save(mols, d.join("test"), format=["PRMTOP", "RST"])
+
+    # Reload the file to check everything is ok
+    mols = sr.load(f)
+
+    mol = mols[0]
+
+    assert mol.num_atoms() == ala_mols[0].num_atoms() + n_to_add
+    assert len(mol.bonds("atomname Re")) == 1


### PR DESCRIPTION
This fixes a bug in AtomCoords that now allows it to create coordinates when the value of is None.

This modifies Molecules so that we can now update a molecule when the molecule layout changes (as long as the whole molecule was contained in the Molecules object)

This fixes a bug in StructureEditor whereby the MoleculeInfoData was not being updated correctly in commitChanges if the molecule layout had changed.

# Is this pull request to fix a bug, or to introduce new functionality?

Mixture - allowing molecules be updated by molecules that change layout is new functionality, so is a feature and should not be backported. The bug fixes relate to this new functionality, and won't impact earlier versions of the code.

## If this introduces new functionality...

Changes proposed in this pull request:

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [n]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@lohedges

## Any additional context of information?

The new functionality is minor and not ready to be documented. This will be built on when we modernise the editing API. This is needed now for @jmichel80's some fix.