### PR TITLE
Fix RDKit null molecule issue (58)

### DIFF
--- a/doc/source/tutorial/part05/03_smiles.rst
+++ b/doc/source/tutorial/part05/03_smiles.rst
@@ -72,6 +72,15 @@ create an `rdkit Molecule <https://www.rdkit.org/docs/source/rdkit.Chem.rdchem.h
 which is converted to a :mod:`sire` :class:`~sire.mol.Molecule` using
 the functions in the :mod:`~sire.convert` module.
 
+.. note::
+
+   Note that the default is that all sanitization steps provided by rdkit
+   will be performed when generating the molecule. If any fail, then
+   an exception will be raised and the molecule won't be generated.
+   You can change this behaviour by passing ``must_sanitize`` as ``False``.
+   This will run as many of the sanitization steps as possible, ignoring
+   errors caused by individual steps.
+
 Generating smiles strings from molecules
 ----------------------------------------
 

--- a/src/sire/_load.py
+++ b/src/sire/_load.py
@@ -642,6 +642,7 @@ def smiles(
     labels_column: str = "labels",
     add_hydrogens: bool = True,
     generate_coordinates: bool = True,
+    must_sanitize: bool = True,
     map=None,
 ):
     """
@@ -677,6 +678,13 @@ def smiles(
             Whether or not to automatically generate 3D coordinates.
             Note that generating coordinates requires that
             hydrogens are automatically added.
+        must_sanitize: bool (default True)
+            Whether or not all sanity checks must pass when creating
+            the molecule. This will ensure that all sanity checks pass,
+            and if they don't, then an exception will be raised.
+            If this is not True, then sanity checks that failed are
+            skipped and silently ignored. It is possible, in this case,
+            that a null or malformed molecule may be returned.
         map:
             Property map if you want to put the molecule properties
             into different places
@@ -717,9 +725,39 @@ def smiles(
         {
             "add_hydrogens": add_hydrogens,
             "generate_coordinates": generate_coordinates,
+            "must_sanitize": must_sanitize,
         },
     )
 
     rdkit_mols = smiles_to_rdkit(smiles, labels, map)
 
-    return rdkit_to_sire(rdkit_mols)
+    mols = rdkit_to_sire(rdkit_mols)
+
+    if must_sanitize:
+        if len(smiles) == 1:
+            mol = mols
+            if mol.num_atoms() == 0:
+                raise ValueError(
+                    "Failed to generate a molecule from the smiles string "
+                    f"'{smiles[0]}'. Re-run this function setting "
+                    "'must_sanitize' to False if you want to try again, "
+                    "ignoring the sanitization steps that failed."
+                )
+        else:
+            empty_mols = []
+
+            for i, mol in enumerate(mols):
+                if mol.num_atoms() == 0:
+                    empty_mols.append(smiles[i])
+
+            if len(empty_mols) > 0:
+                empty_mols = ", ".join(empty_mols)
+
+                raise ValueError(
+                    "Failed to generate some molecules from smiles strings. "
+                    f"Failed conversions were: [{empty_mols}]. Re-run setting "
+                    "'must_sanitize' to False to try to generate the molecule "
+                    "ignoring the errors."
+                )
+
+    return mols

--- a/tests/convert/test_rdkit.py
+++ b/tests/convert/test_rdkit.py
@@ -89,3 +89,26 @@ def test_hybridization2():
 
     for atom, e in zip(mol.atoms(), expected):
         assert atom.property("hybridization").to_rdkit() == e
+
+
+@pytest.mark.skipif(
+    "rdkit" not in sr.convert.supported_formats(),
+    reason="rdkit support is not available",
+)
+def test_rdkit_returns_null():
+    # This molecule should construct if sanitization is turned off
+    mol = sr.smiles("c3cc[c+]2cc(C1CCCC1)[nH]c2c3", must_sanitize=False)
+
+    assert mol.num_atoms() == 36
+
+    # coordinates should be possible, albeit likely wrong!
+    assert mol.has_property("coordinates")
+
+    # We should raise an exception if sanitization fails
+    # and `must_sanitize` is True
+    with pytest.raises(ValueError):
+        mol = sr.smiles("c3cc[c+]2cc(C1CCCC1)[nH]c2c3", must_sanitize=True)
+
+    # this should be the default
+    with pytest.raises(ValueError):
+        mol = sr.smiles("c3cc[c+]2cc(C1CCCC1)[nH]c2c3")


### PR DESCRIPTION
Added a `must_sanitize` option that forces full sanitization of molecules generated

from smiles strings, and raises an exception if they fail to generate. This is set as default True.

If this is False, then sanitization is run manually, skipping any stages that fail.

Added a unit test to check this, plus added an addition to the documentation explaining the new mode.

## If this is to fix a bug...

This pull request fixes issue #58

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@lohedges

## Any additional context of information?

We are only a month away from the next major release. Do you think we are close enough that we can hold this for `2023.3.0` and not back-port to `2023.2.X`?