### PR TITLE
Fix AmberRst bug (wrong velocities)

### DIFF
--- a/actions/update_recipe.py
+++ b/actions/update_recipe.py
@@ -201,6 +201,7 @@ def check_reqs(reqs0, reqs1):
 # check_environment_reqs(env_reqs)
 
 build_reqs = dep_lines(check_reqs(build_reqs, env_reqs))
+host_reqs = combine(host_reqs, bss_reqs)
 host_reqs = dep_lines(combine(host_reqs, env_reqs))
 run_reqs = dep_lines(check_reqs(run_reqs, env_reqs))
 test_reqs = dep_lines(check_reqs(test_reqs, env_reqs))

--- a/actions/update_recipe.py
+++ b/actions/update_recipe.py
@@ -205,6 +205,8 @@ host_reqs = dep_lines(combine(host_reqs, env_reqs))
 run_reqs = dep_lines(check_reqs(run_reqs, env_reqs))
 test_reqs = dep_lines(check_reqs(test_reqs, env_reqs))
 
+print("\nRECIPE")
+
 with open(recipe, "w") as FILE:
     for line in lines:
         if line.find("SIRE_BUILD_REQUIREMENTS") != -1:
@@ -220,6 +222,7 @@ with open(recipe, "w") as FILE:
             line = line.replace("SIRE_BRANCH", sire_branch)
 
         FILE.write(line)
+        print(line, end="")
 
 channels = ["conda-forge", "openbiosim/label/dev"]
 

--- a/corelib/src/libs/SireIO/fortranfile.cpp
+++ b/corelib/src/libs/SireIO/fortranfile.cpp
@@ -373,7 +373,7 @@ FortranFile::FortranFile(const QString &filename,
         // open the file in writing mode
         f.reset(new FortranFileHandle(abs_filename, mode));
 
-        int_size = 8;
+        int_size = 4; // most readers expect an int_size of 4
 
 #if Q_BYTE_ORDER == Q_LITTLE_ENDIAN
         is_little_endian = true;

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -21,6 +21,9 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Fixed a bug where outputs from legacy script would be written with base physical
   units, rather than prettier internal or SI units.
 
+* Fixed a bug in the writing of DCD headers, meaning that the files couldn't be read
+  by other DCD reader software (written non-compliant header)
+
 `2023.3.0 <https://github.com/openbiosim/sire/compare/2023.2.3...2023.3.0>`__ - June 2023
 -----------------------------------------------------------------------------------------
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -12,6 +12,12 @@ Development was migrated into the
 `OpenBioSim <https://github.com/openbiosim>`__
 organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 
+`2023.3.1 <https://github.com/openbiosim/sire/compare/2023.2.3...2023.3.1>`__ - ???? 2023
+-----------------------------------------------------------------------------------------
+
+* Fixed a bug in the AmberRst parser where velocities were written with the wrong 
+  unit (A ps-1 instead of AKMA time). Also added the correct labels to the AmberRst file.
+
 `2023.3.0 <https://github.com/openbiosim/sire/compare/2023.2.3...2023.3.0>`__ - June 2023
 -----------------------------------------------------------------------------------------
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -18,6 +18,9 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Fixed a bug in the AmberRst parser where velocities were written with the wrong 
   unit (A ps-1 instead of AKMA time). Also added the correct labels to the AmberRst file.
 
+* Fixed a bug where outputs from legacy script would be written with base physical
+  units, rather than prettier internal or SI units.
+
 `2023.3.0 <https://github.com/openbiosim/sire/compare/2023.2.3...2023.3.0>`__ - June 2023
 -----------------------------------------------------------------------------------------
 

--- a/requirements_bss.txt
+++ b/requirements_bss.txt
@@ -29,7 +29,7 @@ py3dmol
 pydot
 pygtail
 pyyaml
-rdkit
+rdkit>=2023.0.0
 
 # The below are packages that aren't available on all
 # platforms/OSs and so need to be conditionally included

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -13,5 +13,5 @@ sysroot_linux-64==2.17 ; sys_platform == "linux"
 
 # These packages are needed to compile
 # the SireRDKit plugin
-rdkit
-rdkit-dev
+rdkit>=2023.0.0
+rdkit-dev>=2023.0.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 # Test requirements. These aren't needed by Sire, but if installed, will
 # enable test to run to validate advanced functionality
 
-rdkit
+rdkit>=2023.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,9 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(skip_slow)
 
     if not runveryslow:
-        skip_veryslow = pytest.mark.skip(reason="need --runveryslow option to run")
+        skip_veryslow = pytest.mark.skip(
+            reason="need --runveryslow option to run"
+        )
         for item in items:
             if "veryslow" in item.keywords:
                 item.add_marker(skip_veryslow)
@@ -106,4 +108,20 @@ def wrapped_mols():
 
 @pytest.fixture(scope="session")
 def openmm_interchange_mols():
-    return sr.load_test_files("openmm_interchange.rst7", "openmm_interchange.prm7")
+    return sr.load_test_files(
+        "openmm_interchange.rst7", "openmm_interchange.prm7"
+    )
+
+
+@pytest.fixture(scope="session")
+def triclinic_protein():
+    return sr.load_test_files(
+        "triclinic_protein.prm7", "triclinic_protein.crd"
+    )
+
+
+@pytest.fixture(scope="session")
+def triclinic_protein_rst7():
+    return sr.load_test_files(
+        "triclinic_protein.prm7", "triclinic_protein.rst"
+    )

--- a/tests/io/test_ambervels.py
+++ b/tests/io/test_ambervels.py
@@ -1,0 +1,51 @@
+import pytest
+import sire as sr
+
+
+def _assert_same_vel(v1, v2, precision):
+    for i in range(0, 3):
+        x1 = v1[i]
+        x2 = v2[i]
+
+        assert x1.has_same_units(x2)
+        assert x1.value() == pytest.approx(x2.value(), precision)
+
+
+@pytest.mark.veryslow
+def test_amber_vels_compare(tmpdir, triclinic_protein, triclinic_protein_rst7):
+    mols = triclinic_protein
+    mols7 = triclinic_protein_rst7
+
+    # check that the velocities are the same between these two files
+    for mol, mol7 in zip(mols[0::100], mols7[0::100]):
+        for atom, atom7 in zip(mol.atoms()[0::20], mol7.atoms()[0::20]):
+            _assert_same_vel(
+                atom.property("velocity"),
+                atom7.property("velocity"),
+                precision=1e-3,
+            )
+
+    # now write out to a rst7 file and rst file, then compare those
+    d = tmpdir.mkdir("test_amber_vels_compare")
+
+    f = sr.save(mols, d.join("test"), format=["PRMTOP", "RST7"])
+    f7 = sr.save(mols7, d.join("test"), format=["RST"])
+
+    check = sr.load(f[0], f[1])
+    check7 = sr.load(f[0], f7[0])
+
+    for mol, mol7 in zip(check[0::100], mols7[0::100]):
+        for atom, atom7 in zip(mol.atoms()[0::20], mol7.atoms()[0::20]):
+            _assert_same_vel(
+                atom.property("velocity"),
+                atom7.property("velocity"),
+                precision=1e-3,
+            )
+
+    for mol, mol7 in zip(mols[0::100], check7[0::100]):
+        for atom, atom7 in zip(mol.atoms()[0::20], mol7.atoms()[0::20]):
+            _assert_same_vel(
+                atom.property("velocity"),
+                atom7.property("velocity"),
+                precision=1e-3,
+            )

--- a/wrapper/Units/__init__.py
+++ b/wrapper/Units/__init__.py
@@ -1,3 +1,50 @@
 from ._Units import *
 
 from .. import Base as _Base
+
+
+_have_set_internal_units = False
+
+
+def _set_internal_units():
+    global _have_set_internal_units
+
+    if _have_set_internal_units:
+        return
+
+    _have_set_internal_units = True
+
+    try:
+        GeneralUnit.clearDefaults()
+    except AttributeError:
+        # we have activated the new api, which will
+        # handle setting internal units for us
+        return
+
+    for unit in [
+        "g",
+        "kcal",
+        "Å",
+        "ps",
+        "|e|",
+        "°",
+        "K",
+        "kcal mol-1",
+        "kcal mol-1 Å-1",
+        "kcal mol-1 Å-2",
+        "kcal mol-1 Å-3",
+        "kcal mol-1 °-1",
+        "kcal mol-1 °-2",
+        "kcal mol-1 K-1",
+        "kcal mol-1 K-2",
+        "kcal s",
+        "kcal s-1",
+        "kcal mol-1 s",
+        "kcal mol-1 s-1",
+        "kcal Å-1",
+    ]:
+        u = GeneralUnit(unit)
+        u.setAsDefault(unit)
+
+
+_set_internal_units()


### PR DESCRIPTION
Fixed the bug in AmberRst, where velocities were written out in units of A ps-1, but needed to be written as AKMA time velocities.

Also added in the labels as missing these caused issues for cpptraj

This is the backport into main.

* I confirm that I have merged the latest version of `main` into this branch before issuing this pull request (e.g. by running `git pull origin main`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Any additional context of information?

This is a quick PR to fix Exscientia's deployment.