### PR TITLE
Allow user to perform a conda build against a tag checkout/clone

### DIFF
--- a/actions/update_recipe.py
+++ b/actions/update_recipe.py
@@ -67,6 +67,17 @@ print(sire_remote)
 sire_branch = run_cmd(
     f"git --git-dir={gitdir} --work-tree={srcdir} rev-parse --abbrev-ref HEAD"
 )
+
+# If the branch is "HEAD", then we might be in detached head mode. If so, check
+# the tag.
+if sire_branch == "HEAD":
+    sire_branch = run_cmd(
+        f"git --git-dir={gitdir} --work-tree={srcdir} describe --tags"
+    )
+    # Make sure this is a pure tag commit.
+    if "-" in sire_branch:
+        raise RuntimeError("Cannot perform a tag build from a non-tag commit!")
+
 print(sire_branch)
 
 lines = open(template, "r").readlines()


### PR DESCRIPTION
This PR modified `update_recipe.py` so that the `git_tag` entry in the recipe will be updated correctly if the user clones a tag rather than a branch. I've tested this locally as follows:

```
git clone https://github.com/openbiosim/sire -b 2023.3.2
cd sire
git checkout 2023.3.2
python actions/update_recipe.py
```

In the resulting output I see `git_tag: 2023.3.2`, as expected. I've also checked that we still get the correct output on the current `devel` branch.

This change _could_ break CI from PRs, which are also in a detached `HEAD` state. However, we already solve this by performing a single-branch clone in the workflow script, i.e. the clone repo _will_ have a branch name, which will be used as the tag.

Once we're happy, I can apply this change to BioSImSpace too.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y] (Tested locally)
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [n] N/A
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [n]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods