### PR TITLE
Fix issue #122

### DIFF
--- a/corelib/src/libs/SireIO/biosimspace.cpp
+++ b/corelib/src/libs/SireIO/biosimspace.cpp
@@ -271,7 +271,7 @@ namespace SireIO
         // Copy across all properties that are unique to the original molecule.
         for (const auto &prop : molecule.propertyKeys())
         {
-            if (not water.hasProperty(prop) and not prop.compare("is_non_searchable_water"))
+            if (not water.hasProperty(prop) and prop.compare("is_non_searchable_water") != 0)
             {
                 edit_mol = edit_mol.setProperty(prop, molecule.property(prop)).molecule();
             }
@@ -493,7 +493,7 @@ namespace SireIO
         // Copy across all properties that are unique to the original molecule.
         for (const auto &prop : molecule.propertyKeys())
         {
-            if (not water.hasProperty(prop) and not prop.compare("is_non_searchable_water"))
+            if (not water.hasProperty(prop) and prop.compare("is_non_searchable_water") != 0)
             {
                 edit_mol = edit_mol.setProperty(prop, molecule.property(prop)).molecule();
             }

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -15,6 +15,9 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 `2023.5.0 <https://github.com/openbiosim/sire/compare/2023.4.0...2023.5.0>`__ - December 2023
 ---------------------------------------------------------------------------------------------
 
+* Fix use of ``QString::compare`` when comparing molecular properties during
+  a water topology swap.
+
 * Added a new :mod:`sire.options` module that contains new
   :cls:`sire.options.Option` objects to represent configurable options.
   These include documentation, and make it easier to validate and expose


### PR DESCRIPTION
This PR closes #122 by fixing the use of `QString::compare` when comparing molecular properties. We added a new (as yet unused) `is_non_searchable_water` property to allow a user to preserve water topologies, e.g. by excluding them from a search. However, I don't want to keep this property when swapping topology, so don't copy it to the new water template. I was incorrectly using `QString::compare` since I hadn't realised that it returned an `int`, not a `bool`. The return value is zero only when the strings match.

This will be tested via BioSimSpace.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods
