### PR TITLE
Fix issue #130

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -48,6 +48,9 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
   to keep existing behaviour, but we would recommend setting this to ``True``
   and would like to change the default in the future.
 
+* Fix validation of ``perturbable_constraint`` dynamics option when the string
+  includes hyphens. This fixes issue #130.
+
 * Please add an item to this changelog when you create your PR
 
 `2023.4.1 <https://github.com/openbiosim/sire/compare/2023.4.0...2023.4.1>`__ - October 2023

--- a/wrapper/Convert/SireOpenMM/openmmmolecule.cpp
+++ b/wrapper/Convert/SireOpenMM/openmmmolecule.cpp
@@ -130,7 +130,7 @@ OpenMMMolecule::OpenMMMolecule(const Molecule &mol,
         {
             perturbable_constraint_type = CONSTRAIN_NONE;
         }
-        else if (c == "h-bonds")
+        else if (c == "h-bonds" or c == "h_bonds")
         {
             perturbable_constraint_type = CONSTRAIN_HBONDS;
         }
@@ -138,11 +138,11 @@ OpenMMMolecule::OpenMMMolecule(const Molecule &mol,
         {
             perturbable_constraint_type = CONSTRAIN_BONDS;
         }
-        else if (c == "h-bonds-h-angles")
+        else if (c == "h-bonds-h-angles" or c == "h_bonds_h_angles")
         {
             perturbable_constraint_type = CONSTRAIN_HBONDS | CONSTRAIN_HANGLES;
         }
-        else if (c == "bonds-h-angles")
+        else if (c == "bonds-h-angles" or c == "bonds_h_angles")
         {
             perturbable_constraint_type = CONSTRAIN_BONDS | CONSTRAIN_HANGLES;
         }


### PR DESCRIPTION
This PR closes #130 by allowing the `perturbable_constraint` dynamics option to contain hyphens.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods