### PR TITLE
Feature optimise lever

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -57,6 +57,15 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
   a zero sigma value. They will either be sigma=1/epsilon=0 for non-perturbable
   atoms, or sigma=1e-9/epsilon=1e-9 for perturbable atoms.
 
+* Optimised the ``LambaLever`` class so that it caches the forcefield parameters
+  calculated at different lambda values. This means that we don't have to
+  re-calculate the parameters at each lambda update step. This is a
+  significant speed-up for alchemical free energy simulations.
+
+* Now catch ``std::bad_alloc`` and raise it as a ``MemoryError``. This
+  means that we can catch out-of-memory errors and raise a more
+  informative exception.
+
 * Please add an item to this changelog when you create your PR
 
 `2023.4.1 <https://github.com/openbiosim/sire/compare/2023.4.0...2023.4.1>`__ - October 2023

--- a/wrapper/Convert/SireOpenMM/CMakeLists.txt
+++ b/wrapper/Convert/SireOpenMM/CMakeLists.txt
@@ -24,6 +24,25 @@ if (${SIRE_USE_OPENMM})
     # Other python wrapping directories
     include_directories(${CMAKE_SOURCE_DIR})
 
+    # Check to see if we have support for updating some parameters in context
+    include(CheckCXXSourceCompiles)
+    check_cxx_source_compiles( "#include <openmm/CustomNonbondedForce.h>
+                                 int main() {
+                                   OpenMM::CustomNonbondedForce *force;
+                                   OpenMM::Context *context;
+                                   force->updateSomeParametersInContext(0, 0, *context);
+                                   return 0;
+                                 }"
+                               SIREOPENMM_HAS_UPDATESOMEPARAMETERSINCONTEXT )
+
+    if ( ${SIREOPENMM_HAS_UPDATESOMEPARAMETERSINCONTEXT} )
+      message( STATUS "OpenMM has support for updating some parameters in context")
+      add_definitions("-DSIRE_HAS_UPDATE_SOME_IN_CONTEXT")
+    else()
+      message( STATUS "OpenMM does not have support for updating some parameters in context")
+      message( STATUS "The free energy code will be a little slower.")
+    endif()
+
     # Define the sources in SireOpenMM
     set ( SIREOPENMM_SOURCES
 

--- a/wrapper/Convert/SireOpenMM/lambdalever.cpp
+++ b/wrapper/Convert/SireOpenMM/lambdalever.cpp
@@ -664,9 +664,6 @@ double LambdaLever::setLambda(OpenMM::Context &context,
     if (ghost_14ff)
         ghost_14ff->updateParametersInContext(context);
 
-    // in OpenMM 8.1beta updating the bond parameters past lambda=0.25
-    // causes a "All Forces must have identical exclusions" error,
-    // when running minimisation without h-bond constraints...
     if (bondff)
         bondff->updateParametersInContext(context);
 

--- a/wrapper/Convert/SireOpenMM/lambdalever.cpp
+++ b/wrapper/Convert/SireOpenMM/lambdalever.cpp
@@ -670,12 +670,18 @@ double LambdaLever::setLambda(OpenMM::Context &context,
         cljff->updateParametersInContext(context);
 
     if (ghost_ghostff)
-        // ghost_ghostff->updateSomeParametersInContext(start_change_atom, end_change_atom - start_change_atom, context);
+#ifdef SIRE_HAS_UPDATE_SOME_IN_CONTEXT
+        ghost_ghostff->updateSomeParametersInContext(start_change_atom, end_change_atom - start_change_atom, context);
+#else
         ghost_ghostff->updateParametersInContext(context);
+#endif
 
     if (ghost_nonghostff)
-        // ghost_nonghostff->updateSomeParametersInContext(start_change_atom, end_change_atom - start_change_atom, context);
+#ifdef SIRE_HAS_UPDATE_SOME_IN_CONTEXT
+        ghost_nonghostff->updateSomeParametersInContext(start_change_atom, end_change_atom - start_change_atom, context);
+#else
         ghost_nonghostff->updateParametersInContext(context);
+#endif
 
     if (ghost_14ff)
         ghost_14ff->updateParametersInContext(context);

--- a/wrapper/Convert/SireOpenMM/lambdalever.cpp
+++ b/wrapper/Convert/SireOpenMM/lambdalever.cpp
@@ -35,6 +35,125 @@
 using namespace SireOpenMM;
 using namespace SireCAS;
 
+//////
+////// Implementation of MolLambdaCache
+//////
+
+MolLambdaCache::MolLambdaCache() : lam_val(0)
+{
+}
+
+MolLambdaCache::MolLambdaCache(double lam) : lam_val(lam)
+{
+}
+
+MolLambdaCache::MolLambdaCache(const MolLambdaCache &other)
+    : lam_val(other.lam_val), cache(other.cache)
+{
+}
+
+MolLambdaCache::~MolLambdaCache()
+{
+}
+
+MolLambdaCache &MolLambdaCache::operator=(const MolLambdaCache &other)
+{
+    if (this != &other)
+    {
+        lam_val = other.lam_val;
+        cache = other.cache;
+    }
+
+    return *this;
+}
+
+const QVector<double> &MolLambdaCache::morph(const LambdaSchedule &schedule,
+                                             const QString &key,
+                                             const QVector<double> &initial,
+                                             const QVector<double> &final) const
+{
+    auto nonconst_this = const_cast<MolLambdaCache *>(this);
+
+    QReadLocker lkr(&(nonconst_this->lock));
+
+    auto it = cache.constFind(key);
+
+    if (it != cache.constEnd())
+        return it.value();
+
+    lkr.unlock();
+
+    QWriteLocker wkr(&(nonconst_this->lock));
+
+    // check that someone didn't beat us to create the values
+    it = cache.constFind(key);
+
+    if (it != cache.constEnd())
+        return it.value();
+
+    // create the values
+    nonconst_this->cache.insert(key, schedule.morph(key, initial, final, lam_val));
+
+    return cache.constFind(key).value();
+}
+
+//////
+////// Implementation of LeverCache
+//////
+
+LeverCache::LeverCache()
+{
+}
+
+LeverCache::LeverCache(const LeverCache &other) : cache(other.cache)
+{
+}
+
+LeverCache::~LeverCache()
+{
+}
+
+LeverCache &LeverCache::operator=(const LeverCache &other)
+{
+    if (this != &other)
+    {
+        cache = other.cache;
+    }
+
+    return *this;
+}
+
+const MolLambdaCache &LeverCache::get(int molidx, double lam_val) const
+{
+    auto nonconst_this = const_cast<LeverCache *>(this);
+
+    if (not this->cache.contains(molidx))
+    {
+        nonconst_this->cache.insert(molidx, QHash<double, MolLambdaCache>());
+    }
+
+    auto &mol_cache = nonconst_this->cache.find(molidx).value();
+
+    auto it = mol_cache.constFind(lam_val);
+
+    if (it == mol_cache.constEnd())
+    {
+        // need to create a new cache for this lambda value
+        it = mol_cache.insert(lam_val, MolLambdaCache(lam_val));
+    }
+
+    return it.value();
+}
+
+void LeverCache::clear()
+{
+    cache.clear();
+}
+
+//////
+////// Implementation of LambdaLever
+//////
+
 LambdaLever::LambdaLever() : SireBase::ConcreteProperty<LambdaLever, SireBase::Property>()
 {
 }
@@ -46,7 +165,8 @@ LambdaLever::LambdaLever(const LambdaLever &other)
       lambda_schedule(other.lambda_schedule),
       perturbable_mols(other.perturbable_mols),
       start_indicies(other.start_indicies),
-      perturbable_maps(other.perturbable_maps)
+      perturbable_maps(other.perturbable_maps),
+      lambda_cache(other.lambda_cache)
 {
 }
 
@@ -64,6 +184,7 @@ LambdaLever &LambdaLever::operator=(const LambdaLever &other)
         perturbable_mols = other.perturbable_mols;
         start_indicies = other.start_indicies;
         perturbable_maps = other.perturbable_maps;
+        lambda_cache = other.lambda_cache;
         Property::operator=(other);
     }
 
@@ -108,6 +229,7 @@ bool LambdaLever::hasLever(const QString &lever_name)
 void LambdaLever::addLever(const QString &lever_name)
 {
     this->lambda_schedule.addLever(lever_name);
+    this->lambda_cache.clear();
 }
 
 /** Get the index of the force called 'name'. Returns -1 if
@@ -259,78 +381,80 @@ double LambdaLever::setLambda(OpenMM::Context &context,
         const auto &perturbable_mol = this->perturbable_mols[i];
         const auto &start_idxs = this->start_indicies[i];
 
+        const auto &cache = this->lambda_cache.get(i, lambda_value);
+
         // calculate the new parameters for this lambda value
-        const auto morphed_charges = this->lambda_schedule.morph(
+        const auto morphed_charges = cache.morph(
+            this->lambda_schedule,
             "charge",
             perturbable_mol.getCharges0(),
-            perturbable_mol.getCharges1(),
-            lambda_value);
+            perturbable_mol.getCharges1());
 
-        const auto morphed_sigmas = this->lambda_schedule.morph(
+        const auto morphed_sigmas = cache.morph(
+            this->lambda_schedule,
             "sigma",
             perturbable_mol.getSigmas0(),
-            perturbable_mol.getSigmas1(),
-            lambda_value);
+            perturbable_mol.getSigmas1());
 
-        const auto morphed_epsilons = this->lambda_schedule.morph(
+        const auto morphed_epsilons = cache.morph(
+            this->lambda_schedule,
             "epsilon",
             perturbable_mol.getEpsilons0(),
-            perturbable_mol.getEpsilons1(),
-            lambda_value);
+            perturbable_mol.getEpsilons1());
 
-        const auto morphed_alphas = this->lambda_schedule.morph(
+        const auto morphed_alphas = cache.morph(
+            this->lambda_schedule,
             "alpha",
             perturbable_mol.getAlphas0(),
-            perturbable_mol.getAlphas1(),
-            lambda_value);
+            perturbable_mol.getAlphas1());
 
-        const auto morphed_bond_k = this->lambda_schedule.morph(
+        const auto morphed_bond_k = cache.morph(
+            this->lambda_schedule,
             "bond_k",
             perturbable_mol.getBondKs0(),
-            perturbable_mol.getBondKs1(),
-            lambda_value);
+            perturbable_mol.getBondKs1());
 
-        const auto morphed_bond_length = this->lambda_schedule.morph(
+        const auto morphed_bond_length = cache.morph(
+            this->lambda_schedule,
             "bond_length",
             perturbable_mol.getBondLengths0(),
-            perturbable_mol.getBondLengths1(),
-            lambda_value);
+            perturbable_mol.getBondLengths1());
 
-        const auto morphed_angle_k = this->lambda_schedule.morph(
+        const auto morphed_angle_k = cache.morph(
+            this->lambda_schedule,
             "angle_k",
             perturbable_mol.getAngleKs0(),
-            perturbable_mol.getAngleKs1(),
-            lambda_value);
+            perturbable_mol.getAngleKs1());
 
-        const auto morphed_angle_size = this->lambda_schedule.morph(
+        const auto morphed_angle_size = cache.morph(
+            this->lambda_schedule,
             "angle_size",
             perturbable_mol.getAngleSizes0(),
-            perturbable_mol.getAngleSizes1(),
-            lambda_value);
+            perturbable_mol.getAngleSizes1());
 
-        const auto morphed_torsion_phase = this->lambda_schedule.morph(
+        const auto morphed_torsion_phase = cache.morph(
+            this->lambda_schedule,
             "torsion_phase",
             perturbable_mol.getTorsionPhases0(),
-            perturbable_mol.getTorsionPhases1(),
-            lambda_value);
+            perturbable_mol.getTorsionPhases1());
 
-        const auto morphed_torsion_k = this->lambda_schedule.morph(
+        const auto morphed_torsion_k = cache.morph(
+            this->lambda_schedule,
             "torsion_k",
             perturbable_mol.getTorsionKs0(),
-            perturbable_mol.getTorsionKs1(),
-            lambda_value);
+            perturbable_mol.getTorsionKs1());
 
-        const auto morphed_charge_scale = this->lambda_schedule.morph(
+        const auto morphed_charge_scale = cache.morph(
+            this->lambda_schedule,
             "charge_scale",
             perturbable_mol.getChargeScales0(),
-            perturbable_mol.getChargeScales1(),
-            lambda_value);
+            perturbable_mol.getChargeScales1());
 
-        const auto morphed_lj_scale = this->lambda_schedule.morph(
+        const auto morphed_lj_scale = cache.morph(
+            this->lambda_schedule,
             "lj_scale",
             perturbable_mol.getLJScales0(),
-            perturbable_mol.getLJScales1(),
-            lambda_value);
+            perturbable_mol.getLJScales1());
 
         // now update the forcefields
         int start_index = start_idxs.value("clj", -1);
@@ -767,6 +891,7 @@ int LambdaLever::addPerturbableMolecule(const OpenMMMolecule &molecule,
     this->perturbable_mols.append(PerturbableOpenMMMolecule(molecule));
     this->start_indicies.append(starts);
     this->perturbable_maps.insert(molecule.number, molecule.perturtable_map);
+    this->lambda_cache.clear();
     return this->perturbable_mols.count() - 1;
 }
 
@@ -805,4 +930,6 @@ void LambdaLever::setSchedule(const LambdaSchedule &sched)
     {
         lambda_schedule.addLever(lever);
     }
+
+    this->lambda_cache.clear();
 }

--- a/wrapper/Convert/SireOpenMM/lambdalever.cpp
+++ b/wrapper/Convert/SireOpenMM/lambdalever.cpp
@@ -375,6 +375,10 @@ double LambdaLever::setLambda(OpenMM::Context &context,
 
     std::vector<double> custom_params = {0.0, 0.0, 0.0, 0.0};
 
+    // record the range of indicies of the atoms which change
+    int start_change_atom = -1;
+    int end_change_atom = -1;
+
     // change the parameters for all of the perturbable molecules
     for (int i = 0; i < this->perturbable_mols.count(); ++i)
     {
@@ -462,6 +466,16 @@ double LambdaLever::setLambda(OpenMM::Context &context,
         if (start_index != -1 and cljff != 0)
         {
             const int nparams = morphed_charges.count();
+
+            if (start_change_atom == -1)
+            {
+                start_change_atom = start_index;
+                end_change_atom = start_index + nparams;
+            }
+            else if (start_index >= end_change_atom)
+            {
+                end_change_atom = start_index + nparams;
+            }
 
             if (have_ghost_atoms)
             {
@@ -656,9 +670,11 @@ double LambdaLever::setLambda(OpenMM::Context &context,
         cljff->updateParametersInContext(context);
 
     if (ghost_ghostff)
+        // ghost_ghostff->updateSomeParametersInContext(start_change_atom, end_change_atom - start_change_atom, context);
         ghost_ghostff->updateParametersInContext(context);
 
     if (ghost_nonghostff)
+        // ghost_nonghostff->updateSomeParametersInContext(start_change_atom, end_change_atom - start_change_atom, context);
         ghost_nonghostff->updateParametersInContext(context);
 
     if (ghost_14ff)

--- a/wrapper/Convert/SireOpenMM/lambdalever.h
+++ b/wrapper/Convert/SireOpenMM/lambdalever.h
@@ -33,10 +33,52 @@
 
 #include "SireCAS/lambdaschedule.h"
 
+#include <QReadWriteLock>
+
+#include <memory>
+
 SIRE_BEGIN_HEADER
 
 namespace SireOpenMM
 {
+    class MolLambdaCache
+    {
+    public:
+        MolLambdaCache();
+        MolLambdaCache(double lam_val);
+        MolLambdaCache(const MolLambdaCache &other);
+        ~MolLambdaCache();
+
+        MolLambdaCache &operator=(const MolLambdaCache &other);
+
+        const QVector<double> &morph(const SireCAS::LambdaSchedule &schedule,
+                                     const QString &key,
+                                     const QVector<double> &initial,
+                                     const QVector<double> &final) const;
+
+    private:
+        QHash<QString, QVector<double>> cache;
+        QReadWriteLock lock;
+        double lam_val;
+    };
+
+    class LeverCache
+    {
+    public:
+        LeverCache();
+        LeverCache(const LeverCache &other);
+        ~LeverCache();
+
+        LeverCache &operator=(const LeverCache &other);
+
+        const MolLambdaCache &get(int molidx, double lam_val) const;
+
+        void clear();
+
+    private:
+        QHash<int, QHash<double, MolLambdaCache>> cache;
+    };
+
     /** This is a lever that is used to change the parameters in an OpenMM
      *  context according to a lambda value. This is actually a collection
      *  of levers, each of which is controlled by the main lever.
@@ -117,6 +159,9 @@ namespace SireOpenMM
 
         /** All of the property maps for the perturbable molecules */
         QHash<SireMol::MolNum, SireBase::PropertyMap> perturbable_maps;
+
+        /** Cache of the parameters for different lambda values */
+        LeverCache lambda_cache;
     };
 
 #ifndef SIRE_SKIP_INLINE_FUNCTION

--- a/wrapper/Convert/SireOpenMM/openmmmolecule.cpp
+++ b/wrapper/Convert/SireOpenMM/openmmmolecule.cpp
@@ -500,11 +500,17 @@ void OpenMMMolecule::constructFromAmber(const Molecule &mol,
         double sig = lj.sigma().to(SireUnits::nanometer);
         double eps = lj.epsilon().to(SireUnits::kJ_per_mol);
 
-        if (std::abs(sig) < 1e-9)
+        if (sig == 0)
         {
             // this must be a null parameter
+            // Using eps=0 sig=1 causes instability though (NaN errors)
+            // so we will set sig=1e-9. This seems to be more stable
             eps = 0;
-            sig = 1;
+            sig = 1e-9;
+        }
+        else if (std::abs(sig) < 1e-9)
+        {
+            sig = 1e-9;
         }
 
         cljs_data[i] = std::make_tuple(chg, sig, eps);

--- a/wrapper/Error/wrap_exceptions.cpp
+++ b/wrapper/Error/wrap_exceptions.cpp
@@ -152,15 +152,31 @@ namespace SireError
     void exception_translator(const SireError::exception &ex)
     {
         boost::python::release_gil_policy::acquire_gil_no_raii();
-        PyErr_SetString(PyExc_UserWarning,
+        PyErr_SetString(PyExc_RuntimeError,
                         get_exception_string(ex).toUtf8());
+    }
+
+    void bad_alloc_exception_translator(const std::bad_alloc &ex)
+    {
+        boost::python::release_gil_policy::acquire_gil_no_raii();
+        PyErr_SetString(PyExc_MemoryError,
+                        QString("%1").arg(ex.what()).toUtf8());
     }
 
     void std_exception_translator(const std::exception &ex)
     {
         boost::python::release_gil_policy::acquire_gil_no_raii();
-        PyErr_SetString(PyExc_UserWarning,
-                        QString("%1").arg(ex.what()).toUtf8());
+
+        if (dynamic_cast<const std::bad_alloc *>(&ex) != 0)
+        {
+            PyErr_SetString(PyExc_MemoryError,
+                            "Memory error - out of memory?");
+        }
+        else
+        {
+            PyErr_SetString(PyExc_RuntimeError,
+                            QString("%1").arg(ex.what()).toUtf8());
+        }
     }
 
     SireError::FastExceptionFlag *fast_exception_flag(0);


### PR DESCRIPTION
Changes proposed in this pull request:

Optimisations to the lambda lever to cache the results of calculating lambda parameters. This significantly speeds up the free energy simulations. Also includes the sire-specific changes that relate to the optimisation work going on in our temporary [fork of OpenMM](https://github.com/chryswoods/openmm). The cmake test will only activate this if a custom version of OpenMM is detected. I am leaving it in as it will make the optimisation work easier.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [n/a]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [n/a]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@lohedges

## Any additional context of information?

There's no docs or tests as this is an optimisation, so is covered by existing docs and tests.