### PR TITLE
Specify python<3.12 in requirements files

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -15,7 +15,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 `2024.1.0 <https://github.com/openbiosim/sire/compare/2023.5.0...2024.1.0>`__ - March 2024
 ------------------------------------------------------------------------------------------
 
-* Please add an item to this changelog when you create your PR
+* Specified python < 3.12 in the requirements files.
 
 `2023.5.1 <https://github.com/openbiosim/sire/compare/2023.5.0...2023.5.1>`__ - January 2024
 --------------------------------------------------------------------------------------------

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -2,7 +2,7 @@
 
 cmake
 git
-python
+python <3.12
 
 make ; sys_platform == "darwin"
 libtool ; sys_platform == "darwin"

--- a/requirements_host.txt
+++ b/requirements_host.txt
@@ -7,7 +7,7 @@ libcblas
 libnetcdf
 openmm
 pandas
-python
+python<3.12
 qt-main
 rich
 tbb


### PR DESCRIPTION
This pull request fixes issue #147 by specifying python<3.12 in the requirements files. I've checked that I can now compile following the instructions in the README.

Sorry, I forgot to specify "ci skip" in my last commit.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): y
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): y
* I confirm that I have permission to release this code under the GPL3 license: y

## Suggested reviewers:
@chryswoods, @lohedges
