### PR TITLE
Preserve existing atom names when writing to PDB

### DIFF
--- a/corelib/src/libs/SireIO/pdb2.cpp
+++ b/corelib/src/libs/SireIO/pdb2.cpp
@@ -312,7 +312,7 @@ PDBAtom::PDBAtom(const QString &line, QStringList &errors)
         An array of error messages.
  */
 PDBAtom::PDBAtom(const SireMol::Atom &atom, bool is_ter, const PropertyMap &map, QStringList &errors)
-    : name(atom.name().value().toUpper()), occupancy(1.0), temperature(0.0), element("X"), charge(0), is_het(false),
+    : name(atom.name().value()), occupancy(1.0), temperature(0.0), element("X"), charge(0), is_het(false),
       is_ter(is_ter)
 {
     setSerial(atom.number().value());

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -32,6 +32,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Fixed bug in :class`sire.legacy.Mol.ResIdxAtomCoordMatcher` by ensuring
   that we only compare residues with the same number of atoms.
 
+* Preserve user atom names when writing to PDB format.
+
 * Please add an item to this changelog when you create your PR
 
 `2023.5.1 <https://github.com/openbiosim/sire/compare/2023.5.0...2023.5.1>`__ - January 2024


### PR DESCRIPTION
This PR ensures that existing atom names are preserved when writing to PDB format. Previously they were always converted to upper case, which caused issues with the parameterisation of free ions where the PDB atom name is used by `LEaP` to match a template.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods