### PR TITLE
Fix issue #179

### DIFF
--- a/src/sire/morph/_pertfile.py
+++ b/src/sire/morph/_pertfile.py
@@ -86,7 +86,6 @@ def create_from_pertfile(mol, pertfile, map=None):
             typ0 = template.get_init_type(atomname)
             typ1 = template.get_final_type(atomname)
         except Exception as e:
-            print(e)
             continue
 
         atom["charge0"] = q0

--- a/src/sire/morph/_pertfile.py
+++ b/src/sire/morph/_pertfile.py
@@ -87,7 +87,7 @@ def create_from_pertfile(mol, pertfile, map=None):
             typ1 = template.get_final_type(atomname)
         except Exception as e:
             print(e)
-            next
+            continue
 
         atom["charge0"] = q0
         atom["charge1"] = q1


### PR DESCRIPTION
This PR closes #179 by using `continue` to skip atoms that aren't in the perturbation template, i.e. those atoms which don't change their `charge`, `LJ`, or `ambertype` properties between the reference and perturbed state.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods