### PR TITLE
Fix issue #186

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -16,6 +16,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 -----------------------------------------------------------------------------------------
 
 * Please add an item to this changelog when you create your PR
+* Correctly set the ``element1`` property in ``sire.morph.create_from_pertfile``.
 
 `2024.1.0 <https://github.com/openbiosim/sire/compare/2023.5.2...2024.1.0>`__ - April 2024
 ------------------------------------------------------------------------------------------

--- a/src/sire/morph/_pertfile.py
+++ b/src/sire/morph/_pertfile.py
@@ -26,6 +26,7 @@ def create_from_pertfile(mol, pertfile, map=None):
     from ..legacy.IO import PerturbationsLibrary
 
     from ..base import create_map
+    from ..mol import Element
 
     map = create_map(map)
 
@@ -65,6 +66,7 @@ def create_from_pertfile(mol, pertfile, map=None):
     chg_prop = map["charge"].source()
     lj_prop = map["LJ"].source()
     typ_prop = map["ambertype"].source()
+    elem_prop = map["element"].source()
 
     c["charge0"] = c[chg_prop]
     c["charge1"] = c[chg_prop]
@@ -75,8 +77,12 @@ def create_from_pertfile(mol, pertfile, map=None):
     c["ambertype0"] = c[typ_prop]
     c["ambertype1"] = c[typ_prop]
 
+    c["element0"] = c[elem_prop]
+
     for atom in c.atoms():
         atomname = atom.name
+
+        atom["element1"] = atom["element"]
 
         try:
             q0 = template.get_init_charge(atomname)
@@ -96,6 +102,8 @@ def create_from_pertfile(mol, pertfile, map=None):
 
         atom["ambertype0"] = typ0
         atom["ambertype1"] = typ1
+
+        atom["element1"] = Element.biological_element(typ1)
 
     # now update all of the internals
     bond_prop = map["bond"].source()
@@ -251,8 +259,8 @@ def create_from_pertfile(mol, pertfile, map=None):
     c["improper0"] = impropers0
     c["improper1"] = impropers1
 
-    # duplicate the coordinates, mass, and element properties
-    for prop in ["coordinates", "mass", "element", "forcefield", "intrascale"]:
+    # duplicate unperturbed properties
+    for prop in ["coordinates", "mass", "forcefield", "intrascale"]:
         orig_prop = map[prop].source()
         c[prop + "0"] = c[orig_prop]
         c[prop + "1"] = c[orig_prop]
@@ -262,6 +270,7 @@ def create_from_pertfile(mol, pertfile, map=None):
     del c[chg_prop]
     del c[lj_prop]
     del c[typ_prop]
+    del c[elem_prop]
     del c[bond_prop]
     del c[ang_prop]
     del c[dih_prop]

--- a/src/sire/morph/_pertfile.py
+++ b/src/sire/morph/_pertfile.py
@@ -78,11 +78,10 @@ def create_from_pertfile(mol, pertfile, map=None):
     c["ambertype1"] = c[typ_prop]
 
     c["element0"] = c[elem_prop]
+    c["element1"] = c[elem_prop]
 
     for atom in c.atoms():
         atomname = atom.name
-
-        atom["element1"] = atom["element"]
 
         try:
             q0 = template.get_init_charge(atomname)

--- a/tests/morph/test_pert.py
+++ b/tests/morph/test_pert.py
@@ -320,3 +320,21 @@ def test_extract_and_link_solv(solvated_neopentane_methane, openmm_platform):
     nrg_pert = pert_mols.dynamics(map=map).current_potential_energy().value()
 
     assert nrg_1_1 == pytest.approx(nrg_pert, 1e-3)
+
+
+def test_ambertype_to_element(neopentane_methane):
+    from sire.mol import Element
+
+    mols = neopentane_methane.clone()
+
+    mols = sr.morph.link_to_reference(mols)
+
+    mols2 = sr.morph.extract_reference(mols)
+
+    mol = sr.morph.create_from_pertfile(mols2[0], neopentane_methane_pert)
+
+    element1 = mol.property("element1")
+    ambertype1 = mol.property("ambertype1")
+
+    for a, e in zip(ambertype1, element1):
+        assert e == Element.biological_element(a)


### PR DESCRIPTION
This PR fixes #186 by updating `sire.morph.create_from_pertfile` so that the `element1` property of the perturbable molecule is correct. Here, the property is inferred from the `ambertype1` property using `Element.biological_element`. I've added a test to make sure that the property is set correctly.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods