### PR TITLE
Fix issue #189

### DIFF
--- a/corelib/src/libs/SireVol/triclinicbox.cpp
+++ b/corelib/src/libs/SireVol/triclinicbox.cpp
@@ -565,6 +565,21 @@ Matrix TriclinicBox::boxMatrix() const
     return this->cellMatrix();
 }
 
+SireUnits::Dimension::Length TriclinicBox::maximumCutoff() const
+{
+    // If the box is reduced, then use the minumum diagonal element.
+    if (this->isReduced())
+    {
+        QList<double> diagonals = {this->v0.x(), this->v1.y(), this->v2.z()};
+        return SireUnits::Dimension::Length(*std::min_element(diagonals.begin(), diagonals.end())/2.0);
+    }
+    // Otherwise, use half the norm of the smallest box vector.
+    else
+    {
+        return SireUnits::Dimension::Length(this->dist_max);
+    }
+}
+
 /** Return the volume of the central box of this space. */
 SireUnits::Dimension::Volume TriclinicBox::volume() const
 {

--- a/corelib/src/libs/SireVol/triclinicbox.cpp
+++ b/corelib/src/libs/SireVol/triclinicbox.cpp
@@ -567,7 +567,7 @@ Matrix TriclinicBox::boxMatrix() const
 
 SireUnits::Dimension::Length TriclinicBox::maximumCutoff() const
 {
-    // If the box is reduced, then use the minumum diagonal element.
+    // If the box is reduced, then use half the minimum diagonal element.
     if (this->isReduced())
     {
         QList<double> diagonals = {this->v0.x(), this->v1.y(), this->v2.z()};

--- a/corelib/src/libs/SireVol/triclinicbox.h
+++ b/corelib/src/libs/SireVol/triclinicbox.h
@@ -153,6 +153,9 @@ namespace SireVol
 
         QString toString() const;
 
+        /** Get the maximum cutoff distance for the triclinic box. */
+        SireUnits::Dimension::Length maximumCutoff() const;
+
         /** Get the volume of the triclinic box. */
         SireUnits::Dimension::Volume volume() const;
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -17,6 +17,9 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 
 * Please add an item to this changelog when you create your PR
 * Correctly set the ``element1`` property in ``sire.morph.create_from_pertfile``.
+* Added mising :meth:`~sire.vol.TriclinicBox.maximum_cutoff` method so that
+  the cutoff is set correctly when creating a :obj:`~sire.system.ForceFieldInfo`
+  object.
 
 `2024.1.0 <https://github.com/openbiosim/sire/compare/2023.5.2...2024.1.0>`__ - April 2024
 ------------------------------------------------------------------------------------------

--- a/tests/vol/test_triclinic.py
+++ b/tests/vol/test_triclinic.py
@@ -141,3 +141,34 @@ def test_stream():
 
     # Make sure the boxes are the same.
     assert recovered_box == box
+
+
+def test_max_cutoff(ala_mols):
+    """
+    Test that the maximum cutoff is set correctly.
+    """
+
+    # Create a local
+    mols = ala_mols.clone()
+
+    # Create a cubic triclinic space.
+
+    # Set the vectors.
+    v0 = sr.maths.Vector(50, 0, 0)
+    v1 = sr.maths.Vector(0, 50, 0)
+    v2 = sr.maths.Vector(0, 0, 50)
+
+    # Create the space.
+    space = sr.vol.TriclinicBox(v0, v1, v2)
+
+    # Check the maximum cutoff.
+    assert space.maximum_cutoff() == 25 * sr.units.angstroms
+
+    # Now set the space property on the molecules.
+    mols.set_property("space", space)
+
+    # Create a ForceFieldInfo object.
+    ffinfo = sr.system.ForceFieldInfo(mols)
+
+    # Check the cutoff. This is the maximum cutoff minus 1 angstrom.
+    assert ffinfo.cutoff() == 24 * sr.units.angstroms

--- a/tests/vol/test_triclinic.py
+++ b/tests/vol/test_triclinic.py
@@ -148,7 +148,7 @@ def test_max_cutoff(ala_mols):
     Test that the maximum cutoff is set correctly.
     """
 
-    # Create a local
+    # Create a local copy of the molecules.
     mols = ala_mols.clone()
 
     # Create a cubic triclinic space.


### PR DESCRIPTION
This PR closes #189 by adding the missing `TriclinicBox::maximumCutoff` method. This uses the approach from OpenMM, i.e. we use the theoretical maximum of half the norm of the smallest vector when the box _isn't_ in reduced form, but limit it to the minimum diagonal element of the box vector matrix for efficiency when it _is_ in reduced form. (See the discussion [here](https://github.com/openmm/openmm/issues/1831) and the linked PR [here](https://github.com/choderalab/yank/pull/698).)

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods