### PR TITLE
Fix issue #194

### DIFF
--- a/corelib/src/libs/SireIO/grotop.cpp
+++ b/corelib/src/libs/SireIO/grotop.cpp
@@ -5399,6 +5399,12 @@ QVector<QString> GroTop::preprocess(const QVector<QString> &lines, QHash<QString
             }
         }
 
+        // skip BioSimSpace position restraint includes
+        if (line.contains("#include \"posre"))
+        {
+            continue;
+        }
+
         // now look for #include lines
         if (line.startsWith("#include"))
         {

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -42,6 +42,9 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
   standard trajectory save functions, e.g.
   ``sire.save(mols.trajectory(), "output", format=["PRMTOP", "RST"])``.
 
+* Ignore BioSimSpace format position restraint include directives when
+  parsing GROMACS topology files.
+
 * Please add an item to this changelog when you create your PR
 
 `2024.1.0 <https://github.com/openbiosim/sire/compare/2023.5.2...2024.1.0>`__ - April 2024

--- a/tests/io/test_grotop.py
+++ b/tests/io/test_grotop.py
@@ -33,3 +33,9 @@ def test_grospace(tmpdir, kigaki_mols):
     mols = sr.load(f, show_warnings=False)
 
     assert energy.value() == pytest.approx(mols.energy().value())
+
+
+def test_posre():
+    # Make sure we can parse a file with BioSimSpace position restraint include
+    # directives.
+    mols = sr.load_test_files("posre.top")


### PR DESCRIPTION
This PR closes #194 by skipping BioSimSpace position restraint include directives when parsing GROMACS topology files. I'm not sure if there is a more general way of fixing this issue, but this will work for the purposes of being able to read GROMACS files that were written as input to a `BioSimSpac.Process.Gromacs` simulation using position restraints. Here the restraints will be ignored, but they would be re-written if the user wanted to run the same protocol. In this instance, they just want to be able to read the system back in, i.e. the topology. 

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods