### PR TITLE
Add map option to prevent peturbation of the LJ sigma value for ghost atoms

### DIFF
--- a/corelib/src/libs/SireIO/grotop.cpp
+++ b/corelib/src/libs/SireIO/grotop.cpp
@@ -5399,6 +5399,12 @@ QVector<QString> GroTop::preprocess(const QVector<QString> &lines, QHash<QString
             }
         }
 
+        // skip BioSimSpace position restraint includes
+        if (line.contains("#include \"posre"))
+        {
+            continue;
+        }
+
         // now look for #include lines
         if (line.startsWith("#include"))
         {

--- a/corelib/src/libs/SireMM/ljparameter.h
+++ b/corelib/src/libs/SireMM/ljparameter.h
@@ -141,12 +141,14 @@ namespace SireMM
         return not operator==(other);
     }
 
-    /** Return whether or not this is a dummy LJ parameter */
+    /** Return whether or not this is a dummy LJ parameter. A dummy LJ
+     *  parameter is one with a zero epsilon value (i.e. it will have a
+     *  a zero LJ interaction energy with all other particles, regardless
+     *  of their LJ parameters)
+     */
     SIRE_ALWAYS_INLINE bool LJParameter::isDummy() const
     {
-        // we only need to compare sqrtsig as this will be set to zero if
-        // sqrteps is zero
-        return sqrtsig == 0.0;
+        return sqrteps == 0.0;
     }
 
     /** Return whether or not this parameter has non-zero LJ parameters */

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -45,6 +45,9 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Ignore BioSimSpace format position restraint include directives when
   parsing GROMACS topology files.
 
+* Add a map option to prevent perturbation of the Lennard-Jones sigma
+  parameter for ghost atoms during alchemical free energy simulations.
+
 * Please add an item to this changelog when you create your PR
 
 `2024.1.0 <https://github.com/openbiosim/sire/compare/2023.5.2...2024.1.0>`__ - April 2024

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -42,6 +42,9 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
   standard trajectory save functions, e.g.
   ``sire.save(mols.trajectory(), "output", format=["PRMTOP", "RST"])``.
 
+* Ignore BioSimSpace format position restraint include directives when
+  parsing GROMACS topology files.
+
 * Please add an item to this changelog when you create your PR
 
 `2024.1.0 <https://github.com/openbiosim/sire/compare/2023.5.2...2024.1.0>`__ - April 2024

--- a/tests/io/test_grotop.py
+++ b/tests/io/test_grotop.py
@@ -33,3 +33,9 @@ def test_grospace(tmpdir, kigaki_mols):
     mols = sr.load(f, show_warnings=False)
 
     assert energy.value() == pytest.approx(mols.energy().value())
+
+
+def test_posre():
+    # Make sure we can parse a file with BioSimSpace position restraint include
+    # directives.
+    mols = sr.load_test_files("posre.top")

--- a/wrapper/Convert/SireOpenMM/LambdaLever.pypp.cpp
+++ b/wrapper/Convert/SireOpenMM/LambdaLever.pypp.cpp
@@ -29,6 +29,8 @@ namespace bp = boost::python;
 
 SireOpenMM::LambdaLever __copy__(const SireOpenMM::LambdaLever &other){ return SireOpenMM::LambdaLever(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -55,14 +57,13 @@ void register_LambdaLever_class(){
         }
         { //::SireOpenMM::LambdaLever::addPerturbableMolecule
         
-            typedef int ( ::SireOpenMM::LambdaLever::*addPerturbableMolecule_function_type)( ::SireOpenMM::OpenMMMolecule const &,::QHash< QString, int > const & ) ;
+            typedef int ( ::SireOpenMM::LambdaLever::*addPerturbableMolecule_function_type)( ::SireOpenMM::OpenMMMolecule const &,::QHash< QString, int > const &,::SireBase::PropertyMap const & ) ;
             addPerturbableMolecule_function_type addPerturbableMolecule_function_value( &::SireOpenMM::LambdaLever::addPerturbableMolecule );
             
             LambdaLever_exposer.def( 
                 "addPerturbableMolecule"
                 , addPerturbableMolecule_function_value
-                , ( bp::arg("molecule"), bp::arg("start_indicies") )
-                , bp::release_gil_policy()
+                , ( bp::arg("molecule"), bp::arg("start_indicies"), bp::arg("map")=SireBase::PropertyMap() )
                 , "Add info for the passed perturbable OpenMMMolecule, returning\n  its index in the list of perturbable molecules\n" );
         
         }
@@ -115,7 +116,7 @@ void register_LambdaLever_class(){
                 , getLeverValues_function_value
                 , ( bp::arg("lambda_values"), bp::arg("mol") )
                 , bp::release_gil_policy()
-                , "" );
+                , "Get all of the lever values that would be set for the passed\n  lambda values using the current context. This returns a PropertyList\n  of columns, where each column is a PropertyMap with the column name\n  and either double or QString array property of values.\n\n  This is designed to be used by a higher-level python function that\n  will convert this output into, e.g. a pandas DataFrame\n" );
         
         }
         { //::SireOpenMM::LambdaLever::getPerturbableMoleculeMaps
@@ -272,9 +273,9 @@ void register_LambdaLever_class(){
         
         }
         LambdaLever_exposer.staticmethod( "typeName" );
-        LambdaLever_exposer.def( "__copy__", &__copy__);
-        LambdaLever_exposer.def( "__deepcopy__", &__copy__);
-        LambdaLever_exposer.def( "clone", &__copy__);
+        LambdaLever_exposer.def( "__copy__", &__copy__<SireOpenMM::LambdaLever>);
+        LambdaLever_exposer.def( "__deepcopy__", &__copy__<SireOpenMM::LambdaLever>);
+        LambdaLever_exposer.def( "clone", &__copy__<SireOpenMM::LambdaLever>);
         LambdaLever_exposer.def( "__str__", &__str__< ::SireOpenMM::LambdaLever > );
         LambdaLever_exposer.def( "__repr__", &__str__< ::SireOpenMM::LambdaLever > );
     }

--- a/wrapper/Convert/SireOpenMM/OpenMMMetaData.pypp.cpp
+++ b/wrapper/Convert/SireOpenMM/OpenMMMetaData.pypp.cpp
@@ -129,6 +129,8 @@ namespace bp = boost::python;
 
 SireOpenMM::OpenMMMetaData __copy__(const SireOpenMM::OpenMMMetaData &other){ return SireOpenMM::OpenMMMetaData(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -273,9 +275,9 @@ void register_OpenMMMetaData_class(){
         
         }
         OpenMMMetaData_exposer.staticmethod( "typeName" );
-        OpenMMMetaData_exposer.def( "__copy__", &__copy__);
-        OpenMMMetaData_exposer.def( "__deepcopy__", &__copy__);
-        OpenMMMetaData_exposer.def( "clone", &__copy__);
+        OpenMMMetaData_exposer.def( "__copy__", &__copy__<SireOpenMM::OpenMMMetaData>);
+        OpenMMMetaData_exposer.def( "__deepcopy__", &__copy__<SireOpenMM::OpenMMMetaData>);
+        OpenMMMetaData_exposer.def( "clone", &__copy__<SireOpenMM::OpenMMMetaData>);
         OpenMMMetaData_exposer.def( "__str__", &__str__< ::SireOpenMM::OpenMMMetaData > );
         OpenMMMetaData_exposer.def( "__repr__", &__str__< ::SireOpenMM::OpenMMMetaData > );
     }

--- a/wrapper/Convert/SireOpenMM/PerturbableOpenMMMolecule.pypp.cpp
+++ b/wrapper/Convert/SireOpenMM/PerturbableOpenMMMolecule.pypp.cpp
@@ -113,6 +113,8 @@ namespace bp = boost::python;
 
 SireOpenMM::PerturbableOpenMMMolecule __copy__(const SireOpenMM::PerturbableOpenMMMolecule &other){ return SireOpenMM::PerturbableOpenMMMolecule(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -123,8 +125,8 @@ void register_PerturbableOpenMMMolecule_class(){
         typedef bp::class_< SireOpenMM::PerturbableOpenMMMolecule > PerturbableOpenMMMolecule_exposer_t;
         PerturbableOpenMMMolecule_exposer_t PerturbableOpenMMMolecule_exposer = PerturbableOpenMMMolecule_exposer_t( "PerturbableOpenMMMolecule", "This class holds all of the information of an OpenMM molecule\nthat can be perturbed using a LambdaSchedule. The data is held\nin easy-to-access arrays, with guarantees that the arrays are\ncompatible and the data is aligned.\n", bp::init< >("Null constructor") );
         bp::scope PerturbableOpenMMMolecule_scope( PerturbableOpenMMMolecule_exposer );
-        PerturbableOpenMMMolecule_exposer.def( bp::init< SireOpenMM::OpenMMMolecule const & >(( bp::arg("mol") ), "Construct from the passed OpenMMMolecule") );
-        PerturbableOpenMMMolecule_exposer.def( bp::init< SireMol::Molecule const &, SireBase::PropertyMap const & >(( bp::arg("mol"), bp::arg("map") ), "Construct from a passed molecule and map") );
+        PerturbableOpenMMMolecule_exposer.def( bp::init< SireOpenMM::OpenMMMolecule const &, bp::optional< SireBase::PropertyMap const & > >(( bp::arg("mol"), bp::arg("map")=SireBase::PropertyMap() ), "Construct from the passed OpenMMMolecule") );
+        PerturbableOpenMMMolecule_exposer.def( bp::init< SireMol::Molecule const &, bp::optional< SireBase::PropertyMap const & > >(( bp::arg("mol"), bp::arg("map")=SireBase::PropertyMap() ), "Construct from a passed molecule and map") );
         PerturbableOpenMMMolecule_exposer.def( bp::init< SireOpenMM::PerturbableOpenMMMolecule const & >(( bp::arg("other") ), "Copy constructor") );
         { //::SireOpenMM::PerturbableOpenMMMolecule::angles
         
@@ -596,6 +598,18 @@ void register_PerturbableOpenMMMolecule_class(){
                 , "Return true if the atom is a ghost atom in the\n  referenece or perturbed states" );
         
         }
+        { //::SireOpenMM::PerturbableOpenMMMolecule::isNull
+        
+            typedef bool ( ::SireOpenMM::PerturbableOpenMMMolecule::*isNull_function_type)(  ) const;
+            isNull_function_type isNull_function_value( &::SireOpenMM::PerturbableOpenMMMolecule::isNull );
+            
+            PerturbableOpenMMMolecule_exposer.def( 
+                "isNull"
+                , isNull_function_value
+                , bp::release_gil_policy()
+                , "Return whether or not this is null" );
+        
+        }
         PerturbableOpenMMMolecule_exposer.def( bp::self != bp::self );
         { //::SireOpenMM::PerturbableOpenMMMolecule::operator=
         
@@ -686,9 +700,9 @@ void register_PerturbableOpenMMMolecule_class(){
         
         }
         PerturbableOpenMMMolecule_exposer.staticmethod( "typeName" );
-        PerturbableOpenMMMolecule_exposer.def( "__copy__", &__copy__);
-        PerturbableOpenMMMolecule_exposer.def( "__deepcopy__", &__copy__);
-        PerturbableOpenMMMolecule_exposer.def( "clone", &__copy__);
+        PerturbableOpenMMMolecule_exposer.def( "__copy__", &__copy__<SireOpenMM::PerturbableOpenMMMolecule>);
+        PerturbableOpenMMMolecule_exposer.def( "__deepcopy__", &__copy__<SireOpenMM::PerturbableOpenMMMolecule>);
+        PerturbableOpenMMMolecule_exposer.def( "clone", &__copy__<SireOpenMM::PerturbableOpenMMMolecule>);
         PerturbableOpenMMMolecule_exposer.def( "__str__", &__str__< ::SireOpenMM::PerturbableOpenMMMolecule > );
         PerturbableOpenMMMolecule_exposer.def( "__repr__", &__str__< ::SireOpenMM::PerturbableOpenMMMolecule > );
     }

--- a/wrapper/Convert/SireOpenMM/lambdalever.cpp
+++ b/wrapper/Convert/SireOpenMM/lambdalever.cpp
@@ -1964,10 +1964,11 @@ QList<OpenMM::Force *> LambdaLever::getRestraints(const QString &name,
  *  its index in the list of perturbable molecules
  */
 int LambdaLever::addPerturbableMolecule(const OpenMMMolecule &molecule,
-                                        const QHash<QString, qint32> &starts)
+                                        const QHash<QString, qint32> &starts,
+                                        const PropertyMap &map)
 {
     // should add in some sanity checks for these inputs
-    this->perturbable_mols.append(PerturbableOpenMMMolecule(molecule));
+    this->perturbable_mols.append(PerturbableOpenMMMolecule(molecule, map));
     this->start_indicies.append(starts);
     this->perturbable_maps.insert(molecule.number, molecule.perturtable_map);
     this->lambda_cache.clear();

--- a/wrapper/Convert/SireOpenMM/lambdalever.h
+++ b/wrapper/Convert/SireOpenMM/lambdalever.h
@@ -123,7 +123,8 @@ namespace SireOpenMM
         void addRestraintIndex(const QString &force, int index);
 
         int addPerturbableMolecule(const OpenMMMolecule &molecule,
-                                   const QHash<QString, qint32> &start_indicies);
+                                   const QHash<QString, qint32> &start_indicies,
+                                   const SireBase::PropertyMap &map = SireBase::PropertyMap());
 
         void setExceptionIndicies(int idx, const QString &ff,
                                   const QVector<boost::tuple<int, int>> &exception_idxs);

--- a/wrapper/Convert/SireOpenMM/openmmmolecule.h
+++ b/wrapper/Convert/SireOpenMM/openmmmolecule.h
@@ -204,10 +204,11 @@ namespace SireOpenMM
     public:
         PerturbableOpenMMMolecule();
 
-        PerturbableOpenMMMolecule(const OpenMMMolecule &mol);
+        PerturbableOpenMMMolecule(const OpenMMMolecule &mol,
+                                  const SireBase::PropertyMap &map = SireBase::PropertyMap());
 
         PerturbableOpenMMMolecule(const SireMol::Molecule &mol,
-                                  const SireBase::PropertyMap &map);
+                                  const SireBase::PropertyMap &map = SireBase::PropertyMap());
 
         PerturbableOpenMMMolecule(const PerturbableOpenMMMolecule &other);
 

--- a/wrapper/Convert/SireOpenMM/sire_to_openmm_system.cpp
+++ b/wrapper/Convert/SireOpenMM/sire_to_openmm_system.cpp
@@ -1144,7 +1144,8 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
             // of perturbable molecules (e.g. the first perturbable
             // molecule we find has index 0)
             auto pert_idx = lambda_lever.addPerturbableMolecule(mol,
-                                                                start_indicies);
+                                                                start_indicies,
+                                                                map);
 
             // and we can record the map from the molecule index
             // to the perturbable molecule index

--- a/wrapper/Convert/__init__.py
+++ b/wrapper/Convert/__init__.py
@@ -398,7 +398,7 @@ try:
                     platform = platforms["cpu"]
 
                 elif len(platforms) > 0:
-                    platform = platforms[platforms.keys()[0]]
+                    platform = platforms[list(platforms.keys())[0]]
 
             if platform is None:
                 raise ValueError(

--- a/wrapper/MM/AmberAngle.pypp.cpp
+++ b/wrapper/MM/AmberAngle.pypp.cpp
@@ -73,6 +73,8 @@ namespace bp = boost::python;
 
 SireMM::AmberAngle __copy__(const SireMM::AmberAngle &other){ return SireMM::AmberAngle(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -217,9 +219,9 @@ void register_AmberAngle_class(){
         
         }
         AmberAngle_exposer.staticmethod( "typeName" );
-        AmberAngle_exposer.def( "__copy__", &__copy__);
-        AmberAngle_exposer.def( "__deepcopy__", &__copy__);
-        AmberAngle_exposer.def( "clone", &__copy__);
+        AmberAngle_exposer.def( "__copy__", &__copy__<SireMM::AmberAngle>);
+        AmberAngle_exposer.def( "__deepcopy__", &__copy__<SireMM::AmberAngle>);
+        AmberAngle_exposer.def( "clone", &__copy__<SireMM::AmberAngle>);
         AmberAngle_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::AmberAngle >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         AmberAngle_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::AmberAngle >,

--- a/wrapper/MM/AmberBond.pypp.cpp
+++ b/wrapper/MM/AmberBond.pypp.cpp
@@ -73,6 +73,8 @@ namespace bp = boost::python;
 
 SireMM::AmberBond __copy__(const SireMM::AmberBond &other){ return SireMM::AmberBond(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -217,9 +219,9 @@ void register_AmberBond_class(){
         
         }
         AmberBond_exposer.staticmethod( "typeName" );
-        AmberBond_exposer.def( "__copy__", &__copy__);
-        AmberBond_exposer.def( "__deepcopy__", &__copy__);
-        AmberBond_exposer.def( "clone", &__copy__);
+        AmberBond_exposer.def( "__copy__", &__copy__<SireMM::AmberBond>);
+        AmberBond_exposer.def( "__deepcopy__", &__copy__<SireMM::AmberBond>);
+        AmberBond_exposer.def( "clone", &__copy__<SireMM::AmberBond>);
         AmberBond_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::AmberBond >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         AmberBond_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::AmberBond >,

--- a/wrapper/MM/AmberDihPart.pypp.cpp
+++ b/wrapper/MM/AmberDihPart.pypp.cpp
@@ -73,6 +73,8 @@ namespace bp = boost::python;
 
 SireMM::AmberDihPart __copy__(const SireMM::AmberDihPart &other){ return SireMM::AmberDihPart(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -215,9 +217,9 @@ void register_AmberDihPart_class(){
         
         }
         AmberDihPart_exposer.staticmethod( "typeName" );
-        AmberDihPart_exposer.def( "__copy__", &__copy__);
-        AmberDihPart_exposer.def( "__deepcopy__", &__copy__);
-        AmberDihPart_exposer.def( "clone", &__copy__);
+        AmberDihPart_exposer.def( "__copy__", &__copy__<SireMM::AmberDihPart>);
+        AmberDihPart_exposer.def( "__deepcopy__", &__copy__<SireMM::AmberDihPart>);
+        AmberDihPart_exposer.def( "clone", &__copy__<SireMM::AmberDihPart>);
         AmberDihPart_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::AmberDihPart >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         AmberDihPart_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::AmberDihPart >,

--- a/wrapper/MM/AmberDihedral.pypp.cpp
+++ b/wrapper/MM/AmberDihedral.pypp.cpp
@@ -73,6 +73,8 @@ namespace bp = boost::python;
 
 SireMM::AmberDihedral __copy__(const SireMM::AmberDihedral &other){ return SireMM::AmberDihedral(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -203,9 +205,9 @@ void register_AmberDihedral_class(){
         
         }
         AmberDihedral_exposer.staticmethod( "typeName" );
-        AmberDihedral_exposer.def( "__copy__", &__copy__);
-        AmberDihedral_exposer.def( "__deepcopy__", &__copy__);
-        AmberDihedral_exposer.def( "clone", &__copy__);
+        AmberDihedral_exposer.def( "__copy__", &__copy__<SireMM::AmberDihedral>);
+        AmberDihedral_exposer.def( "__deepcopy__", &__copy__<SireMM::AmberDihedral>);
+        AmberDihedral_exposer.def( "clone", &__copy__<SireMM::AmberDihedral>);
         AmberDihedral_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::AmberDihedral >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         AmberDihedral_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::AmberDihedral >,

--- a/wrapper/MM/AmberNB14.pypp.cpp
+++ b/wrapper/MM/AmberNB14.pypp.cpp
@@ -73,6 +73,8 @@ namespace bp = boost::python;
 
 SireMM::AmberNB14 __copy__(const SireMM::AmberNB14 &other){ return SireMM::AmberNB14(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -190,9 +192,9 @@ void register_AmberNB14_class(){
         
         }
         AmberNB14_exposer.staticmethod( "typeName" );
-        AmberNB14_exposer.def( "__copy__", &__copy__);
-        AmberNB14_exposer.def( "__deepcopy__", &__copy__);
-        AmberNB14_exposer.def( "clone", &__copy__);
+        AmberNB14_exposer.def( "__copy__", &__copy__<SireMM::AmberNB14>);
+        AmberNB14_exposer.def( "__deepcopy__", &__copy__<SireMM::AmberNB14>);
+        AmberNB14_exposer.def( "clone", &__copy__<SireMM::AmberNB14>);
         AmberNB14_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::AmberNB14 >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         AmberNB14_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::AmberNB14 >,

--- a/wrapper/MM/AmberParams.pypp.cpp
+++ b/wrapper/MM/AmberParams.pypp.cpp
@@ -73,6 +73,8 @@ namespace bp = boost::python;
 
 SireMM::AmberParams __copy__(const SireMM::AmberParams &other){ return SireMM::AmberParams(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -858,9 +860,9 @@ void register_AmberParams_class(){
         
         }
         AmberParams_exposer.staticmethod( "typeName" );
-        AmberParams_exposer.def( "__copy__", &__copy__);
-        AmberParams_exposer.def( "__deepcopy__", &__copy__);
-        AmberParams_exposer.def( "clone", &__copy__);
+        AmberParams_exposer.def( "__copy__", &__copy__<SireMM::AmberParams>);
+        AmberParams_exposer.def( "__deepcopy__", &__copy__<SireMM::AmberParams>);
+        AmberParams_exposer.def( "clone", &__copy__<SireMM::AmberParams>);
         AmberParams_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::AmberParams >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         AmberParams_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::AmberParams >,

--- a/wrapper/MM/Angle.pypp.cpp
+++ b/wrapper/MM/Angle.pypp.cpp
@@ -42,6 +42,8 @@ namespace bp = boost::python;
 
 SireMM::Angle __copy__(const SireMM::Angle &other){ return SireMM::Angle(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -471,9 +473,9 @@ void register_Angle_class(){
         
         }
         Angle_exposer.staticmethod( "typeName" );
-        Angle_exposer.def( "__copy__", &__copy__);
-        Angle_exposer.def( "__deepcopy__", &__copy__);
-        Angle_exposer.def( "clone", &__copy__);
+        Angle_exposer.def( "__copy__", &__copy__<SireMM::Angle>);
+        Angle_exposer.def( "__deepcopy__", &__copy__<SireMM::Angle>);
+        Angle_exposer.def( "clone", &__copy__<SireMM::Angle>);
         Angle_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::Angle >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         Angle_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::Angle >,

--- a/wrapper/MM/AngleComponent.pypp.cpp
+++ b/wrapper/MM/AngleComponent.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireMM::AngleComponent __copy__(const SireMM::AngleComponent &other){ return SireMM::AngleComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -107,9 +109,9 @@ void register_AngleComponent_class(){
         
         }
         AngleComponent_exposer.staticmethod( "typeName" );
-        AngleComponent_exposer.def( "__copy__", &__copy__);
-        AngleComponent_exposer.def( "__deepcopy__", &__copy__);
-        AngleComponent_exposer.def( "clone", &__copy__);
+        AngleComponent_exposer.def( "__copy__", &__copy__<SireMM::AngleComponent>);
+        AngleComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::AngleComponent>);
+        AngleComponent_exposer.def( "clone", &__copy__<SireMM::AngleComponent>);
         AngleComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::AngleComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         AngleComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::AngleComponent >,

--- a/wrapper/MM/AngleParameterName.pypp.cpp
+++ b/wrapper/MM/AngleParameterName.pypp.cpp
@@ -49,6 +49,8 @@ namespace bp = boost::python;
 
 SireMM::AngleParameterName __copy__(const SireMM::AngleParameterName &other){ return SireMM::AngleParameterName(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::AngleParameterName&){ return "SireMM::AngleParameterName";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -71,9 +73,9 @@ void register_AngleParameterName_class(){
                 , "" );
         
         }
-        AngleParameterName_exposer.def( "__copy__", &__copy__);
-        AngleParameterName_exposer.def( "__deepcopy__", &__copy__);
-        AngleParameterName_exposer.def( "clone", &__copy__);
+        AngleParameterName_exposer.def( "__copy__", &__copy__<SireMM::AngleParameterName>);
+        AngleParameterName_exposer.def( "__deepcopy__", &__copy__<SireMM::AngleParameterName>);
+        AngleParameterName_exposer.def( "clone", &__copy__<SireMM::AngleParameterName>);
         AngleParameterName_exposer.def( "__str__", &pvt_get_name);
         AngleParameterName_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/AngleRestraint.pypp.cpp
+++ b/wrapper/MM/AngleRestraint.pypp.cpp
@@ -36,6 +36,8 @@ namespace bp = boost::python;
 
 SireMM::AngleRestraint __copy__(const SireMM::AngleRestraint &other){ return SireMM::AngleRestraint(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -357,9 +359,9 @@ void register_AngleRestraint_class(){
         AngleRestraint_exposer.staticmethod( "harmonic" );
         AngleRestraint_exposer.staticmethod( "theta" );
         AngleRestraint_exposer.staticmethod( "typeName" );
-        AngleRestraint_exposer.def( "__copy__", &__copy__);
-        AngleRestraint_exposer.def( "__deepcopy__", &__copy__);
-        AngleRestraint_exposer.def( "clone", &__copy__);
+        AngleRestraint_exposer.def( "__copy__", &__copy__<SireMM::AngleRestraint>);
+        AngleRestraint_exposer.def( "__deepcopy__", &__copy__<SireMM::AngleRestraint>);
+        AngleRestraint_exposer.def( "clone", &__copy__<SireMM::AngleRestraint>);
         AngleRestraint_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::AngleRestraint >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         AngleRestraint_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::AngleRestraint >,

--- a/wrapper/MM/AngleSymbols.pypp.cpp
+++ b/wrapper/MM/AngleSymbols.pypp.cpp
@@ -34,6 +34,8 @@ namespace bp = boost::python;
 
 SireMM::AngleSymbols __copy__(const SireMM::AngleSymbols &other){ return SireMM::AngleSymbols(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::AngleSymbols&){ return "SireMM::AngleSymbols";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -56,9 +58,9 @@ void register_AngleSymbols_class(){
                 , "Return the symbols representing the angle (theta)" );
         
         }
-        AngleSymbols_exposer.def( "__copy__", &__copy__);
-        AngleSymbols_exposer.def( "__deepcopy__", &__copy__);
-        AngleSymbols_exposer.def( "clone", &__copy__);
+        AngleSymbols_exposer.def( "__copy__", &__copy__<SireMM::AngleSymbols>);
+        AngleSymbols_exposer.def( "__deepcopy__", &__copy__<SireMM::AngleSymbols>);
+        AngleSymbols_exposer.def( "clone", &__copy__<SireMM::AngleSymbols>);
         AngleSymbols_exposer.def( "__str__", &pvt_get_name);
         AngleSymbols_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/AtomLJs.pypp.cpp
+++ b/wrapper/MM/AtomLJs.pypp.cpp
@@ -33,6 +33,8 @@ namespace bp = boost::python;
 
 SireMol::AtomProperty<SireMM::LJParameter> __copy__(const SireMol::AtomProperty<SireMM::LJParameter> &other){ return SireMol::AtomProperty<SireMM::LJParameter>(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -827,9 +829,9 @@ void register_AtomLJs_class(){
         }
         AtomLJs_exposer.staticmethod( "fromVariant" );
         AtomLJs_exposer.staticmethod( "typeName" );
-        AtomLJs_exposer.def( "__copy__", &__copy__);
-        AtomLJs_exposer.def( "__deepcopy__", &__copy__);
-        AtomLJs_exposer.def( "clone", &__copy__);
+        AtomLJs_exposer.def( "__copy__", &__copy__<SireMol::AtomProperty<SireMM::LJParameter>>);
+        AtomLJs_exposer.def( "__deepcopy__", &__copy__<SireMol::AtomProperty<SireMM::LJParameter>>);
+        AtomLJs_exposer.def( "clone", &__copy__<SireMol::AtomProperty<SireMM::LJParameter>>);
         AtomLJs_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMol::AtomProperty<SireMM::LJParameter> >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         AtomLJs_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMol::AtomProperty<SireMM::LJParameter> >,

--- a/wrapper/MM/BendBendComponent.pypp.cpp
+++ b/wrapper/MM/BendBendComponent.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireMM::BendBendComponent __copy__(const SireMM::BendBendComponent &other){ return SireMM::BendBendComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -107,9 +109,9 @@ void register_BendBendComponent_class(){
         
         }
         BendBendComponent_exposer.staticmethod( "typeName" );
-        BendBendComponent_exposer.def( "__copy__", &__copy__);
-        BendBendComponent_exposer.def( "__deepcopy__", &__copy__);
-        BendBendComponent_exposer.def( "clone", &__copy__);
+        BendBendComponent_exposer.def( "__copy__", &__copy__<SireMM::BendBendComponent>);
+        BendBendComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::BendBendComponent>);
+        BendBendComponent_exposer.def( "clone", &__copy__<SireMM::BendBendComponent>);
         BendBendComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::BendBendComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         BendBendComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::BendBendComponent >,

--- a/wrapper/MM/BendBendParameterName.pypp.cpp
+++ b/wrapper/MM/BendBendParameterName.pypp.cpp
@@ -49,6 +49,8 @@ namespace bp = boost::python;
 
 SireMM::BendBendParameterName __copy__(const SireMM::BendBendParameterName &other){ return SireMM::BendBendParameterName(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::BendBendParameterName&){ return "SireMM::BendBendParameterName";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -71,9 +73,9 @@ void register_BendBendParameterName_class(){
                 , "" );
         
         }
-        BendBendParameterName_exposer.def( "__copy__", &__copy__);
-        BendBendParameterName_exposer.def( "__deepcopy__", &__copy__);
-        BendBendParameterName_exposer.def( "clone", &__copy__);
+        BendBendParameterName_exposer.def( "__copy__", &__copy__<SireMM::BendBendParameterName>);
+        BendBendParameterName_exposer.def( "__deepcopy__", &__copy__<SireMM::BendBendParameterName>);
+        BendBendParameterName_exposer.def( "clone", &__copy__<SireMM::BendBendParameterName>);
         BendBendParameterName_exposer.def( "__str__", &pvt_get_name);
         BendBendParameterName_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/BendBendSymbols.pypp.cpp
+++ b/wrapper/MM/BendBendSymbols.pypp.cpp
@@ -34,6 +34,8 @@ namespace bp = boost::python;
 
 SireMM::BendBendSymbols __copy__(const SireMM::BendBendSymbols &other){ return SireMM::BendBendSymbols(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::BendBendSymbols&){ return "SireMM::BendBendSymbols";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -80,9 +82,9 @@ void register_BendBendSymbols_class(){
                 , "Return the symbol representing the angle between atoms 3-1-0, theta_\n{310}" );
         
         }
-        BendBendSymbols_exposer.def( "__copy__", &__copy__);
-        BendBendSymbols_exposer.def( "__deepcopy__", &__copy__);
-        BendBendSymbols_exposer.def( "clone", &__copy__);
+        BendBendSymbols_exposer.def( "__copy__", &__copy__<SireMM::BendBendSymbols>);
+        BendBendSymbols_exposer.def( "__deepcopy__", &__copy__<SireMM::BendBendSymbols>);
+        BendBendSymbols_exposer.def( "clone", &__copy__<SireMM::BendBendSymbols>);
         BendBendSymbols_exposer.def( "__str__", &pvt_get_name);
         BendBendSymbols_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/Bond.pypp.cpp
+++ b/wrapper/MM/Bond.pypp.cpp
@@ -42,6 +42,8 @@ namespace bp = boost::python;
 
 SireMM::Bond __copy__(const SireMM::Bond &other){ return SireMM::Bond(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -459,9 +461,9 @@ void register_Bond_class(){
         
         }
         Bond_exposer.staticmethod( "typeName" );
-        Bond_exposer.def( "__copy__", &__copy__);
-        Bond_exposer.def( "__deepcopy__", &__copy__);
-        Bond_exposer.def( "clone", &__copy__);
+        Bond_exposer.def( "__copy__", &__copy__<SireMM::Bond>);
+        Bond_exposer.def( "__deepcopy__", &__copy__<SireMM::Bond>);
+        Bond_exposer.def( "clone", &__copy__<SireMM::Bond>);
         Bond_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::Bond >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         Bond_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::Bond >,

--- a/wrapper/MM/BondComponent.pypp.cpp
+++ b/wrapper/MM/BondComponent.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireMM::BondComponent __copy__(const SireMM::BondComponent &other){ return SireMM::BondComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -107,9 +109,9 @@ void register_BondComponent_class(){
         
         }
         BondComponent_exposer.staticmethod( "typeName" );
-        BondComponent_exposer.def( "__copy__", &__copy__);
-        BondComponent_exposer.def( "__deepcopy__", &__copy__);
-        BondComponent_exposer.def( "clone", &__copy__);
+        BondComponent_exposer.def( "__copy__", &__copy__<SireMM::BondComponent>);
+        BondComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::BondComponent>);
+        BondComponent_exposer.def( "clone", &__copy__<SireMM::BondComponent>);
         BondComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::BondComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         BondComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::BondComponent >,

--- a/wrapper/MM/BondParameterName.pypp.cpp
+++ b/wrapper/MM/BondParameterName.pypp.cpp
@@ -49,6 +49,8 @@ namespace bp = boost::python;
 
 SireMM::BondParameterName __copy__(const SireMM::BondParameterName &other){ return SireMM::BondParameterName(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::BondParameterName&){ return "SireMM::BondParameterName";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -71,9 +73,9 @@ void register_BondParameterName_class(){
                 , "" );
         
         }
-        BondParameterName_exposer.def( "__copy__", &__copy__);
-        BondParameterName_exposer.def( "__deepcopy__", &__copy__);
-        BondParameterName_exposer.def( "clone", &__copy__);
+        BondParameterName_exposer.def( "__copy__", &__copy__<SireMM::BondParameterName>);
+        BondParameterName_exposer.def( "__deepcopy__", &__copy__<SireMM::BondParameterName>);
+        BondParameterName_exposer.def( "clone", &__copy__<SireMM::BondParameterName>);
         BondParameterName_exposer.def( "__str__", &pvt_get_name);
         BondParameterName_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/BondRestraint.pypp.cpp
+++ b/wrapper/MM/BondRestraint.pypp.cpp
@@ -25,6 +25,8 @@ namespace bp = boost::python;
 
 SireMM::BondRestraint __copy__(const SireMM::BondRestraint &other){ return SireMM::BondRestraint(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -202,9 +204,9 @@ void register_BondRestraint_class(){
         
         }
         BondRestraint_exposer.staticmethod( "typeName" );
-        BondRestraint_exposer.def( "__copy__", &__copy__);
-        BondRestraint_exposer.def( "__deepcopy__", &__copy__);
-        BondRestraint_exposer.def( "clone", &__copy__);
+        BondRestraint_exposer.def( "__copy__", &__copy__<SireMM::BondRestraint>);
+        BondRestraint_exposer.def( "__deepcopy__", &__copy__<SireMM::BondRestraint>);
+        BondRestraint_exposer.def( "clone", &__copy__<SireMM::BondRestraint>);
         BondRestraint_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::BondRestraint >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         BondRestraint_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::BondRestraint >,

--- a/wrapper/MM/BondRestraints.pypp.cpp
+++ b/wrapper/MM/BondRestraints.pypp.cpp
@@ -26,6 +26,8 @@ namespace bp = boost::python;
 
 SireMM::BondRestraints __copy__(const SireMM::BondRestraints &other){ return SireMM::BondRestraints(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -296,9 +298,9 @@ void register_BondRestraints_class(){
         
         }
         BondRestraints_exposer.staticmethod( "typeName" );
-        BondRestraints_exposer.def( "__copy__", &__copy__);
-        BondRestraints_exposer.def( "__deepcopy__", &__copy__);
-        BondRestraints_exposer.def( "clone", &__copy__);
+        BondRestraints_exposer.def( "__copy__", &__copy__<SireMM::BondRestraints>);
+        BondRestraints_exposer.def( "__deepcopy__", &__copy__<SireMM::BondRestraints>);
+        BondRestraints_exposer.def( "clone", &__copy__<SireMM::BondRestraints>);
         BondRestraints_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::BondRestraints >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         BondRestraints_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::BondRestraints >,

--- a/wrapper/MM/BondSymbols.pypp.cpp
+++ b/wrapper/MM/BondSymbols.pypp.cpp
@@ -34,6 +34,8 @@ namespace bp = boost::python;
 
 SireMM::BondSymbols __copy__(const SireMM::BondSymbols &other){ return SireMM::BondSymbols(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::BondSymbols&){ return "SireMM::BondSymbols";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -56,9 +58,9 @@ void register_BondSymbols_class(){
                 , "Return the symbol representing the vector along the bond (r)" );
         
         }
-        BondSymbols_exposer.def( "__copy__", &__copy__);
-        BondSymbols_exposer.def( "__deepcopy__", &__copy__);
-        BondSymbols_exposer.def( "clone", &__copy__);
+        BondSymbols_exposer.def( "__copy__", &__copy__<SireMM::BondSymbols>);
+        BondSymbols_exposer.def( "__deepcopy__", &__copy__<SireMM::BondSymbols>);
+        BondSymbols_exposer.def( "clone", &__copy__<SireMM::BondSymbols>);
         BondSymbols_exposer.def( "__str__", &pvt_get_name);
         BondSymbols_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/BoreschRestraint.pypp.cpp
+++ b/wrapper/MM/BoreschRestraint.pypp.cpp
@@ -25,6 +25,8 @@ namespace bp = boost::python;
 
 SireMM::BoreschRestraint __copy__(const SireMM::BoreschRestraint &other){ return SireMM::BoreschRestraint(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -201,9 +203,9 @@ void register_BoreschRestraint_class(){
         
         }
         BoreschRestraint_exposer.staticmethod( "typeName" );
-        BoreschRestraint_exposer.def( "__copy__", &__copy__);
-        BoreschRestraint_exposer.def( "__deepcopy__", &__copy__);
-        BoreschRestraint_exposer.def( "clone", &__copy__);
+        BoreschRestraint_exposer.def( "__copy__", &__copy__<SireMM::BoreschRestraint>);
+        BoreschRestraint_exposer.def( "__deepcopy__", &__copy__<SireMM::BoreschRestraint>);
+        BoreschRestraint_exposer.def( "clone", &__copy__<SireMM::BoreschRestraint>);
         BoreschRestraint_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::BoreschRestraint >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         BoreschRestraint_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::BoreschRestraint >,

--- a/wrapper/MM/BoreschRestraints.pypp.cpp
+++ b/wrapper/MM/BoreschRestraints.pypp.cpp
@@ -26,6 +26,8 @@ namespace bp = boost::python;
 
 SireMM::BoreschRestraints __copy__(const SireMM::BoreschRestraints &other){ return SireMM::BoreschRestraints(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -224,9 +226,9 @@ void register_BoreschRestraints_class(){
         
         }
         BoreschRestraints_exposer.staticmethod( "typeName" );
-        BoreschRestraints_exposer.def( "__copy__", &__copy__);
-        BoreschRestraints_exposer.def( "__deepcopy__", &__copy__);
-        BoreschRestraints_exposer.def( "clone", &__copy__);
+        BoreschRestraints_exposer.def( "__copy__", &__copy__<SireMM::BoreschRestraints>);
+        BoreschRestraints_exposer.def( "__deepcopy__", &__copy__<SireMM::BoreschRestraints>);
+        BoreschRestraints_exposer.def( "clone", &__copy__<SireMM::BoreschRestraints>);
         BoreschRestraints_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::BoreschRestraints >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         BoreschRestraints_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::BoreschRestraints >,

--- a/wrapper/MM/CHARMMSwitchingFunction.pypp.cpp
+++ b/wrapper/MM/CHARMMSwitchingFunction.pypp.cpp
@@ -29,6 +29,8 @@ namespace bp = boost::python;
 
 SireMM::CHARMMSwitchingFunction __copy__(const SireMM::CHARMMSwitchingFunction &other){ return SireMM::CHARMMSwitchingFunction(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -138,9 +140,9 @@ void register_CHARMMSwitchingFunction_class(){
         
         }
         CHARMMSwitchingFunction_exposer.staticmethod( "typeName" );
-        CHARMMSwitchingFunction_exposer.def( "__copy__", &__copy__);
-        CHARMMSwitchingFunction_exposer.def( "__deepcopy__", &__copy__);
-        CHARMMSwitchingFunction_exposer.def( "clone", &__copy__);
+        CHARMMSwitchingFunction_exposer.def( "__copy__", &__copy__<SireMM::CHARMMSwitchingFunction>);
+        CHARMMSwitchingFunction_exposer.def( "__deepcopy__", &__copy__<SireMM::CHARMMSwitchingFunction>);
+        CHARMMSwitchingFunction_exposer.def( "clone", &__copy__<SireMM::CHARMMSwitchingFunction>);
         CHARMMSwitchingFunction_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CHARMMSwitchingFunction >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CHARMMSwitchingFunction_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CHARMMSwitchingFunction >,

--- a/wrapper/MM/CLJ14Group.pypp.cpp
+++ b/wrapper/MM/CLJ14Group.pypp.cpp
@@ -36,6 +36,8 @@ namespace bp = boost::python;
 
 SireMM::CLJ14Group __copy__(const SireMM::CLJ14Group &other){ return SireMM::CLJ14Group(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -378,9 +380,9 @@ void register_CLJ14Group_class(){
         
         }
         CLJ14Group_exposer.staticmethod( "typeName" );
-        CLJ14Group_exposer.def( "__copy__", &__copy__);
-        CLJ14Group_exposer.def( "__deepcopy__", &__copy__);
-        CLJ14Group_exposer.def( "clone", &__copy__);
+        CLJ14Group_exposer.def( "__copy__", &__copy__<SireMM::CLJ14Group>);
+        CLJ14Group_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJ14Group>);
+        CLJ14Group_exposer.def( "clone", &__copy__<SireMM::CLJ14Group>);
         CLJ14Group_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJ14Group >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJ14Group_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJ14Group >,

--- a/wrapper/MM/CLJAtom.pypp.cpp
+++ b/wrapper/MM/CLJAtom.pypp.cpp
@@ -45,6 +45,8 @@ namespace bp = boost::python;
 
 SireMM::CLJAtom __copy__(const SireMM::CLJAtom &other){ return SireMM::CLJAtom(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -208,9 +210,9 @@ void register_CLJAtom_class(){
         }
         CLJAtom_exposer.staticmethod( "buildFrom" );
         CLJAtom_exposer.staticmethod( "typeName" );
-        CLJAtom_exposer.def( "__copy__", &__copy__);
-        CLJAtom_exposer.def( "__deepcopy__", &__copy__);
-        CLJAtom_exposer.def( "clone", &__copy__);
+        CLJAtom_exposer.def( "__copy__", &__copy__<SireMM::CLJAtom>);
+        CLJAtom_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJAtom>);
+        CLJAtom_exposer.def( "clone", &__copy__<SireMM::CLJAtom>);
         CLJAtom_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJAtom >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJAtom_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJAtom >,

--- a/wrapper/MM/CLJAtoms.pypp.cpp
+++ b/wrapper/MM/CLJAtoms.pypp.cpp
@@ -45,6 +45,8 @@ namespace bp = boost::python;
 
 SireMM::CLJAtoms __copy__(const SireMM::CLJAtoms &other){ return SireMM::CLJAtoms(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -650,9 +652,9 @@ void register_CLJAtoms_class(){
         }
         CLJAtoms_exposer.staticmethod( "idOfDummy" );
         CLJAtoms_exposer.staticmethod( "typeName" );
-        CLJAtoms_exposer.def( "__copy__", &__copy__);
-        CLJAtoms_exposer.def( "__deepcopy__", &__copy__);
-        CLJAtoms_exposer.def( "clone", &__copy__);
+        CLJAtoms_exposer.def( "__copy__", &__copy__<SireMM::CLJAtoms>);
+        CLJAtoms_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJAtoms>);
+        CLJAtoms_exposer.def( "clone", &__copy__<SireMM::CLJAtoms>);
         CLJAtoms_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJAtoms >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJAtoms_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJAtoms >,

--- a/wrapper/MM/CLJBox.pypp.cpp
+++ b/wrapper/MM/CLJBox.pypp.cpp
@@ -37,6 +37,8 @@ namespace bp = boost::python;
 
 SireMM::CLJBox __copy__(const SireMM::CLJBox &other){ return SireMM::CLJBox(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -331,9 +333,9 @@ void register_CLJBox_class(){
         
         }
         CLJBox_exposer.staticmethod( "typeName" );
-        CLJBox_exposer.def( "__copy__", &__copy__);
-        CLJBox_exposer.def( "__deepcopy__", &__copy__);
-        CLJBox_exposer.def( "clone", &__copy__);
+        CLJBox_exposer.def( "__copy__", &__copy__<SireMM::CLJBox>);
+        CLJBox_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJBox>);
+        CLJBox_exposer.def( "clone", &__copy__<SireMM::CLJBox>);
         CLJBox_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJBox >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJBox_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJBox >,

--- a/wrapper/MM/CLJBoxDistance.pypp.cpp
+++ b/wrapper/MM/CLJBoxDistance.pypp.cpp
@@ -37,6 +37,8 @@ namespace bp = boost::python;
 
 SireMM::CLJBoxDistance __copy__(const SireMM::CLJBoxDistance &other){ return SireMM::CLJBoxDistance(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -141,9 +143,9 @@ void register_CLJBoxDistance_class(){
         
         }
         CLJBoxDistance_exposer.staticmethod( "typeName" );
-        CLJBoxDistance_exposer.def( "__copy__", &__copy__);
-        CLJBoxDistance_exposer.def( "__deepcopy__", &__copy__);
-        CLJBoxDistance_exposer.def( "clone", &__copy__);
+        CLJBoxDistance_exposer.def( "__copy__", &__copy__<SireMM::CLJBoxDistance>);
+        CLJBoxDistance_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJBoxDistance>);
+        CLJBoxDistance_exposer.def( "clone", &__copy__<SireMM::CLJBoxDistance>);
         CLJBoxDistance_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJBoxDistance >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJBoxDistance_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJBoxDistance >,

--- a/wrapper/MM/CLJBoxIndex.pypp.cpp
+++ b/wrapper/MM/CLJBoxIndex.pypp.cpp
@@ -37,6 +37,8 @@ namespace bp = boost::python;
 
 SireMM::CLJBoxIndex __copy__(const SireMM::CLJBoxIndex &other){ return SireMM::CLJBoxIndex(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -336,9 +338,9 @@ void register_CLJBoxIndex_class(){
         CLJBoxIndex_exposer.staticmethod( "createWithInverseBoxLength" );
         CLJBoxIndex_exposer.staticmethod( "null" );
         CLJBoxIndex_exposer.staticmethod( "typeName" );
-        CLJBoxIndex_exposer.def( "__copy__", &__copy__);
-        CLJBoxIndex_exposer.def( "__deepcopy__", &__copy__);
-        CLJBoxIndex_exposer.def( "clone", &__copy__);
+        CLJBoxIndex_exposer.def( "__copy__", &__copy__<SireMM::CLJBoxIndex>);
+        CLJBoxIndex_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJBoxIndex>);
+        CLJBoxIndex_exposer.def( "clone", &__copy__<SireMM::CLJBoxIndex>);
         CLJBoxIndex_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJBoxIndex >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJBoxIndex_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJBoxIndex >,

--- a/wrapper/MM/CLJBoxes.pypp.cpp
+++ b/wrapper/MM/CLJBoxes.pypp.cpp
@@ -37,6 +37,8 @@ namespace bp = boost::python;
 
 SireMM::CLJBoxes __copy__(const SireMM::CLJBoxes &other){ return SireMM::CLJBoxes(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -527,9 +529,9 @@ void register_CLJBoxes_class(){
         }
         CLJBoxes_exposer.staticmethod( "getDistances" );
         CLJBoxes_exposer.staticmethod( "typeName" );
-        CLJBoxes_exposer.def( "__copy__", &__copy__);
-        CLJBoxes_exposer.def( "__deepcopy__", &__copy__);
-        CLJBoxes_exposer.def( "clone", &__copy__);
+        CLJBoxes_exposer.def( "__copy__", &__copy__<SireMM::CLJBoxes>);
+        CLJBoxes_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJBoxes>);
+        CLJBoxes_exposer.def( "clone", &__copy__<SireMM::CLJBoxes>);
         CLJBoxes_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJBoxes >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJBoxes_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJBoxes >,

--- a/wrapper/MM/CLJCalculator.pypp.cpp
+++ b/wrapper/MM/CLJCalculator.pypp.cpp
@@ -27,6 +27,8 @@ namespace bp = boost::python;
 
 SireMM::CLJCalculator __copy__(const SireMM::CLJCalculator &other){ return SireMM::CLJCalculator(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -170,9 +172,9 @@ void register_CLJCalculator_class(){
         
         }
         CLJCalculator_exposer.staticmethod( "typeName" );
-        CLJCalculator_exposer.def( "__copy__", &__copy__);
-        CLJCalculator_exposer.def( "__deepcopy__", &__copy__);
-        CLJCalculator_exposer.def( "clone", &__copy__);
+        CLJCalculator_exposer.def( "__copy__", &__copy__<SireMM::CLJCalculator>);
+        CLJCalculator_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJCalculator>);
+        CLJCalculator_exposer.def( "clone", &__copy__<SireMM::CLJCalculator>);
         CLJCalculator_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJCalculator >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJCalculator_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJCalculator >,

--- a/wrapper/MM/CLJComponent.pypp.cpp
+++ b/wrapper/MM/CLJComponent.pypp.cpp
@@ -16,6 +16,8 @@ namespace bp = boost::python;
 
 SireMM::CLJComponent __copy__(const SireMM::CLJComponent &other){ return SireMM::CLJComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -130,9 +132,9 @@ void register_CLJComponent_class(){
         
         }
         CLJComponent_exposer.staticmethod( "typeName" );
-        CLJComponent_exposer.def( "__copy__", &__copy__);
-        CLJComponent_exposer.def( "__deepcopy__", &__copy__);
-        CLJComponent_exposer.def( "clone", &__copy__);
+        CLJComponent_exposer.def( "__copy__", &__copy__<SireMM::CLJComponent>);
+        CLJComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJComponent>);
+        CLJComponent_exposer.def( "clone", &__copy__<SireMM::CLJComponent>);
         CLJComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJComponent >,

--- a/wrapper/MM/CLJDelta.pypp.cpp
+++ b/wrapper/MM/CLJDelta.pypp.cpp
@@ -21,6 +21,8 @@ namespace bp = boost::python;
 
 SireMM::CLJDelta __copy__(const SireMM::CLJDelta &other){ return SireMM::CLJDelta(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -280,9 +282,9 @@ void register_CLJDelta_class(){
         CLJDelta_exposer.staticmethod( "mergeNew" );
         CLJDelta_exposer.staticmethod( "mergeOld" );
         CLJDelta_exposer.staticmethod( "typeName" );
-        CLJDelta_exposer.def( "__copy__", &__copy__);
-        CLJDelta_exposer.def( "__deepcopy__", &__copy__);
-        CLJDelta_exposer.def( "clone", &__copy__);
+        CLJDelta_exposer.def( "__copy__", &__copy__<SireMM::CLJDelta>);
+        CLJDelta_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJDelta>);
+        CLJDelta_exposer.def( "clone", &__copy__<SireMM::CLJDelta>);
         CLJDelta_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJDelta >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJDelta_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJDelta >,

--- a/wrapper/MM/CLJExtractor.pypp.cpp
+++ b/wrapper/MM/CLJExtractor.pypp.cpp
@@ -37,6 +37,8 @@ namespace bp = boost::python;
 
 SireMM::CLJExtractor __copy__(const SireMM::CLJExtractor &other){ return SireMM::CLJExtractor(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -409,9 +411,9 @@ void register_CLJExtractor_class(){
         
         }
         CLJExtractor_exposer.staticmethod( "typeName" );
-        CLJExtractor_exposer.def( "__copy__", &__copy__);
-        CLJExtractor_exposer.def( "__deepcopy__", &__copy__);
-        CLJExtractor_exposer.def( "clone", &__copy__);
+        CLJExtractor_exposer.def( "__copy__", &__copy__<SireMM::CLJExtractor>);
+        CLJExtractor_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJExtractor>);
+        CLJExtractor_exposer.def( "clone", &__copy__<SireMM::CLJExtractor>);
         CLJExtractor_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJExtractor >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJExtractor_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJExtractor >,

--- a/wrapper/MM/CLJGrid.pypp.cpp
+++ b/wrapper/MM/CLJGrid.pypp.cpp
@@ -34,6 +34,8 @@ namespace bp = boost::python;
 
 SireMM::CLJGrid __copy__(const SireMM::CLJGrid &other){ return SireMM::CLJGrid(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -621,9 +623,9 @@ void register_CLJGrid_class(){
         }
         CLJGrid_exposer.staticmethod( "idOfFixedAtom" );
         CLJGrid_exposer.staticmethod( "typeName" );
-        CLJGrid_exposer.def( "__copy__", &__copy__);
-        CLJGrid_exposer.def( "__deepcopy__", &__copy__);
-        CLJGrid_exposer.def( "clone", &__copy__);
+        CLJGrid_exposer.def( "__copy__", &__copy__<SireMM::CLJGrid>);
+        CLJGrid_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJGrid>);
+        CLJGrid_exposer.def( "clone", &__copy__<SireMM::CLJGrid>);
         CLJGrid_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJGrid >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJGrid_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJGrid >,

--- a/wrapper/MM/CLJGroup.pypp.cpp
+++ b/wrapper/MM/CLJGroup.pypp.cpp
@@ -21,6 +21,8 @@ namespace bp = boost::python;
 
 SireMM::CLJGroup __copy__(const SireMM::CLJGroup &other){ return SireMM::CLJGroup(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -458,9 +460,9 @@ void register_CLJGroup_class(){
         
         }
         CLJGroup_exposer.staticmethod( "typeName" );
-        CLJGroup_exposer.def( "__copy__", &__copy__);
-        CLJGroup_exposer.def( "__deepcopy__", &__copy__);
-        CLJGroup_exposer.def( "clone", &__copy__);
+        CLJGroup_exposer.def( "__copy__", &__copy__<SireMM::CLJGroup>);
+        CLJGroup_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJGroup>);
+        CLJGroup_exposer.def( "clone", &__copy__<SireMM::CLJGroup>);
         CLJGroup_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJGroup >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJGroup_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJGroup >,

--- a/wrapper/MM/CLJIntraRFFunction.pypp.cpp
+++ b/wrapper/MM/CLJIntraRFFunction.pypp.cpp
@@ -35,6 +35,8 @@ namespace bp = boost::python;
 
 SireMM::CLJIntraRFFunction __copy__(const SireMM::CLJIntraRFFunction &other){ return SireMM::CLJIntraRFFunction(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -186,9 +188,9 @@ void register_CLJIntraRFFunction_class(){
         }
         CLJIntraRFFunction_exposer.staticmethod( "defaultRFFunction" );
         CLJIntraRFFunction_exposer.staticmethod( "typeName" );
-        CLJIntraRFFunction_exposer.def( "__copy__", &__copy__);
-        CLJIntraRFFunction_exposer.def( "__deepcopy__", &__copy__);
-        CLJIntraRFFunction_exposer.def( "clone", &__copy__);
+        CLJIntraRFFunction_exposer.def( "__copy__", &__copy__<SireMM::CLJIntraRFFunction>);
+        CLJIntraRFFunction_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJIntraRFFunction>);
+        CLJIntraRFFunction_exposer.def( "clone", &__copy__<SireMM::CLJIntraRFFunction>);
         CLJIntraRFFunction_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJIntraRFFunction >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJIntraRFFunction_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJIntraRFFunction >,

--- a/wrapper/MM/CLJIntraShiftFunction.pypp.cpp
+++ b/wrapper/MM/CLJIntraShiftFunction.pypp.cpp
@@ -33,6 +33,8 @@ namespace bp = boost::python;
 
 SireMM::CLJIntraShiftFunction __copy__(const SireMM::CLJIntraShiftFunction &other){ return SireMM::CLJIntraShiftFunction(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -108,9 +110,9 @@ void register_CLJIntraShiftFunction_class(){
         }
         CLJIntraShiftFunction_exposer.staticmethod( "defaultShiftFunction" );
         CLJIntraShiftFunction_exposer.staticmethod( "typeName" );
-        CLJIntraShiftFunction_exposer.def( "__copy__", &__copy__);
-        CLJIntraShiftFunction_exposer.def( "__deepcopy__", &__copy__);
-        CLJIntraShiftFunction_exposer.def( "clone", &__copy__);
+        CLJIntraShiftFunction_exposer.def( "__copy__", &__copy__<SireMM::CLJIntraShiftFunction>);
+        CLJIntraShiftFunction_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJIntraShiftFunction>);
+        CLJIntraShiftFunction_exposer.def( "clone", &__copy__<SireMM::CLJIntraShiftFunction>);
         CLJIntraShiftFunction_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJIntraShiftFunction >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJIntraShiftFunction_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJIntraShiftFunction >,

--- a/wrapper/MM/CLJNBPairs.pypp.cpp
+++ b/wrapper/MM/CLJNBPairs.pypp.cpp
@@ -19,6 +19,8 @@ namespace bp = boost::python;
 
 SireMM::CLJNBPairs __copy__(const SireMM::CLJNBPairs &other){ return SireMM::CLJNBPairs(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -83,7 +85,7 @@ void register_CLJNBPairs_class(){
                 "merge"
                 , merge_function_value
                 , ( bp::arg("other"), bp::arg("mapping"), bp::arg("ghost")=::QString( ), bp::arg("map")=SireBase::PropertyMap() )
-                , "" );
+                , "Merge this property with another property" );
         
         }
         { //::SireMM::CLJNBPairs::nExcludedAtoms
@@ -151,9 +153,9 @@ void register_CLJNBPairs_class(){
         
         }
         CLJNBPairs_exposer.staticmethod( "typeName" );
-        CLJNBPairs_exposer.def( "__copy__", &__copy__);
-        CLJNBPairs_exposer.def( "__deepcopy__", &__copy__);
-        CLJNBPairs_exposer.def( "clone", &__copy__);
+        CLJNBPairs_exposer.def( "__copy__", &__copy__<SireMM::CLJNBPairs>);
+        CLJNBPairs_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJNBPairs>);
+        CLJNBPairs_exposer.def( "clone", &__copy__<SireMM::CLJNBPairs>);
         CLJNBPairs_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJNBPairs >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJNBPairs_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJNBPairs >,

--- a/wrapper/MM/CLJParameterNames.pypp.cpp
+++ b/wrapper/MM/CLJParameterNames.pypp.cpp
@@ -43,6 +43,8 @@ namespace bp = boost::python;
 
 SireMM::CLJParameterNames __copy__(const SireMM::CLJParameterNames &other){ return SireMM::CLJParameterNames(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::CLJParameterNames&){ return "SireMM::CLJParameterNames";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -53,9 +55,9 @@ void register_CLJParameterNames_class(){
         typedef bp::class_< SireMM::CLJParameterNames, bp::bases< SireMM::LJParameterName, SireMM::ChargeParameterName > > CLJParameterNames_exposer_t;
         CLJParameterNames_exposer_t CLJParameterNames_exposer = CLJParameterNames_exposer_t( "CLJParameterNames", "This class provides the default name of the properties\nthat contain the charge and LJ parameters", bp::init< >("") );
         bp::scope CLJParameterNames_scope( CLJParameterNames_exposer );
-        CLJParameterNames_exposer.def( "__copy__", &__copy__);
-        CLJParameterNames_exposer.def( "__deepcopy__", &__copy__);
-        CLJParameterNames_exposer.def( "clone", &__copy__);
+        CLJParameterNames_exposer.def( "__copy__", &__copy__<SireMM::CLJParameterNames>);
+        CLJParameterNames_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJParameterNames>);
+        CLJParameterNames_exposer.def( "clone", &__copy__<SireMM::CLJParameterNames>);
         CLJParameterNames_exposer.def( "__str__", &pvt_get_name);
         CLJParameterNames_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/CLJParameterNames3D.pypp.cpp
+++ b/wrapper/MM/CLJParameterNames3D.pypp.cpp
@@ -43,6 +43,8 @@ namespace bp = boost::python;
 
 SireMM::CLJParameterNames3D __copy__(const SireMM::CLJParameterNames3D &other){ return SireMM::CLJParameterNames3D(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::CLJParameterNames3D&){ return "SireMM::CLJParameterNames3D";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -53,9 +55,9 @@ void register_CLJParameterNames3D_class(){
         typedef bp::class_< SireMM::CLJParameterNames3D, bp::bases< SireMM::CLJParameterNames, SireMM::LJParameterName, SireMM::ChargeParameterName > > CLJParameterNames3D_exposer_t;
         CLJParameterNames3D_exposer_t CLJParameterNames3D_exposer = CLJParameterNames3D_exposer_t( "CLJParameterNames3D", "This class provides the default name of the properties\nthat contain the charge, LJ and 3D coordinates properties", bp::init< >("") );
         bp::scope CLJParameterNames3D_scope( CLJParameterNames3D_exposer );
-        CLJParameterNames3D_exposer.def( "__copy__", &__copy__);
-        CLJParameterNames3D_exposer.def( "__deepcopy__", &__copy__);
-        CLJParameterNames3D_exposer.def( "clone", &__copy__);
+        CLJParameterNames3D_exposer.def( "__copy__", &__copy__<SireMM::CLJParameterNames3D>);
+        CLJParameterNames3D_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJParameterNames3D>);
+        CLJParameterNames3D_exposer.def( "clone", &__copy__<SireMM::CLJParameterNames3D>);
         CLJParameterNames3D_exposer.def( "__str__", &pvt_get_name);
         CLJParameterNames3D_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/CLJProbe.pypp.cpp
+++ b/wrapper/MM/CLJProbe.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireMM::CLJProbe __copy__(const SireMM::CLJProbe &other){ return SireMM::CLJProbe(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -100,9 +102,9 @@ void register_CLJProbe_class(){
         
         }
         CLJProbe_exposer.staticmethod( "typeName" );
-        CLJProbe_exposer.def( "__copy__", &__copy__);
-        CLJProbe_exposer.def( "__deepcopy__", &__copy__);
-        CLJProbe_exposer.def( "clone", &__copy__);
+        CLJProbe_exposer.def( "__copy__", &__copy__<SireMM::CLJProbe>);
+        CLJProbe_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJProbe>);
+        CLJProbe_exposer.def( "clone", &__copy__<SireMM::CLJProbe>);
         CLJProbe_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJProbe >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJProbe_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJProbe >,

--- a/wrapper/MM/CLJRFFunction.pypp.cpp
+++ b/wrapper/MM/CLJRFFunction.pypp.cpp
@@ -35,6 +35,8 @@ namespace bp = boost::python;
 
 SireMM::CLJRFFunction __copy__(const SireMM::CLJRFFunction &other){ return SireMM::CLJRFFunction(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -210,9 +212,9 @@ void register_CLJRFFunction_class(){
         }
         CLJRFFunction_exposer.staticmethod( "defaultRFFunction" );
         CLJRFFunction_exposer.staticmethod( "typeName" );
-        CLJRFFunction_exposer.def( "__copy__", &__copy__);
-        CLJRFFunction_exposer.def( "__deepcopy__", &__copy__);
-        CLJRFFunction_exposer.def( "clone", &__copy__);
+        CLJRFFunction_exposer.def( "__copy__", &__copy__<SireMM::CLJRFFunction>);
+        CLJRFFunction_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJRFFunction>);
+        CLJRFFunction_exposer.def( "clone", &__copy__<SireMM::CLJRFFunction>);
         CLJRFFunction_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJRFFunction >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJRFFunction_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJRFFunction >,

--- a/wrapper/MM/CLJScaleFactor.pypp.cpp
+++ b/wrapper/MM/CLJScaleFactor.pypp.cpp
@@ -19,6 +19,8 @@ namespace bp = boost::python;
 
 SireMM::CLJScaleFactor __copy__(const SireMM::CLJScaleFactor &other){ return SireMM::CLJScaleFactor(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -85,9 +87,9 @@ void register_CLJScaleFactor_class(){
         
         }
         CLJScaleFactor_exposer.staticmethod( "typeName" );
-        CLJScaleFactor_exposer.def( "__copy__", &__copy__);
-        CLJScaleFactor_exposer.def( "__deepcopy__", &__copy__);
-        CLJScaleFactor_exposer.def( "clone", &__copy__);
+        CLJScaleFactor_exposer.def( "__copy__", &__copy__<SireMM::CLJScaleFactor>);
+        CLJScaleFactor_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJScaleFactor>);
+        CLJScaleFactor_exposer.def( "clone", &__copy__<SireMM::CLJScaleFactor>);
         CLJScaleFactor_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJScaleFactor >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJScaleFactor_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJScaleFactor >,

--- a/wrapper/MM/CLJShiftFunction.pypp.cpp
+++ b/wrapper/MM/CLJShiftFunction.pypp.cpp
@@ -33,6 +33,8 @@ namespace bp = boost::python;
 
 SireMM::CLJShiftFunction __copy__(const SireMM::CLJShiftFunction &other){ return SireMM::CLJShiftFunction(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -132,9 +134,9 @@ void register_CLJShiftFunction_class(){
         }
         CLJShiftFunction_exposer.staticmethod( "defaultShiftFunction" );
         CLJShiftFunction_exposer.staticmethod( "typeName" );
-        CLJShiftFunction_exposer.def( "__copy__", &__copy__);
-        CLJShiftFunction_exposer.def( "__deepcopy__", &__copy__);
-        CLJShiftFunction_exposer.def( "clone", &__copy__);
+        CLJShiftFunction_exposer.def( "__copy__", &__copy__<SireMM::CLJShiftFunction>);
+        CLJShiftFunction_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJShiftFunction>);
+        CLJShiftFunction_exposer.def( "clone", &__copy__<SireMM::CLJShiftFunction>);
         CLJShiftFunction_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJShiftFunction >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJShiftFunction_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJShiftFunction >,

--- a/wrapper/MM/CLJSoftIntraRFFunction.pypp.cpp
+++ b/wrapper/MM/CLJSoftIntraRFFunction.pypp.cpp
@@ -35,6 +35,8 @@ namespace bp = boost::python;
 
 SireMM::CLJSoftIntraRFFunction __copy__(const SireMM::CLJSoftIntraRFFunction &other){ return SireMM::CLJSoftIntraRFFunction(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -186,9 +188,9 @@ void register_CLJSoftIntraRFFunction_class(){
         }
         CLJSoftIntraRFFunction_exposer.staticmethod( "defaultRFFunction" );
         CLJSoftIntraRFFunction_exposer.staticmethod( "typeName" );
-        CLJSoftIntraRFFunction_exposer.def( "__copy__", &__copy__);
-        CLJSoftIntraRFFunction_exposer.def( "__deepcopy__", &__copy__);
-        CLJSoftIntraRFFunction_exposer.def( "clone", &__copy__);
+        CLJSoftIntraRFFunction_exposer.def( "__copy__", &__copy__<SireMM::CLJSoftIntraRFFunction>);
+        CLJSoftIntraRFFunction_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJSoftIntraRFFunction>);
+        CLJSoftIntraRFFunction_exposer.def( "clone", &__copy__<SireMM::CLJSoftIntraRFFunction>);
         CLJSoftIntraRFFunction_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJSoftIntraRFFunction >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJSoftIntraRFFunction_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJSoftIntraRFFunction >,

--- a/wrapper/MM/CLJSoftIntraShiftFunction.pypp.cpp
+++ b/wrapper/MM/CLJSoftIntraShiftFunction.pypp.cpp
@@ -33,6 +33,8 @@ namespace bp = boost::python;
 
 SireMM::CLJSoftIntraShiftFunction __copy__(const SireMM::CLJSoftIntraShiftFunction &other){ return SireMM::CLJSoftIntraShiftFunction(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -108,9 +110,9 @@ void register_CLJSoftIntraShiftFunction_class(){
         }
         CLJSoftIntraShiftFunction_exposer.staticmethod( "defaultShiftFunction" );
         CLJSoftIntraShiftFunction_exposer.staticmethod( "typeName" );
-        CLJSoftIntraShiftFunction_exposer.def( "__copy__", &__copy__);
-        CLJSoftIntraShiftFunction_exposer.def( "__deepcopy__", &__copy__);
-        CLJSoftIntraShiftFunction_exposer.def( "clone", &__copy__);
+        CLJSoftIntraShiftFunction_exposer.def( "__copy__", &__copy__<SireMM::CLJSoftIntraShiftFunction>);
+        CLJSoftIntraShiftFunction_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJSoftIntraShiftFunction>);
+        CLJSoftIntraShiftFunction_exposer.def( "clone", &__copy__<SireMM::CLJSoftIntraShiftFunction>);
         CLJSoftIntraShiftFunction_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJSoftIntraShiftFunction >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJSoftIntraShiftFunction_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJSoftIntraShiftFunction >,

--- a/wrapper/MM/CLJSoftRFFunction.pypp.cpp
+++ b/wrapper/MM/CLJSoftRFFunction.pypp.cpp
@@ -35,6 +35,8 @@ namespace bp = boost::python;
 
 SireMM::CLJSoftRFFunction __copy__(const SireMM::CLJSoftRFFunction &other){ return SireMM::CLJSoftRFFunction(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -198,9 +200,9 @@ void register_CLJSoftRFFunction_class(){
         }
         CLJSoftRFFunction_exposer.staticmethod( "defaultRFFunction" );
         CLJSoftRFFunction_exposer.staticmethod( "typeName" );
-        CLJSoftRFFunction_exposer.def( "__copy__", &__copy__);
-        CLJSoftRFFunction_exposer.def( "__deepcopy__", &__copy__);
-        CLJSoftRFFunction_exposer.def( "clone", &__copy__);
+        CLJSoftRFFunction_exposer.def( "__copy__", &__copy__<SireMM::CLJSoftRFFunction>);
+        CLJSoftRFFunction_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJSoftRFFunction>);
+        CLJSoftRFFunction_exposer.def( "clone", &__copy__<SireMM::CLJSoftRFFunction>);
         CLJSoftRFFunction_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJSoftRFFunction >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJSoftRFFunction_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJSoftRFFunction >,

--- a/wrapper/MM/CLJSoftShiftFunction.pypp.cpp
+++ b/wrapper/MM/CLJSoftShiftFunction.pypp.cpp
@@ -33,6 +33,8 @@ namespace bp = boost::python;
 
 SireMM::CLJSoftShiftFunction __copy__(const SireMM::CLJSoftShiftFunction &other){ return SireMM::CLJSoftShiftFunction(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -120,9 +122,9 @@ void register_CLJSoftShiftFunction_class(){
         }
         CLJSoftShiftFunction_exposer.staticmethod( "defaultShiftFunction" );
         CLJSoftShiftFunction_exposer.staticmethod( "typeName" );
-        CLJSoftShiftFunction_exposer.def( "__copy__", &__copy__);
-        CLJSoftShiftFunction_exposer.def( "__deepcopy__", &__copy__);
-        CLJSoftShiftFunction_exposer.def( "clone", &__copy__);
+        CLJSoftShiftFunction_exposer.def( "__copy__", &__copy__<SireMM::CLJSoftShiftFunction>);
+        CLJSoftShiftFunction_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJSoftShiftFunction>);
+        CLJSoftShiftFunction_exposer.def( "clone", &__copy__<SireMM::CLJSoftShiftFunction>);
         CLJSoftShiftFunction_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJSoftShiftFunction >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJSoftShiftFunction_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJSoftShiftFunction >,

--- a/wrapper/MM/CLJWorkspace.pypp.cpp
+++ b/wrapper/MM/CLJWorkspace.pypp.cpp
@@ -23,6 +23,8 @@ namespace bp = boost::python;
 
 SireMM::CLJWorkspace __copy__(const SireMM::CLJWorkspace &other){ return SireMM::CLJWorkspace(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -351,9 +353,9 @@ void register_CLJWorkspace_class(){
         
         }
         CLJWorkspace_exposer.staticmethod( "typeName" );
-        CLJWorkspace_exposer.def( "__copy__", &__copy__);
-        CLJWorkspace_exposer.def( "__deepcopy__", &__copy__);
-        CLJWorkspace_exposer.def( "clone", &__copy__);
+        CLJWorkspace_exposer.def( "__copy__", &__copy__<SireMM::CLJWorkspace>);
+        CLJWorkspace_exposer.def( "__deepcopy__", &__copy__<SireMM::CLJWorkspace>);
+        CLJWorkspace_exposer.def( "clone", &__copy__<SireMM::CLJWorkspace>);
         CLJWorkspace_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CLJWorkspace >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CLJWorkspace_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CLJWorkspace >,

--- a/wrapper/MM/ChargeParameterName.pypp.cpp
+++ b/wrapper/MM/ChargeParameterName.pypp.cpp
@@ -41,6 +41,8 @@ namespace bp = boost::python;
 
 SireMM::ChargeParameterName __copy__(const SireMM::ChargeParameterName &other){ return SireMM::ChargeParameterName(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::ChargeParameterName&){ return "SireMM::ChargeParameterName";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -63,9 +65,9 @@ void register_ChargeParameterName_class(){
                 , "" );
         
         }
-        ChargeParameterName_exposer.def( "__copy__", &__copy__);
-        ChargeParameterName_exposer.def( "__deepcopy__", &__copy__);
-        ChargeParameterName_exposer.def( "clone", &__copy__);
+        ChargeParameterName_exposer.def( "__copy__", &__copy__<SireMM::ChargeParameterName>);
+        ChargeParameterName_exposer.def( "__deepcopy__", &__copy__<SireMM::ChargeParameterName>);
+        ChargeParameterName_exposer.def( "clone", &__copy__<SireMM::ChargeParameterName>);
         ChargeParameterName_exposer.def( "__str__", &pvt_get_name);
         ChargeParameterName_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/ChargeParameterName3D.pypp.cpp
+++ b/wrapper/MM/ChargeParameterName3D.pypp.cpp
@@ -41,6 +41,8 @@ namespace bp = boost::python;
 
 SireMM::ChargeParameterName3D __copy__(const SireMM::ChargeParameterName3D &other){ return SireMM::ChargeParameterName3D(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::ChargeParameterName3D&){ return "SireMM::ChargeParameterName3D";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -51,9 +53,9 @@ void register_ChargeParameterName3D_class(){
         typedef bp::class_< SireMM::ChargeParameterName3D, bp::bases< SireMM::ChargeParameterName > > ChargeParameterName3D_exposer_t;
         ChargeParameterName3D_exposer_t ChargeParameterName3D_exposer = ChargeParameterName3D_exposer_t( "ChargeParameterName3D", "This class provides the default name of the properties\nthat contain the charge, LJ and 3D coordinates properties", bp::init< >("") );
         bp::scope ChargeParameterName3D_scope( ChargeParameterName3D_exposer );
-        ChargeParameterName3D_exposer.def( "__copy__", &__copy__);
-        ChargeParameterName3D_exposer.def( "__deepcopy__", &__copy__);
-        ChargeParameterName3D_exposer.def( "clone", &__copy__);
+        ChargeParameterName3D_exposer.def( "__copy__", &__copy__<SireMM::ChargeParameterName3D>);
+        ChargeParameterName3D_exposer.def( "__deepcopy__", &__copy__<SireMM::ChargeParameterName3D>);
+        ChargeParameterName3D_exposer.def( "clone", &__copy__<SireMM::ChargeParameterName3D>);
         ChargeParameterName3D_exposer.def( "__str__", &pvt_get_name);
         ChargeParameterName3D_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/CoulombComponent.pypp.cpp
+++ b/wrapper/MM/CoulombComponent.pypp.cpp
@@ -16,6 +16,8 @@ namespace bp = boost::python;
 
 SireMM::CoulombComponent __copy__(const SireMM::CoulombComponent &other){ return SireMM::CoulombComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -106,9 +108,9 @@ void register_CoulombComponent_class(){
         
         }
         CoulombComponent_exposer.staticmethod( "typeName" );
-        CoulombComponent_exposer.def( "__copy__", &__copy__);
-        CoulombComponent_exposer.def( "__deepcopy__", &__copy__);
-        CoulombComponent_exposer.def( "clone", &__copy__);
+        CoulombComponent_exposer.def( "__copy__", &__copy__<SireMM::CoulombComponent>);
+        CoulombComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::CoulombComponent>);
+        CoulombComponent_exposer.def( "clone", &__copy__<SireMM::CoulombComponent>);
         CoulombComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CoulombComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CoulombComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CoulombComponent >,

--- a/wrapper/MM/CoulombNBPairs.pypp.cpp
+++ b/wrapper/MM/CoulombNBPairs.pypp.cpp
@@ -19,6 +19,8 @@ namespace bp = boost::python;
 
 SireMM::CoulombNBPairs __copy__(const SireMM::CoulombNBPairs &other){ return SireMM::CoulombNBPairs(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -76,9 +78,9 @@ void register_CoulombNBPairs_class(){
         
         }
         CoulombNBPairs_exposer.staticmethod( "typeName" );
-        CoulombNBPairs_exposer.def( "__copy__", &__copy__);
-        CoulombNBPairs_exposer.def( "__deepcopy__", &__copy__);
-        CoulombNBPairs_exposer.def( "clone", &__copy__);
+        CoulombNBPairs_exposer.def( "__copy__", &__copy__<SireMM::CoulombNBPairs>);
+        CoulombNBPairs_exposer.def( "__deepcopy__", &__copy__<SireMM::CoulombNBPairs>);
+        CoulombNBPairs_exposer.def( "clone", &__copy__<SireMM::CoulombNBPairs>);
         CoulombNBPairs_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CoulombNBPairs >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CoulombNBPairs_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CoulombNBPairs >,

--- a/wrapper/MM/CoulombProbe.pypp.cpp
+++ b/wrapper/MM/CoulombProbe.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireMM::CoulombProbe __copy__(const SireMM::CoulombProbe &other){ return SireMM::CoulombProbe(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -85,9 +87,9 @@ void register_CoulombProbe_class(){
         
         }
         CoulombProbe_exposer.staticmethod( "typeName" );
-        CoulombProbe_exposer.def( "__copy__", &__copy__);
-        CoulombProbe_exposer.def( "__deepcopy__", &__copy__);
-        CoulombProbe_exposer.def( "clone", &__copy__);
+        CoulombProbe_exposer.def( "__copy__", &__copy__<SireMM::CoulombProbe>);
+        CoulombProbe_exposer.def( "__deepcopy__", &__copy__<SireMM::CoulombProbe>);
+        CoulombProbe_exposer.def( "clone", &__copy__<SireMM::CoulombProbe>);
         CoulombProbe_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CoulombProbe >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CoulombProbe_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CoulombProbe >,

--- a/wrapper/MM/CoulombScaleFactor.pypp.cpp
+++ b/wrapper/MM/CoulombScaleFactor.pypp.cpp
@@ -19,6 +19,8 @@ namespace bp = boost::python;
 
 SireMM::CoulombScaleFactor __copy__(const SireMM::CoulombScaleFactor &other){ return SireMM::CoulombScaleFactor(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 const char* pvt_get_name(const SireMM::CoulombScaleFactor&){ return "SireMM::CoulombScaleFactor";}
@@ -84,9 +86,9 @@ void register_CoulombScaleFactor_class(){
         
         }
         CoulombScaleFactor_exposer.staticmethod( "typeName" );
-        CoulombScaleFactor_exposer.def( "__copy__", &__copy__);
-        CoulombScaleFactor_exposer.def( "__deepcopy__", &__copy__);
-        CoulombScaleFactor_exposer.def( "clone", &__copy__);
+        CoulombScaleFactor_exposer.def( "__copy__", &__copy__<SireMM::CoulombScaleFactor>);
+        CoulombScaleFactor_exposer.def( "__deepcopy__", &__copy__<SireMM::CoulombScaleFactor>);
+        CoulombScaleFactor_exposer.def( "clone", &__copy__<SireMM::CoulombScaleFactor>);
         CoulombScaleFactor_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::CoulombScaleFactor >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         CoulombScaleFactor_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::CoulombScaleFactor >,

--- a/wrapper/MM/Dihedral.pypp.cpp
+++ b/wrapper/MM/Dihedral.pypp.cpp
@@ -42,6 +42,8 @@ namespace bp = boost::python;
 
 SireMM::Dihedral __copy__(const SireMM::Dihedral &other){ return SireMM::Dihedral(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -483,9 +485,9 @@ void register_Dihedral_class(){
         
         }
         Dihedral_exposer.staticmethod( "typeName" );
-        Dihedral_exposer.def( "__copy__", &__copy__);
-        Dihedral_exposer.def( "__deepcopy__", &__copy__);
-        Dihedral_exposer.def( "clone", &__copy__);
+        Dihedral_exposer.def( "__copy__", &__copy__<SireMM::Dihedral>);
+        Dihedral_exposer.def( "__deepcopy__", &__copy__<SireMM::Dihedral>);
+        Dihedral_exposer.def( "clone", &__copy__<SireMM::Dihedral>);
         Dihedral_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::Dihedral >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         Dihedral_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::Dihedral >,

--- a/wrapper/MM/DihedralComponent.pypp.cpp
+++ b/wrapper/MM/DihedralComponent.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireMM::DihedralComponent __copy__(const SireMM::DihedralComponent &other){ return SireMM::DihedralComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -107,9 +109,9 @@ void register_DihedralComponent_class(){
         
         }
         DihedralComponent_exposer.staticmethod( "typeName" );
-        DihedralComponent_exposer.def( "__copy__", &__copy__);
-        DihedralComponent_exposer.def( "__deepcopy__", &__copy__);
-        DihedralComponent_exposer.def( "clone", &__copy__);
+        DihedralComponent_exposer.def( "__copy__", &__copy__<SireMM::DihedralComponent>);
+        DihedralComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::DihedralComponent>);
+        DihedralComponent_exposer.def( "clone", &__copy__<SireMM::DihedralComponent>);
         DihedralComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::DihedralComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         DihedralComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::DihedralComponent >,

--- a/wrapper/MM/DihedralParameterName.pypp.cpp
+++ b/wrapper/MM/DihedralParameterName.pypp.cpp
@@ -49,6 +49,8 @@ namespace bp = boost::python;
 
 SireMM::DihedralParameterName __copy__(const SireMM::DihedralParameterName &other){ return SireMM::DihedralParameterName(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::DihedralParameterName&){ return "SireMM::DihedralParameterName";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -71,9 +73,9 @@ void register_DihedralParameterName_class(){
                 , "" );
         
         }
-        DihedralParameterName_exposer.def( "__copy__", &__copy__);
-        DihedralParameterName_exposer.def( "__deepcopy__", &__copy__);
-        DihedralParameterName_exposer.def( "clone", &__copy__);
+        DihedralParameterName_exposer.def( "__copy__", &__copy__<SireMM::DihedralParameterName>);
+        DihedralParameterName_exposer.def( "__deepcopy__", &__copy__<SireMM::DihedralParameterName>);
+        DihedralParameterName_exposer.def( "clone", &__copy__<SireMM::DihedralParameterName>);
         DihedralParameterName_exposer.def( "__str__", &pvt_get_name);
         DihedralParameterName_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/DihedralRestraint.pypp.cpp
+++ b/wrapper/MM/DihedralRestraint.pypp.cpp
@@ -36,6 +36,8 @@ namespace bp = boost::python;
 
 SireMM::DihedralRestraint __copy__(const SireMM::DihedralRestraint &other){ return SireMM::DihedralRestraint(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -369,9 +371,9 @@ void register_DihedralRestraint_class(){
         DihedralRestraint_exposer.staticmethod( "harmonic" );
         DihedralRestraint_exposer.staticmethod( "phi" );
         DihedralRestraint_exposer.staticmethod( "typeName" );
-        DihedralRestraint_exposer.def( "__copy__", &__copy__);
-        DihedralRestraint_exposer.def( "__deepcopy__", &__copy__);
-        DihedralRestraint_exposer.def( "clone", &__copy__);
+        DihedralRestraint_exposer.def( "__copy__", &__copy__<SireMM::DihedralRestraint>);
+        DihedralRestraint_exposer.def( "__deepcopy__", &__copy__<SireMM::DihedralRestraint>);
+        DihedralRestraint_exposer.def( "clone", &__copy__<SireMM::DihedralRestraint>);
         DihedralRestraint_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::DihedralRestraint >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         DihedralRestraint_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::DihedralRestraint >,

--- a/wrapper/MM/DihedralSymbols.pypp.cpp
+++ b/wrapper/MM/DihedralSymbols.pypp.cpp
@@ -34,6 +34,8 @@ namespace bp = boost::python;
 
 SireMM::DihedralSymbols __copy__(const SireMM::DihedralSymbols &other){ return SireMM::DihedralSymbols(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::DihedralSymbols&){ return "SireMM::DihedralSymbols";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -56,9 +58,9 @@ void register_DihedralSymbols_class(){
                 , "Return the symbol representing the torsion (phi)" );
         
         }
-        DihedralSymbols_exposer.def( "__copy__", &__copy__);
-        DihedralSymbols_exposer.def( "__deepcopy__", &__copy__);
-        DihedralSymbols_exposer.def( "clone", &__copy__);
+        DihedralSymbols_exposer.def( "__copy__", &__copy__<SireMM::DihedralSymbols>);
+        DihedralSymbols_exposer.def( "__deepcopy__", &__copy__<SireMM::DihedralSymbols>);
+        DihedralSymbols_exposer.def( "clone", &__copy__<SireMM::DihedralSymbols>);
         DihedralSymbols_exposer.def( "__str__", &pvt_get_name);
         DihedralSymbols_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/DistanceRestraint.pypp.cpp
+++ b/wrapper/MM/DistanceRestraint.pypp.cpp
@@ -32,6 +32,8 @@ namespace bp = boost::python;
 
 SireMM::DistanceRestraint __copy__(const SireMM::DistanceRestraint &other){ return SireMM::DistanceRestraint(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -341,9 +343,9 @@ void register_DistanceRestraint_class(){
         DistanceRestraint_exposer.staticmethod( "harmonic" );
         DistanceRestraint_exposer.staticmethod( "r" );
         DistanceRestraint_exposer.staticmethod( "typeName" );
-        DistanceRestraint_exposer.def( "__copy__", &__copy__);
-        DistanceRestraint_exposer.def( "__deepcopy__", &__copy__);
-        DistanceRestraint_exposer.def( "clone", &__copy__);
+        DistanceRestraint_exposer.def( "__copy__", &__copy__<SireMM::DistanceRestraint>);
+        DistanceRestraint_exposer.def( "__deepcopy__", &__copy__<SireMM::DistanceRestraint>);
+        DistanceRestraint_exposer.def( "clone", &__copy__<SireMM::DistanceRestraint>);
         DistanceRestraint_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::DistanceRestraint >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         DistanceRestraint_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::DistanceRestraint >,

--- a/wrapper/MM/DoubleDistanceRestraint.pypp.cpp
+++ b/wrapper/MM/DoubleDistanceRestraint.pypp.cpp
@@ -32,6 +32,8 @@ namespace bp = boost::python;
 
 SireMM::DoubleDistanceRestraint __copy__(const SireMM::DoubleDistanceRestraint &other){ return SireMM::DoubleDistanceRestraint(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -362,9 +364,9 @@ void register_DoubleDistanceRestraint_class(){
         DoubleDistanceRestraint_exposer.staticmethod( "r01" );
         DoubleDistanceRestraint_exposer.staticmethod( "r23" );
         DoubleDistanceRestraint_exposer.staticmethod( "typeName" );
-        DoubleDistanceRestraint_exposer.def( "__copy__", &__copy__);
-        DoubleDistanceRestraint_exposer.def( "__deepcopy__", &__copy__);
-        DoubleDistanceRestraint_exposer.def( "clone", &__copy__);
+        DoubleDistanceRestraint_exposer.def( "__copy__", &__copy__<SireMM::DoubleDistanceRestraint>);
+        DoubleDistanceRestraint_exposer.def( "__deepcopy__", &__copy__<SireMM::DoubleDistanceRestraint>);
+        DoubleDistanceRestraint_exposer.def( "clone", &__copy__<SireMM::DoubleDistanceRestraint>);
         DoubleDistanceRestraint_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::DoubleDistanceRestraint >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         DoubleDistanceRestraint_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::DoubleDistanceRestraint >,

--- a/wrapper/MM/ExcludedPairs.pypp.cpp
+++ b/wrapper/MM/ExcludedPairs.pypp.cpp
@@ -19,6 +19,8 @@ namespace bp = boost::python;
 
 SireMM::ExcludedPairs __copy__(const SireMM::ExcludedPairs &other){ return SireMM::ExcludedPairs(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -199,9 +201,9 @@ void register_ExcludedPairs_class(){
         
         }
         ExcludedPairs_exposer.staticmethod( "typeName" );
-        ExcludedPairs_exposer.def( "__copy__", &__copy__);
-        ExcludedPairs_exposer.def( "__deepcopy__", &__copy__);
-        ExcludedPairs_exposer.def( "clone", &__copy__);
+        ExcludedPairs_exposer.def( "__copy__", &__copy__<SireMM::ExcludedPairs>);
+        ExcludedPairs_exposer.def( "__deepcopy__", &__copy__<SireMM::ExcludedPairs>);
+        ExcludedPairs_exposer.def( "clone", &__copy__<SireMM::ExcludedPairs>);
         ExcludedPairs_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::ExcludedPairs >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         ExcludedPairs_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::ExcludedPairs >,

--- a/wrapper/MM/FourAtomFunction.pypp.cpp
+++ b/wrapper/MM/FourAtomFunction.pypp.cpp
@@ -34,6 +34,8 @@ namespace bp = boost::python;
 
 SireMM::FourAtomFunction __copy__(const SireMM::FourAtomFunction &other){ return SireMM::FourAtomFunction(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -123,9 +125,9 @@ void register_FourAtomFunction_class(){
                 , "Return a string representation" );
         
         }
-        FourAtomFunction_exposer.def( "__copy__", &__copy__);
-        FourAtomFunction_exposer.def( "__deepcopy__", &__copy__);
-        FourAtomFunction_exposer.def( "clone", &__copy__);
+        FourAtomFunction_exposer.def( "__copy__", &__copy__<SireMM::FourAtomFunction>);
+        FourAtomFunction_exposer.def( "__deepcopy__", &__copy__<SireMM::FourAtomFunction>);
+        FourAtomFunction_exposer.def( "clone", &__copy__<SireMM::FourAtomFunction>);
         FourAtomFunction_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::FourAtomFunction >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         FourAtomFunction_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::FourAtomFunction >,

--- a/wrapper/MM/FourAtomFunctions.pypp.cpp
+++ b/wrapper/MM/FourAtomFunctions.pypp.cpp
@@ -35,6 +35,8 @@ namespace bp = boost::python;
 
 SireMM::FourAtomFunctions __copy__(const SireMM::FourAtomFunctions &other){ return SireMM::FourAtomFunctions(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -446,9 +448,9 @@ void register_FourAtomFunctions_class(){
         
         }
         FourAtomFunctions_exposer.staticmethod( "typeName" );
-        FourAtomFunctions_exposer.def( "__copy__", &__copy__);
-        FourAtomFunctions_exposer.def( "__deepcopy__", &__copy__);
-        FourAtomFunctions_exposer.def( "clone", &__copy__);
+        FourAtomFunctions_exposer.def( "__copy__", &__copy__<SireMM::FourAtomFunctions>);
+        FourAtomFunctions_exposer.def( "__deepcopy__", &__copy__<SireMM::FourAtomFunctions>);
+        FourAtomFunctions_exposer.def( "clone", &__copy__<SireMM::FourAtomFunctions>);
         FourAtomFunctions_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::FourAtomFunctions >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         FourAtomFunctions_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::FourAtomFunctions >,

--- a/wrapper/MM/FourAtomPerturbation.pypp.cpp
+++ b/wrapper/MM/FourAtomPerturbation.pypp.cpp
@@ -34,6 +34,8 @@ namespace bp = boost::python;
 
 SireMM::FourAtomPerturbation __copy__(const SireMM::FourAtomPerturbation &other){ return SireMM::FourAtomPerturbation(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -164,9 +166,9 @@ void register_FourAtomPerturbation_class(){
         
         }
         FourAtomPerturbation_exposer.staticmethod( "typeName" );
-        FourAtomPerturbation_exposer.def( "__copy__", &__copy__);
-        FourAtomPerturbation_exposer.def( "__deepcopy__", &__copy__);
-        FourAtomPerturbation_exposer.def( "clone", &__copy__);
+        FourAtomPerturbation_exposer.def( "__copy__", &__copy__<SireMM::FourAtomPerturbation>);
+        FourAtomPerturbation_exposer.def( "__deepcopy__", &__copy__<SireMM::FourAtomPerturbation>);
+        FourAtomPerturbation_exposer.def( "clone", &__copy__<SireMM::FourAtomPerturbation>);
         FourAtomPerturbation_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::FourAtomPerturbation >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         FourAtomPerturbation_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::FourAtomPerturbation >,

--- a/wrapper/MM/GridFF.pypp.cpp
+++ b/wrapper/MM/GridFF.pypp.cpp
@@ -35,6 +35,8 @@ namespace bp = boost::python;
 
 SireMM::GridFF __copy__(const SireMM::GridFF &other){ return SireMM::GridFF(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -291,9 +293,9 @@ void register_GridFF_class(){
         
         }
         GridFF_exposer.staticmethod( "typeName" );
-        GridFF_exposer.def( "__copy__", &__copy__);
-        GridFF_exposer.def( "__deepcopy__", &__copy__);
-        GridFF_exposer.def( "clone", &__copy__);
+        GridFF_exposer.def( "__copy__", &__copy__<SireMM::GridFF>);
+        GridFF_exposer.def( "__deepcopy__", &__copy__<SireMM::GridFF>);
+        GridFF_exposer.def( "clone", &__copy__<SireMM::GridFF>);
         GridFF_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::GridFF >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         GridFF_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::GridFF >,

--- a/wrapper/MM/GridFF2.pypp.cpp
+++ b/wrapper/MM/GridFF2.pypp.cpp
@@ -41,6 +41,8 @@ namespace bp = boost::python;
 
 SireMM::GridFF2 __copy__(const SireMM::GridFF2 &other){ return SireMM::GridFF2(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -297,9 +299,9 @@ void register_GridFF2_class(){
         
         }
         GridFF2_exposer.staticmethod( "typeName" );
-        GridFF2_exposer.def( "__copy__", &__copy__);
-        GridFF2_exposer.def( "__deepcopy__", &__copy__);
-        GridFF2_exposer.def( "clone", &__copy__);
+        GridFF2_exposer.def( "__copy__", &__copy__<SireMM::GridFF2>);
+        GridFF2_exposer.def( "__deepcopy__", &__copy__<SireMM::GridFF2>);
+        GridFF2_exposer.def( "clone", &__copy__<SireMM::GridFF2>);
         GridFF2_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::GridFF2 >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         GridFF2_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::GridFF2 >,

--- a/wrapper/MM/GromacsAngle.pypp.cpp
+++ b/wrapper/MM/GromacsAngle.pypp.cpp
@@ -35,6 +35,8 @@ namespace bp = boost::python;
 
 SireMM::GromacsAngle __copy__(const SireMM::GromacsAngle &other){ return SireMM::GromacsAngle(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -355,9 +357,9 @@ void register_GromacsAngle_class(){
         
         }
         GromacsAngle_exposer.staticmethod( "typeName" );
-        GromacsAngle_exposer.def( "__copy__", &__copy__);
-        GromacsAngle_exposer.def( "__deepcopy__", &__copy__);
-        GromacsAngle_exposer.def( "clone", &__copy__);
+        GromacsAngle_exposer.def( "__copy__", &__copy__<SireMM::GromacsAngle>);
+        GromacsAngle_exposer.def( "__deepcopy__", &__copy__<SireMM::GromacsAngle>);
+        GromacsAngle_exposer.def( "clone", &__copy__<SireMM::GromacsAngle>);
         GromacsAngle_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::GromacsAngle >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         GromacsAngle_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::GromacsAngle >,

--- a/wrapper/MM/GromacsAtomType.pypp.cpp
+++ b/wrapper/MM/GromacsAtomType.pypp.cpp
@@ -35,6 +35,8 @@ namespace bp = boost::python;
 
 SireMM::GromacsAtomType __copy__(const SireMM::GromacsAtomType &other){ return SireMM::GromacsAtomType(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -281,9 +283,9 @@ void register_GromacsAtomType_class(){
         }
         GromacsAtomType_exposer.staticmethod( "toParticleType" );
         GromacsAtomType_exposer.staticmethod( "typeName" );
-        GromacsAtomType_exposer.def( "__copy__", &__copy__);
-        GromacsAtomType_exposer.def( "__deepcopy__", &__copy__);
-        GromacsAtomType_exposer.def( "clone", &__copy__);
+        GromacsAtomType_exposer.def( "__copy__", &__copy__<SireMM::GromacsAtomType>);
+        GromacsAtomType_exposer.def( "__deepcopy__", &__copy__<SireMM::GromacsAtomType>);
+        GromacsAtomType_exposer.def( "clone", &__copy__<SireMM::GromacsAtomType>);
         GromacsAtomType_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::GromacsAtomType >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         GromacsAtomType_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::GromacsAtomType >,

--- a/wrapper/MM/GromacsBond.pypp.cpp
+++ b/wrapper/MM/GromacsBond.pypp.cpp
@@ -35,6 +35,8 @@ namespace bp = boost::python;
 
 SireMM::GromacsBond __copy__(const SireMM::GromacsBond &other){ return SireMM::GromacsBond(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -304,9 +306,9 @@ void register_GromacsBond_class(){
         
         }
         GromacsBond_exposer.staticmethod( "typeName" );
-        GromacsBond_exposer.def( "__copy__", &__copy__);
-        GromacsBond_exposer.def( "__deepcopy__", &__copy__);
-        GromacsBond_exposer.def( "clone", &__copy__);
+        GromacsBond_exposer.def( "__copy__", &__copy__<SireMM::GromacsBond>);
+        GromacsBond_exposer.def( "__deepcopy__", &__copy__<SireMM::GromacsBond>);
+        GromacsBond_exposer.def( "clone", &__copy__<SireMM::GromacsBond>);
         GromacsBond_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::GromacsBond >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         GromacsBond_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::GromacsBond >,

--- a/wrapper/MM/GromacsDihedral.pypp.cpp
+++ b/wrapper/MM/GromacsDihedral.pypp.cpp
@@ -35,6 +35,8 @@ namespace bp = boost::python;
 
 SireMM::GromacsDihedral __copy__(const SireMM::GromacsDihedral &other){ return SireMM::GromacsDihedral(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -358,9 +360,9 @@ void register_GromacsDihedral_class(){
         GromacsDihedral_exposer.staticmethod( "construct" );
         GromacsDihedral_exposer.staticmethod( "constructImproper" );
         GromacsDihedral_exposer.staticmethod( "typeName" );
-        GromacsDihedral_exposer.def( "__copy__", &__copy__);
-        GromacsDihedral_exposer.def( "__deepcopy__", &__copy__);
-        GromacsDihedral_exposer.def( "clone", &__copy__);
+        GromacsDihedral_exposer.def( "__copy__", &__copy__<SireMM::GromacsDihedral>);
+        GromacsDihedral_exposer.def( "__deepcopy__", &__copy__<SireMM::GromacsDihedral>);
+        GromacsDihedral_exposer.def( "clone", &__copy__<SireMM::GromacsDihedral>);
         GromacsDihedral_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::GromacsDihedral >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         GromacsDihedral_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::GromacsDihedral >,

--- a/wrapper/MM/GroupInternalParameters.pypp.cpp
+++ b/wrapper/MM/GroupInternalParameters.pypp.cpp
@@ -33,6 +33,8 @@ namespace bp = boost::python;
 
 SireMM::GroupInternalParameters __copy__(const SireMM::GroupInternalParameters &other){ return SireMM::GroupInternalParameters(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 const char* pvt_get_name(const SireMM::GroupInternalParameters&){ return "SireMM::GroupInternalParameters";}
@@ -643,9 +645,9 @@ void register_GroupInternalParameters_class(){
                 , "Return the Urey-Bradley potentials for this group" );
         
         }
-        GroupInternalParameters_exposer.def( "__copy__", &__copy__);
-        GroupInternalParameters_exposer.def( "__deepcopy__", &__copy__);
-        GroupInternalParameters_exposer.def( "clone", &__copy__);
+        GroupInternalParameters_exposer.def( "__copy__", &__copy__<SireMM::GroupInternalParameters>);
+        GroupInternalParameters_exposer.def( "__deepcopy__", &__copy__<SireMM::GroupInternalParameters>);
+        GroupInternalParameters_exposer.def( "clone", &__copy__<SireMM::GroupInternalParameters>);
         GroupInternalParameters_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::GroupInternalParameters >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         GroupInternalParameters_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::GroupInternalParameters >,

--- a/wrapper/MM/HarmonicSwitchingFunction.pypp.cpp
+++ b/wrapper/MM/HarmonicSwitchingFunction.pypp.cpp
@@ -29,6 +29,8 @@ namespace bp = boost::python;
 
 SireMM::HarmonicSwitchingFunction __copy__(const SireMM::HarmonicSwitchingFunction &other){ return SireMM::HarmonicSwitchingFunction(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -138,9 +140,9 @@ void register_HarmonicSwitchingFunction_class(){
         
         }
         HarmonicSwitchingFunction_exposer.staticmethod( "typeName" );
-        HarmonicSwitchingFunction_exposer.def( "__copy__", &__copy__);
-        HarmonicSwitchingFunction_exposer.def( "__deepcopy__", &__copy__);
-        HarmonicSwitchingFunction_exposer.def( "clone", &__copy__);
+        HarmonicSwitchingFunction_exposer.def( "__copy__", &__copy__<SireMM::HarmonicSwitchingFunction>);
+        HarmonicSwitchingFunction_exposer.def( "__deepcopy__", &__copy__<SireMM::HarmonicSwitchingFunction>);
+        HarmonicSwitchingFunction_exposer.def( "clone", &__copy__<SireMM::HarmonicSwitchingFunction>);
         HarmonicSwitchingFunction_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::HarmonicSwitchingFunction >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         HarmonicSwitchingFunction_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::HarmonicSwitchingFunction >,

--- a/wrapper/MM/Improper.pypp.cpp
+++ b/wrapper/MM/Improper.pypp.cpp
@@ -44,6 +44,8 @@ namespace bp = boost::python;
 
 SireMM::Improper __copy__(const SireMM::Improper &other){ return SireMM::Improper(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -535,9 +537,9 @@ void register_Improper_class(){
         
         }
         Improper_exposer.staticmethod( "typeName" );
-        Improper_exposer.def( "__copy__", &__copy__);
-        Improper_exposer.def( "__deepcopy__", &__copy__);
-        Improper_exposer.def( "clone", &__copy__);
+        Improper_exposer.def( "__copy__", &__copy__<SireMM::Improper>);
+        Improper_exposer.def( "__deepcopy__", &__copy__<SireMM::Improper>);
+        Improper_exposer.def( "clone", &__copy__<SireMM::Improper>);
         Improper_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::Improper >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         Improper_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::Improper >,

--- a/wrapper/MM/ImproperComponent.pypp.cpp
+++ b/wrapper/MM/ImproperComponent.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireMM::ImproperComponent __copy__(const SireMM::ImproperComponent &other){ return SireMM::ImproperComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -107,9 +109,9 @@ void register_ImproperComponent_class(){
         
         }
         ImproperComponent_exposer.staticmethod( "typeName" );
-        ImproperComponent_exposer.def( "__copy__", &__copy__);
-        ImproperComponent_exposer.def( "__deepcopy__", &__copy__);
-        ImproperComponent_exposer.def( "clone", &__copy__);
+        ImproperComponent_exposer.def( "__copy__", &__copy__<SireMM::ImproperComponent>);
+        ImproperComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::ImproperComponent>);
+        ImproperComponent_exposer.def( "clone", &__copy__<SireMM::ImproperComponent>);
         ImproperComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::ImproperComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         ImproperComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::ImproperComponent >,

--- a/wrapper/MM/ImproperParameterName.pypp.cpp
+++ b/wrapper/MM/ImproperParameterName.pypp.cpp
@@ -49,6 +49,8 @@ namespace bp = boost::python;
 
 SireMM::ImproperParameterName __copy__(const SireMM::ImproperParameterName &other){ return SireMM::ImproperParameterName(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::ImproperParameterName&){ return "SireMM::ImproperParameterName";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -71,9 +73,9 @@ void register_ImproperParameterName_class(){
                 , "" );
         
         }
-        ImproperParameterName_exposer.def( "__copy__", &__copy__);
-        ImproperParameterName_exposer.def( "__deepcopy__", &__copy__);
-        ImproperParameterName_exposer.def( "clone", &__copy__);
+        ImproperParameterName_exposer.def( "__copy__", &__copy__<SireMM::ImproperParameterName>);
+        ImproperParameterName_exposer.def( "__deepcopy__", &__copy__<SireMM::ImproperParameterName>);
+        ImproperParameterName_exposer.def( "clone", &__copy__<SireMM::ImproperParameterName>);
         ImproperParameterName_exposer.def( "__str__", &pvt_get_name);
         ImproperParameterName_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/ImproperSymbols.pypp.cpp
+++ b/wrapper/MM/ImproperSymbols.pypp.cpp
@@ -34,6 +34,8 @@ namespace bp = boost::python;
 
 SireMM::ImproperSymbols __copy__(const SireMM::ImproperSymbols &other){ return SireMM::ImproperSymbols(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::ImproperSymbols&){ return "SireMM::ImproperSymbols";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -68,9 +70,9 @@ void register_ImproperSymbols_class(){
                 , "Return the symbol representing the angle between the improper\nand the plane formed by atoms 1-3" );
         
         }
-        ImproperSymbols_exposer.def( "__copy__", &__copy__);
-        ImproperSymbols_exposer.def( "__deepcopy__", &__copy__);
-        ImproperSymbols_exposer.def( "clone", &__copy__);
+        ImproperSymbols_exposer.def( "__copy__", &__copy__<SireMM::ImproperSymbols>);
+        ImproperSymbols_exposer.def( "__deepcopy__", &__copy__<SireMM::ImproperSymbols>);
+        ImproperSymbols_exposer.def( "clone", &__copy__<SireMM::ImproperSymbols>);
         ImproperSymbols_exposer.def( "__str__", &pvt_get_name);
         ImproperSymbols_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/InterCLJFF.pypp.cpp
+++ b/wrapper/MM/InterCLJFF.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireFF::Inter2B3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > __copy__(const SireFF::Inter2B3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > &other){ return SireFF::Inter2B3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -270,9 +272,9 @@ void register_InterCLJFF_class(){
         
         }
         InterCLJFF_exposer.staticmethod( "typeName" );
-        InterCLJFF_exposer.def( "__copy__", &__copy__);
-        InterCLJFF_exposer.def( "__deepcopy__", &__copy__);
-        InterCLJFF_exposer.def( "clone", &__copy__);
+        InterCLJFF_exposer.def( "__copy__", &__copy__<SireFF::Inter2B3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> >>);
+        InterCLJFF_exposer.def( "__deepcopy__", &__copy__<SireFF::Inter2B3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> >>);
+        InterCLJFF_exposer.def( "clone", &__copy__<SireFF::Inter2B3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> >>);
         InterCLJFF_exposer.def( "__str__", &__str__< ::SireFF::Inter2B3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > > );
         InterCLJFF_exposer.def( "__repr__", &__str__< ::SireFF::Inter2B3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > > );
         InterCLJFF_exposer.def( "__len__", &__len_count< ::SireFF::Inter2B3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > > );

--- a/wrapper/MM/InterCLJFFBase.pypp.cpp
+++ b/wrapper/MM/InterCLJFFBase.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireFF::Inter2BFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > __copy__(const SireFF::Inter2BFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > &other){ return SireFF::Inter2BFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -158,9 +160,9 @@ void register_InterCLJFFBase_class(){
         
         }
         InterCLJFFBase_exposer.staticmethod( "typeName" );
-        InterCLJFFBase_exposer.def( "__copy__", &__copy__);
-        InterCLJFFBase_exposer.def( "__deepcopy__", &__copy__);
-        InterCLJFFBase_exposer.def( "clone", &__copy__);
+        InterCLJFFBase_exposer.def( "__copy__", &__copy__<SireFF::Inter2BFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> >>);
+        InterCLJFFBase_exposer.def( "__deepcopy__", &__copy__<SireFF::Inter2BFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> >>);
+        InterCLJFFBase_exposer.def( "clone", &__copy__<SireFF::Inter2BFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> >>);
         InterCLJFFBase_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireFF::Inter2BFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         InterCLJFFBase_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireFF::Inter2BFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > >,

--- a/wrapper/MM/InterCoulombFF.pypp.cpp
+++ b/wrapper/MM/InterCoulombFF.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireFF::Inter2B3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > __copy__(const SireFF::Inter2B3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > &other){ return SireFF::Inter2B3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -270,9 +272,9 @@ void register_InterCoulombFF_class(){
         
         }
         InterCoulombFF_exposer.staticmethod( "typeName" );
-        InterCoulombFF_exposer.def( "__copy__", &__copy__);
-        InterCoulombFF_exposer.def( "__deepcopy__", &__copy__);
-        InterCoulombFF_exposer.def( "clone", &__copy__);
+        InterCoulombFF_exposer.def( "__copy__", &__copy__<SireFF::Inter2B3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> >>);
+        InterCoulombFF_exposer.def( "__deepcopy__", &__copy__<SireFF::Inter2B3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> >>);
+        InterCoulombFF_exposer.def( "clone", &__copy__<SireFF::Inter2B3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> >>);
         InterCoulombFF_exposer.def( "__str__", &__str__< ::SireFF::Inter2B3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > > );
         InterCoulombFF_exposer.def( "__repr__", &__str__< ::SireFF::Inter2B3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > > );
         InterCoulombFF_exposer.def( "__len__", &__len_count< ::SireFF::Inter2B3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > > );

--- a/wrapper/MM/InterCoulombFFBase.pypp.cpp
+++ b/wrapper/MM/InterCoulombFFBase.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireFF::Inter2BFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > __copy__(const SireFF::Inter2BFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > &other){ return SireFF::Inter2BFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -158,9 +160,9 @@ void register_InterCoulombFFBase_class(){
         
         }
         InterCoulombFFBase_exposer.staticmethod( "typeName" );
-        InterCoulombFFBase_exposer.def( "__copy__", &__copy__);
-        InterCoulombFFBase_exposer.def( "__deepcopy__", &__copy__);
-        InterCoulombFFBase_exposer.def( "clone", &__copy__);
+        InterCoulombFFBase_exposer.def( "__copy__", &__copy__<SireFF::Inter2BFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> >>);
+        InterCoulombFFBase_exposer.def( "__deepcopy__", &__copy__<SireFF::Inter2BFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> >>);
+        InterCoulombFFBase_exposer.def( "clone", &__copy__<SireFF::Inter2BFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> >>);
         InterCoulombFFBase_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireFF::Inter2BFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         InterCoulombFFBase_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireFF::Inter2BFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > >,

--- a/wrapper/MM/InterFF.pypp.cpp
+++ b/wrapper/MM/InterFF.pypp.cpp
@@ -54,6 +54,8 @@ namespace bp = boost::python;
 
 SireMM::InterFF __copy__(const SireMM::InterFF &other){ return SireMM::InterFF(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -629,9 +631,9 @@ void register_InterFF_class(){
         
         }
         InterFF_exposer.staticmethod( "typeName" );
-        InterFF_exposer.def( "__copy__", &__copy__);
-        InterFF_exposer.def( "__deepcopy__", &__copy__);
-        InterFF_exposer.def( "clone", &__copy__);
+        InterFF_exposer.def( "__copy__", &__copy__<SireMM::InterFF>);
+        InterFF_exposer.def( "__deepcopy__", &__copy__<SireMM::InterFF>);
+        InterFF_exposer.def( "clone", &__copy__<SireMM::InterFF>);
         InterFF_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::InterFF >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         InterFF_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::InterFF >,

--- a/wrapper/MM/InterGroupCLJFF.pypp.cpp
+++ b/wrapper/MM/InterGroupCLJFF.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireFF::Inter2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > __copy__(const SireFF::Inter2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > &other){ return SireFF::Inter2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -257,9 +259,9 @@ void register_InterGroupCLJFF_class(){
         
         }
         InterGroupCLJFF_exposer.staticmethod( "typeName" );
-        InterGroupCLJFF_exposer.def( "__copy__", &__copy__);
-        InterGroupCLJFF_exposer.def( "__deepcopy__", &__copy__);
-        InterGroupCLJFF_exposer.def( "clone", &__copy__);
+        InterGroupCLJFF_exposer.def( "__copy__", &__copy__<SireFF::Inter2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> >>);
+        InterGroupCLJFF_exposer.def( "__deepcopy__", &__copy__<SireFF::Inter2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> >>);
+        InterGroupCLJFF_exposer.def( "clone", &__copy__<SireFF::Inter2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> >>);
         InterGroupCLJFF_exposer.def( "__str__", &__str__< ::SireFF::Inter2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > > );
         InterGroupCLJFF_exposer.def( "__repr__", &__str__< ::SireFF::Inter2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > > );
         InterGroupCLJFF_exposer.def( "__len__", &__len_count< ::SireFF::Inter2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > > );

--- a/wrapper/MM/InterGroupCLJFFBase.pypp.cpp
+++ b/wrapper/MM/InterGroupCLJFFBase.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireFF::Inter2B2GFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > __copy__(const SireFF::Inter2B2GFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > &other){ return SireFF::Inter2B2GFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -158,9 +160,9 @@ void register_InterGroupCLJFFBase_class(){
         
         }
         InterGroupCLJFFBase_exposer.staticmethod( "typeName" );
-        InterGroupCLJFFBase_exposer.def( "__copy__", &__copy__);
-        InterGroupCLJFFBase_exposer.def( "__deepcopy__", &__copy__);
-        InterGroupCLJFFBase_exposer.def( "clone", &__copy__);
+        InterGroupCLJFFBase_exposer.def( "__copy__", &__copy__<SireFF::Inter2B2GFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> >>);
+        InterGroupCLJFFBase_exposer.def( "__deepcopy__", &__copy__<SireFF::Inter2B2GFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> >>);
+        InterGroupCLJFFBase_exposer.def( "clone", &__copy__<SireFF::Inter2B2GFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> >>);
         InterGroupCLJFFBase_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireFF::Inter2B2GFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         InterGroupCLJFFBase_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireFF::Inter2B2GFF<SireMM::CLJPotentialInterface<SireMM::InterCLJPotential> > >,

--- a/wrapper/MM/InterGroupCoulombFF.pypp.cpp
+++ b/wrapper/MM/InterGroupCoulombFF.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireFF::Inter2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > __copy__(const SireFF::Inter2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > &other){ return SireFF::Inter2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -257,9 +259,9 @@ void register_InterGroupCoulombFF_class(){
         
         }
         InterGroupCoulombFF_exposer.staticmethod( "typeName" );
-        InterGroupCoulombFF_exposer.def( "__copy__", &__copy__);
-        InterGroupCoulombFF_exposer.def( "__deepcopy__", &__copy__);
-        InterGroupCoulombFF_exposer.def( "clone", &__copy__);
+        InterGroupCoulombFF_exposer.def( "__copy__", &__copy__<SireFF::Inter2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> >>);
+        InterGroupCoulombFF_exposer.def( "__deepcopy__", &__copy__<SireFF::Inter2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> >>);
+        InterGroupCoulombFF_exposer.def( "clone", &__copy__<SireFF::Inter2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> >>);
         InterGroupCoulombFF_exposer.def( "__str__", &__str__< ::SireFF::Inter2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > > );
         InterGroupCoulombFF_exposer.def( "__repr__", &__str__< ::SireFF::Inter2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > > );
         InterGroupCoulombFF_exposer.def( "__len__", &__len_count< ::SireFF::Inter2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > > );

--- a/wrapper/MM/InterGroupCoulombFFBase.pypp.cpp
+++ b/wrapper/MM/InterGroupCoulombFFBase.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireFF::Inter2B2GFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > __copy__(const SireFF::Inter2B2GFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > &other){ return SireFF::Inter2B2GFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -158,9 +160,9 @@ void register_InterGroupCoulombFFBase_class(){
         
         }
         InterGroupCoulombFFBase_exposer.staticmethod( "typeName" );
-        InterGroupCoulombFFBase_exposer.def( "__copy__", &__copy__);
-        InterGroupCoulombFFBase_exposer.def( "__deepcopy__", &__copy__);
-        InterGroupCoulombFFBase_exposer.def( "clone", &__copy__);
+        InterGroupCoulombFFBase_exposer.def( "__copy__", &__copy__<SireFF::Inter2B2GFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> >>);
+        InterGroupCoulombFFBase_exposer.def( "__deepcopy__", &__copy__<SireFF::Inter2B2GFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> >>);
+        InterGroupCoulombFFBase_exposer.def( "clone", &__copy__<SireFF::Inter2B2GFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> >>);
         InterGroupCoulombFFBase_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireFF::Inter2B2GFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         InterGroupCoulombFFBase_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireFF::Inter2B2GFF<SireMM::CoulombPotentialInterface<SireMM::InterCoulombPotential> > >,

--- a/wrapper/MM/InterGroupFF.pypp.cpp
+++ b/wrapper/MM/InterGroupFF.pypp.cpp
@@ -52,6 +52,8 @@ namespace bp = boost::python;
 
 SireMM::InterGroupFF __copy__(const SireMM::InterGroupFF &other){ return SireMM::InterGroupFF(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -627,9 +629,9 @@ void register_InterGroupFF_class(){
         
         }
         InterGroupFF_exposer.staticmethod( "typeName" );
-        InterGroupFF_exposer.def( "__copy__", &__copy__);
-        InterGroupFF_exposer.def( "__deepcopy__", &__copy__);
-        InterGroupFF_exposer.def( "clone", &__copy__);
+        InterGroupFF_exposer.def( "__copy__", &__copy__<SireMM::InterGroupFF>);
+        InterGroupFF_exposer.def( "__deepcopy__", &__copy__<SireMM::InterGroupFF>);
+        InterGroupFF_exposer.def( "clone", &__copy__<SireMM::InterGroupFF>);
         InterGroupFF_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::InterGroupFF >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         InterGroupFF_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::InterGroupFF >,

--- a/wrapper/MM/InterGroupLJFF.pypp.cpp
+++ b/wrapper/MM/InterGroupLJFF.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireFF::Inter2B2G3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > __copy__(const SireFF::Inter2B2G3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > &other){ return SireFF::Inter2B2G3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -257,9 +259,9 @@ void register_InterGroupLJFF_class(){
         
         }
         InterGroupLJFF_exposer.staticmethod( "typeName" );
-        InterGroupLJFF_exposer.def( "__copy__", &__copy__);
-        InterGroupLJFF_exposer.def( "__deepcopy__", &__copy__);
-        InterGroupLJFF_exposer.def( "clone", &__copy__);
+        InterGroupLJFF_exposer.def( "__copy__", &__copy__<SireFF::Inter2B2G3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> >>);
+        InterGroupLJFF_exposer.def( "__deepcopy__", &__copy__<SireFF::Inter2B2G3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> >>);
+        InterGroupLJFF_exposer.def( "clone", &__copy__<SireFF::Inter2B2G3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> >>);
         InterGroupLJFF_exposer.def( "__str__", &__str__< ::SireFF::Inter2B2G3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > > );
         InterGroupLJFF_exposer.def( "__repr__", &__str__< ::SireFF::Inter2B2G3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > > );
         InterGroupLJFF_exposer.def( "__len__", &__len_count< ::SireFF::Inter2B2G3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > > );

--- a/wrapper/MM/InterGroupLJFFBase.pypp.cpp
+++ b/wrapper/MM/InterGroupLJFFBase.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireFF::Inter2B2GFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > __copy__(const SireFF::Inter2B2GFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > &other){ return SireFF::Inter2B2GFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -158,9 +160,9 @@ void register_InterGroupLJFFBase_class(){
         
         }
         InterGroupLJFFBase_exposer.staticmethod( "typeName" );
-        InterGroupLJFFBase_exposer.def( "__copy__", &__copy__);
-        InterGroupLJFFBase_exposer.def( "__deepcopy__", &__copy__);
-        InterGroupLJFFBase_exposer.def( "clone", &__copy__);
+        InterGroupLJFFBase_exposer.def( "__copy__", &__copy__<SireFF::Inter2B2GFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> >>);
+        InterGroupLJFFBase_exposer.def( "__deepcopy__", &__copy__<SireFF::Inter2B2GFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> >>);
+        InterGroupLJFFBase_exposer.def( "clone", &__copy__<SireFF::Inter2B2GFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> >>);
         InterGroupLJFFBase_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireFF::Inter2B2GFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         InterGroupLJFFBase_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireFF::Inter2B2GFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > >,

--- a/wrapper/MM/InterGroupSoftCLJFF.pypp.cpp
+++ b/wrapper/MM/InterGroupSoftCLJFF.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireFF::Inter2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > __copy__(const SireFF::Inter2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > &other){ return SireFF::Inter2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -257,9 +259,9 @@ void register_InterGroupSoftCLJFF_class(){
         
         }
         InterGroupSoftCLJFF_exposer.staticmethod( "typeName" );
-        InterGroupSoftCLJFF_exposer.def( "__copy__", &__copy__);
-        InterGroupSoftCLJFF_exposer.def( "__deepcopy__", &__copy__);
-        InterGroupSoftCLJFF_exposer.def( "clone", &__copy__);
+        InterGroupSoftCLJFF_exposer.def( "__copy__", &__copy__<SireFF::Inter2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> >>);
+        InterGroupSoftCLJFF_exposer.def( "__deepcopy__", &__copy__<SireFF::Inter2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> >>);
+        InterGroupSoftCLJFF_exposer.def( "clone", &__copy__<SireFF::Inter2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> >>);
         InterGroupSoftCLJFF_exposer.def( "__str__", &__str__< ::SireFF::Inter2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > > );
         InterGroupSoftCLJFF_exposer.def( "__repr__", &__str__< ::SireFF::Inter2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > > );
         InterGroupSoftCLJFF_exposer.def( "__len__", &__len_count< ::SireFF::Inter2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > > );

--- a/wrapper/MM/InterGroupSoftCLJFFBase.pypp.cpp
+++ b/wrapper/MM/InterGroupSoftCLJFFBase.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireFF::Inter2B2GFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > __copy__(const SireFF::Inter2B2GFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > &other){ return SireFF::Inter2B2GFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -158,9 +160,9 @@ void register_InterGroupSoftCLJFFBase_class(){
         
         }
         InterGroupSoftCLJFFBase_exposer.staticmethod( "typeName" );
-        InterGroupSoftCLJFFBase_exposer.def( "__copy__", &__copy__);
-        InterGroupSoftCLJFFBase_exposer.def( "__deepcopy__", &__copy__);
-        InterGroupSoftCLJFFBase_exposer.def( "clone", &__copy__);
+        InterGroupSoftCLJFFBase_exposer.def( "__copy__", &__copy__<SireFF::Inter2B2GFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> >>);
+        InterGroupSoftCLJFFBase_exposer.def( "__deepcopy__", &__copy__<SireFF::Inter2B2GFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> >>);
+        InterGroupSoftCLJFFBase_exposer.def( "clone", &__copy__<SireFF::Inter2B2GFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> >>);
         InterGroupSoftCLJFFBase_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireFF::Inter2B2GFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         InterGroupSoftCLJFFBase_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireFF::Inter2B2GFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > >,

--- a/wrapper/MM/InterLJFF.pypp.cpp
+++ b/wrapper/MM/InterLJFF.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireFF::Inter2B3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > __copy__(const SireFF::Inter2B3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > &other){ return SireFF::Inter2B3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -270,9 +272,9 @@ void register_InterLJFF_class(){
         
         }
         InterLJFF_exposer.staticmethod( "typeName" );
-        InterLJFF_exposer.def( "__copy__", &__copy__);
-        InterLJFF_exposer.def( "__deepcopy__", &__copy__);
-        InterLJFF_exposer.def( "clone", &__copy__);
+        InterLJFF_exposer.def( "__copy__", &__copy__<SireFF::Inter2B3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> >>);
+        InterLJFF_exposer.def( "__deepcopy__", &__copy__<SireFF::Inter2B3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> >>);
+        InterLJFF_exposer.def( "clone", &__copy__<SireFF::Inter2B3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> >>);
         InterLJFF_exposer.def( "__str__", &__str__< ::SireFF::Inter2B3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > > );
         InterLJFF_exposer.def( "__repr__", &__str__< ::SireFF::Inter2B3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > > );
         InterLJFF_exposer.def( "__len__", &__len_count< ::SireFF::Inter2B3DFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > > );

--- a/wrapper/MM/InterLJFFBase.pypp.cpp
+++ b/wrapper/MM/InterLJFFBase.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireFF::Inter2BFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > __copy__(const SireFF::Inter2BFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > &other){ return SireFF::Inter2BFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -158,9 +160,9 @@ void register_InterLJFFBase_class(){
         
         }
         InterLJFFBase_exposer.staticmethod( "typeName" );
-        InterLJFFBase_exposer.def( "__copy__", &__copy__);
-        InterLJFFBase_exposer.def( "__deepcopy__", &__copy__);
-        InterLJFFBase_exposer.def( "clone", &__copy__);
+        InterLJFFBase_exposer.def( "__copy__", &__copy__<SireFF::Inter2BFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> >>);
+        InterLJFFBase_exposer.def( "__deepcopy__", &__copy__<SireFF::Inter2BFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> >>);
+        InterLJFFBase_exposer.def( "clone", &__copy__<SireFF::Inter2BFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> >>);
         InterLJFFBase_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireFF::Inter2BFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         InterLJFFBase_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireFF::Inter2BFF<SireMM::LJPotentialInterface<SireMM::InterLJPotential> > >,

--- a/wrapper/MM/InterSoftCLJFF.pypp.cpp
+++ b/wrapper/MM/InterSoftCLJFF.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireFF::Inter2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > __copy__(const SireFF::Inter2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > &other){ return SireFF::Inter2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -270,9 +272,9 @@ void register_InterSoftCLJFF_class(){
         
         }
         InterSoftCLJFF_exposer.staticmethod( "typeName" );
-        InterSoftCLJFF_exposer.def( "__copy__", &__copy__);
-        InterSoftCLJFF_exposer.def( "__deepcopy__", &__copy__);
-        InterSoftCLJFF_exposer.def( "clone", &__copy__);
+        InterSoftCLJFF_exposer.def( "__copy__", &__copy__<SireFF::Inter2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> >>);
+        InterSoftCLJFF_exposer.def( "__deepcopy__", &__copy__<SireFF::Inter2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> >>);
+        InterSoftCLJFF_exposer.def( "clone", &__copy__<SireFF::Inter2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> >>);
         InterSoftCLJFF_exposer.def( "__str__", &__str__< ::SireFF::Inter2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > > );
         InterSoftCLJFF_exposer.def( "__repr__", &__str__< ::SireFF::Inter2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > > );
         InterSoftCLJFF_exposer.def( "__len__", &__len_count< ::SireFF::Inter2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > > );

--- a/wrapper/MM/InterSoftCLJFFBase.pypp.cpp
+++ b/wrapper/MM/InterSoftCLJFFBase.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireFF::Inter2BFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > __copy__(const SireFF::Inter2BFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > &other){ return SireFF::Inter2BFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -158,9 +160,9 @@ void register_InterSoftCLJFFBase_class(){
         
         }
         InterSoftCLJFFBase_exposer.staticmethod( "typeName" );
-        InterSoftCLJFFBase_exposer.def( "__copy__", &__copy__);
-        InterSoftCLJFFBase_exposer.def( "__deepcopy__", &__copy__);
-        InterSoftCLJFFBase_exposer.def( "clone", &__copy__);
+        InterSoftCLJFFBase_exposer.def( "__copy__", &__copy__<SireFF::Inter2BFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> >>);
+        InterSoftCLJFFBase_exposer.def( "__deepcopy__", &__copy__<SireFF::Inter2BFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> >>);
+        InterSoftCLJFFBase_exposer.def( "clone", &__copy__<SireFF::Inter2BFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> >>);
         InterSoftCLJFFBase_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireFF::Inter2BFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         InterSoftCLJFFBase_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireFF::Inter2BFF<SireMM::SoftCLJPotentialInterface<SireMM::InterSoftCLJPotential> > >,

--- a/wrapper/MM/InternalComponent.pypp.cpp
+++ b/wrapper/MM/InternalComponent.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireMM::InternalComponent __copy__(const SireMM::InternalComponent &other){ return SireMM::InternalComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -251,9 +253,9 @@ void register_InternalComponent_class(){
         
         }
         InternalComponent_exposer.staticmethod( "typeName" );
-        InternalComponent_exposer.def( "__copy__", &__copy__);
-        InternalComponent_exposer.def( "__deepcopy__", &__copy__);
-        InternalComponent_exposer.def( "clone", &__copy__);
+        InternalComponent_exposer.def( "__copy__", &__copy__<SireMM::InternalComponent>);
+        InternalComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::InternalComponent>);
+        InternalComponent_exposer.def( "clone", &__copy__<SireMM::InternalComponent>);
         InternalComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::InternalComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         InternalComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::InternalComponent >,

--- a/wrapper/MM/InternalFF.pypp.cpp
+++ b/wrapper/MM/InternalFF.pypp.cpp
@@ -50,6 +50,8 @@ namespace bp = boost::python;
 
 SireMM::InternalFF __copy__(const SireMM::InternalFF &other){ return SireMM::InternalFF(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -511,9 +513,9 @@ void register_InternalFF_class(){
         
         }
         InternalFF_exposer.staticmethod( "typeName" );
-        InternalFF_exposer.def( "__copy__", &__copy__);
-        InternalFF_exposer.def( "__deepcopy__", &__copy__);
-        InternalFF_exposer.def( "clone", &__copy__);
+        InternalFF_exposer.def( "__copy__", &__copy__<SireMM::InternalFF>);
+        InternalFF_exposer.def( "__deepcopy__", &__copy__<SireMM::InternalFF>);
+        InternalFF_exposer.def( "clone", &__copy__<SireMM::InternalFF>);
         InternalFF_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::InternalFF >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         InternalFF_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::InternalFF >,

--- a/wrapper/MM/InternalGroupFF.pypp.cpp
+++ b/wrapper/MM/InternalGroupFF.pypp.cpp
@@ -54,6 +54,8 @@ namespace bp = boost::python;
 
 SireMM::InternalGroupFF __copy__(const SireMM::InternalGroupFF &other){ return SireMM::InternalGroupFF(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -490,9 +492,9 @@ void register_InternalGroupFF_class(){
         
         }
         InternalGroupFF_exposer.staticmethod( "typeName" );
-        InternalGroupFF_exposer.def( "__copy__", &__copy__);
-        InternalGroupFF_exposer.def( "__deepcopy__", &__copy__);
-        InternalGroupFF_exposer.def( "clone", &__copy__);
+        InternalGroupFF_exposer.def( "__copy__", &__copy__<SireMM::InternalGroupFF>);
+        InternalGroupFF_exposer.def( "__deepcopy__", &__copy__<SireMM::InternalGroupFF>);
+        InternalGroupFF_exposer.def( "clone", &__copy__<SireMM::InternalGroupFF>);
         InternalGroupFF_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::InternalGroupFF >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         InternalGroupFF_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::InternalGroupFF >,

--- a/wrapper/MM/InternalParameterNames.pypp.cpp
+++ b/wrapper/MM/InternalParameterNames.pypp.cpp
@@ -49,6 +49,8 @@ namespace bp = boost::python;
 
 SireMM::InternalParameterNames __copy__(const SireMM::InternalParameterNames &other){ return SireMM::InternalParameterNames(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::InternalParameterNames&){ return "SireMM::InternalParameterNames";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -59,9 +61,9 @@ void register_InternalParameterNames_class(){
         typedef bp::class_< SireMM::InternalParameterNames, bp::bases< SireMM::StretchBendTorsionParameterName, SireMM::BendBendParameterName, SireMM::StretchBendParameterName, SireMM::StretchStretchParameterName, SireMM::UreyBradleyParameterName, SireMM::ImproperParameterName, SireMM::DihedralParameterName, SireMM::AngleParameterName, SireMM::BondParameterName > > InternalParameterNames_exposer_t;
         InternalParameterNames_exposer_t InternalParameterNames_exposer = InternalParameterNames_exposer_t( "InternalParameterNames", "This class provides the default name of the properties\nthat contain the bond, angle, dihedral and Urey-Bradley parameters", bp::init< >("") );
         bp::scope InternalParameterNames_scope( InternalParameterNames_exposer );
-        InternalParameterNames_exposer.def( "__copy__", &__copy__);
-        InternalParameterNames_exposer.def( "__deepcopy__", &__copy__);
-        InternalParameterNames_exposer.def( "clone", &__copy__);
+        InternalParameterNames_exposer.def( "__copy__", &__copy__<SireMM::InternalParameterNames>);
+        InternalParameterNames_exposer.def( "__deepcopy__", &__copy__<SireMM::InternalParameterNames>);
+        InternalParameterNames_exposer.def( "clone", &__copy__<SireMM::InternalParameterNames>);
         InternalParameterNames_exposer.def( "__str__", &pvt_get_name);
         InternalParameterNames_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/InternalParameterNames3D.pypp.cpp
+++ b/wrapper/MM/InternalParameterNames3D.pypp.cpp
@@ -49,6 +49,8 @@ namespace bp = boost::python;
 
 SireMM::InternalParameterNames3D __copy__(const SireMM::InternalParameterNames3D &other){ return SireMM::InternalParameterNames3D(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::InternalParameterNames3D&){ return "SireMM::InternalParameterNames3D";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -59,9 +61,9 @@ void register_InternalParameterNames3D_class(){
         typedef bp::class_< SireMM::InternalParameterNames3D, bp::bases< SireMM::InternalParameterNames, SireMM::StretchBendTorsionParameterName, SireMM::BendBendParameterName, SireMM::StretchBendParameterName, SireMM::StretchStretchParameterName, SireMM::UreyBradleyParameterName, SireMM::ImproperParameterName, SireMM::DihedralParameterName, SireMM::AngleParameterName, SireMM::BondParameterName > > InternalParameterNames3D_exposer_t;
         InternalParameterNames3D_exposer_t InternalParameterNames3D_exposer = InternalParameterNames3D_exposer_t( "InternalParameterNames3D", "This class provides the default name of the properties\nthat contain the internal and 3D coordinates properties", bp::init< >("") );
         bp::scope InternalParameterNames3D_scope( InternalParameterNames3D_exposer );
-        InternalParameterNames3D_exposer.def( "__copy__", &__copy__);
-        InternalParameterNames3D_exposer.def( "__deepcopy__", &__copy__);
-        InternalParameterNames3D_exposer.def( "clone", &__copy__);
+        InternalParameterNames3D_exposer.def( "__copy__", &__copy__<SireMM::InternalParameterNames3D>);
+        InternalParameterNames3D_exposer.def( "__deepcopy__", &__copy__<SireMM::InternalParameterNames3D>);
+        InternalParameterNames3D_exposer.def( "clone", &__copy__<SireMM::InternalParameterNames3D>);
         InternalParameterNames3D_exposer.def( "__str__", &pvt_get_name);
         InternalParameterNames3D_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/InternalParameters.pypp.cpp
+++ b/wrapper/MM/InternalParameters.pypp.cpp
@@ -33,6 +33,8 @@ namespace bp = boost::python;
 
 SireMM::InternalParameters __copy__(const SireMM::InternalParameters &other){ return SireMM::InternalParameters(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 const char* pvt_get_name(const SireMM::InternalParameters&){ return "SireMM::InternalParameters";}
@@ -345,9 +347,9 @@ void register_InternalParameters_class(){
         
         }
         InternalParameters_exposer.staticmethod( "typeName" );
-        InternalParameters_exposer.def( "__copy__", &__copy__);
-        InternalParameters_exposer.def( "__deepcopy__", &__copy__);
-        InternalParameters_exposer.def( "clone", &__copy__);
+        InternalParameters_exposer.def( "__copy__", &__copy__<SireMM::InternalParameters>);
+        InternalParameters_exposer.def( "__deepcopy__", &__copy__<SireMM::InternalParameters>);
+        InternalParameters_exposer.def( "clone", &__copy__<SireMM::InternalParameters>);
         InternalParameters_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::InternalParameters >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         InternalParameters_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::InternalParameters >,

--- a/wrapper/MM/InternalParameters3D.pypp.cpp
+++ b/wrapper/MM/InternalParameters3D.pypp.cpp
@@ -33,6 +33,8 @@ namespace bp = boost::python;
 
 SireMM::InternalParameters3D __copy__(const SireMM::InternalParameters3D &other){ return SireMM::InternalParameters3D(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 const char* pvt_get_name(const SireMM::InternalParameters3D&){ return "SireMM::InternalParameters3D";}
@@ -188,9 +190,9 @@ void register_InternalParameters3D_class(){
         
         }
         InternalParameters3D_exposer.staticmethod( "typeName" );
-        InternalParameters3D_exposer.def( "__copy__", &__copy__);
-        InternalParameters3D_exposer.def( "__deepcopy__", &__copy__);
-        InternalParameters3D_exposer.def( "clone", &__copy__);
+        InternalParameters3D_exposer.def( "__copy__", &__copy__<SireMM::InternalParameters3D>);
+        InternalParameters3D_exposer.def( "__deepcopy__", &__copy__<SireMM::InternalParameters3D>);
+        InternalParameters3D_exposer.def( "clone", &__copy__<SireMM::InternalParameters3D>);
         InternalParameters3D_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::InternalParameters3D >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         InternalParameters3D_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::InternalParameters3D >,

--- a/wrapper/MM/InternalSymbols.pypp.cpp
+++ b/wrapper/MM/InternalSymbols.pypp.cpp
@@ -33,6 +33,8 @@ namespace bp = boost::python;
 
 SireMM::InternalSymbols __copy__(const SireMM::InternalSymbols &other){ return SireMM::InternalSymbols(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::InternalSymbols&){ return "SireMM::InternalSymbols";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -151,9 +153,9 @@ void register_InternalSymbols_class(){
                 , "Return all of the symbols used in the Urey-Bradley parameters" );
         
         }
-        InternalSymbols_exposer.def( "__copy__", &__copy__);
-        InternalSymbols_exposer.def( "__deepcopy__", &__copy__);
-        InternalSymbols_exposer.def( "clone", &__copy__);
+        InternalSymbols_exposer.def( "__copy__", &__copy__<SireMM::InternalSymbols>);
+        InternalSymbols_exposer.def( "__deepcopy__", &__copy__<SireMM::InternalSymbols>);
+        InternalSymbols_exposer.def( "clone", &__copy__<SireMM::InternalSymbols>);
         InternalSymbols_exposer.def( "__str__", &pvt_get_name);
         InternalSymbols_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/Intra14Component.pypp.cpp
+++ b/wrapper/MM/Intra14Component.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireMM::Intra14Component __copy__(const SireMM::Intra14Component &other){ return SireMM::Intra14Component(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -131,9 +133,9 @@ void register_Intra14Component_class(){
         
         }
         Intra14Component_exposer.staticmethod( "typeName" );
-        Intra14Component_exposer.def( "__copy__", &__copy__);
-        Intra14Component_exposer.def( "__deepcopy__", &__copy__);
-        Intra14Component_exposer.def( "clone", &__copy__);
+        Intra14Component_exposer.def( "__copy__", &__copy__<SireMM::Intra14Component>);
+        Intra14Component_exposer.def( "__deepcopy__", &__copy__<SireMM::Intra14Component>);
+        Intra14Component_exposer.def( "clone", &__copy__<SireMM::Intra14Component>);
         Intra14Component_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::Intra14Component >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         Intra14Component_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::Intra14Component >,

--- a/wrapper/MM/Intra14CoulombComponent.pypp.cpp
+++ b/wrapper/MM/Intra14CoulombComponent.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireMM::Intra14CoulombComponent __copy__(const SireMM::Intra14CoulombComponent &other){ return SireMM::Intra14CoulombComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -107,9 +109,9 @@ void register_Intra14CoulombComponent_class(){
         
         }
         Intra14CoulombComponent_exposer.staticmethod( "typeName" );
-        Intra14CoulombComponent_exposer.def( "__copy__", &__copy__);
-        Intra14CoulombComponent_exposer.def( "__deepcopy__", &__copy__);
-        Intra14CoulombComponent_exposer.def( "clone", &__copy__);
+        Intra14CoulombComponent_exposer.def( "__copy__", &__copy__<SireMM::Intra14CoulombComponent>);
+        Intra14CoulombComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::Intra14CoulombComponent>);
+        Intra14CoulombComponent_exposer.def( "clone", &__copy__<SireMM::Intra14CoulombComponent>);
         Intra14CoulombComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::Intra14CoulombComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         Intra14CoulombComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::Intra14CoulombComponent >,

--- a/wrapper/MM/Intra14LJComponent.pypp.cpp
+++ b/wrapper/MM/Intra14LJComponent.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireMM::Intra14LJComponent __copy__(const SireMM::Intra14LJComponent &other){ return SireMM::Intra14LJComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -107,9 +109,9 @@ void register_Intra14LJComponent_class(){
         
         }
         Intra14LJComponent_exposer.staticmethod( "typeName" );
-        Intra14LJComponent_exposer.def( "__copy__", &__copy__);
-        Intra14LJComponent_exposer.def( "__deepcopy__", &__copy__);
-        Intra14LJComponent_exposer.def( "clone", &__copy__);
+        Intra14LJComponent_exposer.def( "__copy__", &__copy__<SireMM::Intra14LJComponent>);
+        Intra14LJComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::Intra14LJComponent>);
+        Intra14LJComponent_exposer.def( "clone", &__copy__<SireMM::Intra14LJComponent>);
         Intra14LJComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::Intra14LJComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         Intra14LJComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::Intra14LJComponent >,

--- a/wrapper/MM/IntraCLJFF.pypp.cpp
+++ b/wrapper/MM/IntraCLJFF.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireFF::Intra2B3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > __copy__(const SireFF::Intra2B3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > &other){ return SireFF::Intra2B3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -257,9 +259,9 @@ void register_IntraCLJFF_class(){
         
         }
         IntraCLJFF_exposer.staticmethod( "typeName" );
-        IntraCLJFF_exposer.def( "__copy__", &__copy__);
-        IntraCLJFF_exposer.def( "__deepcopy__", &__copy__);
-        IntraCLJFF_exposer.def( "clone", &__copy__);
+        IntraCLJFF_exposer.def( "__copy__", &__copy__<SireFF::Intra2B3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> >>);
+        IntraCLJFF_exposer.def( "__deepcopy__", &__copy__<SireFF::Intra2B3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> >>);
+        IntraCLJFF_exposer.def( "clone", &__copy__<SireFF::Intra2B3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> >>);
         IntraCLJFF_exposer.def( "__str__", &__str__< ::SireFF::Intra2B3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > > );
         IntraCLJFF_exposer.def( "__repr__", &__str__< ::SireFF::Intra2B3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > > );
         IntraCLJFF_exposer.def( "__len__", &__len_count< ::SireFF::Intra2B3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > > );

--- a/wrapper/MM/IntraCLJFFBase.pypp.cpp
+++ b/wrapper/MM/IntraCLJFFBase.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireFF::Intra2BFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > __copy__(const SireFF::Intra2BFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > &other){ return SireFF::Intra2BFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -158,9 +160,9 @@ void register_IntraCLJFFBase_class(){
         
         }
         IntraCLJFFBase_exposer.staticmethod( "typeName" );
-        IntraCLJFFBase_exposer.def( "__copy__", &__copy__);
-        IntraCLJFFBase_exposer.def( "__deepcopy__", &__copy__);
-        IntraCLJFFBase_exposer.def( "clone", &__copy__);
+        IntraCLJFFBase_exposer.def( "__copy__", &__copy__<SireFF::Intra2BFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> >>);
+        IntraCLJFFBase_exposer.def( "__deepcopy__", &__copy__<SireFF::Intra2BFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> >>);
+        IntraCLJFFBase_exposer.def( "clone", &__copy__<SireFF::Intra2BFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> >>);
         IntraCLJFFBase_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireFF::Intra2BFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         IntraCLJFFBase_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireFF::Intra2BFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > >,

--- a/wrapper/MM/IntraCoulombFF.pypp.cpp
+++ b/wrapper/MM/IntraCoulombFF.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireFF::Intra2B3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > __copy__(const SireFF::Intra2B3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > &other){ return SireFF::Intra2B3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -257,9 +259,9 @@ void register_IntraCoulombFF_class(){
         
         }
         IntraCoulombFF_exposer.staticmethod( "typeName" );
-        IntraCoulombFF_exposer.def( "__copy__", &__copy__);
-        IntraCoulombFF_exposer.def( "__deepcopy__", &__copy__);
-        IntraCoulombFF_exposer.def( "clone", &__copy__);
+        IntraCoulombFF_exposer.def( "__copy__", &__copy__<SireFF::Intra2B3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> >>);
+        IntraCoulombFF_exposer.def( "__deepcopy__", &__copy__<SireFF::Intra2B3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> >>);
+        IntraCoulombFF_exposer.def( "clone", &__copy__<SireFF::Intra2B3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> >>);
         IntraCoulombFF_exposer.def( "__str__", &__str__< ::SireFF::Intra2B3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > > );
         IntraCoulombFF_exposer.def( "__repr__", &__str__< ::SireFF::Intra2B3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > > );
         IntraCoulombFF_exposer.def( "__len__", &__len_count< ::SireFF::Intra2B3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > > );

--- a/wrapper/MM/IntraCoulombFFBase.pypp.cpp
+++ b/wrapper/MM/IntraCoulombFFBase.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireFF::Intra2BFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > __copy__(const SireFF::Intra2BFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > &other){ return SireFF::Intra2BFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -158,9 +160,9 @@ void register_IntraCoulombFFBase_class(){
         
         }
         IntraCoulombFFBase_exposer.staticmethod( "typeName" );
-        IntraCoulombFFBase_exposer.def( "__copy__", &__copy__);
-        IntraCoulombFFBase_exposer.def( "__deepcopy__", &__copy__);
-        IntraCoulombFFBase_exposer.def( "clone", &__copy__);
+        IntraCoulombFFBase_exposer.def( "__copy__", &__copy__<SireFF::Intra2BFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> >>);
+        IntraCoulombFFBase_exposer.def( "__deepcopy__", &__copy__<SireFF::Intra2BFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> >>);
+        IntraCoulombFFBase_exposer.def( "clone", &__copy__<SireFF::Intra2BFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> >>);
         IntraCoulombFFBase_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireFF::Intra2BFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         IntraCoulombFFBase_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireFF::Intra2BFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > >,

--- a/wrapper/MM/IntraFF.pypp.cpp
+++ b/wrapper/MM/IntraFF.pypp.cpp
@@ -52,6 +52,8 @@ namespace bp = boost::python;
 
 SireMM::IntraFF __copy__(const SireMM::IntraFF &other){ return SireMM::IntraFF(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -417,9 +419,9 @@ void register_IntraFF_class(){
         
         }
         IntraFF_exposer.staticmethod( "typeName" );
-        IntraFF_exposer.def( "__copy__", &__copy__);
-        IntraFF_exposer.def( "__deepcopy__", &__copy__);
-        IntraFF_exposer.def( "clone", &__copy__);
+        IntraFF_exposer.def( "__copy__", &__copy__<SireMM::IntraFF>);
+        IntraFF_exposer.def( "__deepcopy__", &__copy__<SireMM::IntraFF>);
+        IntraFF_exposer.def( "clone", &__copy__<SireMM::IntraFF>);
         IntraFF_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::IntraFF >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         IntraFF_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::IntraFF >,

--- a/wrapper/MM/IntraGroupCLJFF.pypp.cpp
+++ b/wrapper/MM/IntraGroupCLJFF.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireFF::Intra2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > __copy__(const SireFF::Intra2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > &other){ return SireFF::Intra2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -257,9 +259,9 @@ void register_IntraGroupCLJFF_class(){
         
         }
         IntraGroupCLJFF_exposer.staticmethod( "typeName" );
-        IntraGroupCLJFF_exposer.def( "__copy__", &__copy__);
-        IntraGroupCLJFF_exposer.def( "__deepcopy__", &__copy__);
-        IntraGroupCLJFF_exposer.def( "clone", &__copy__);
+        IntraGroupCLJFF_exposer.def( "__copy__", &__copy__<SireFF::Intra2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> >>);
+        IntraGroupCLJFF_exposer.def( "__deepcopy__", &__copy__<SireFF::Intra2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> >>);
+        IntraGroupCLJFF_exposer.def( "clone", &__copy__<SireFF::Intra2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> >>);
         IntraGroupCLJFF_exposer.def( "__str__", &__str__< ::SireFF::Intra2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > > );
         IntraGroupCLJFF_exposer.def( "__repr__", &__str__< ::SireFF::Intra2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > > );
         IntraGroupCLJFF_exposer.def( "__len__", &__len_count< ::SireFF::Intra2B2G3DFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > > );

--- a/wrapper/MM/IntraGroupCLJFFBase.pypp.cpp
+++ b/wrapper/MM/IntraGroupCLJFFBase.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireFF::Intra2B2GFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > __copy__(const SireFF::Intra2B2GFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > &other){ return SireFF::Intra2B2GFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -158,9 +160,9 @@ void register_IntraGroupCLJFFBase_class(){
         
         }
         IntraGroupCLJFFBase_exposer.staticmethod( "typeName" );
-        IntraGroupCLJFFBase_exposer.def( "__copy__", &__copy__);
-        IntraGroupCLJFFBase_exposer.def( "__deepcopy__", &__copy__);
-        IntraGroupCLJFFBase_exposer.def( "clone", &__copy__);
+        IntraGroupCLJFFBase_exposer.def( "__copy__", &__copy__<SireFF::Intra2B2GFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> >>);
+        IntraGroupCLJFFBase_exposer.def( "__deepcopy__", &__copy__<SireFF::Intra2B2GFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> >>);
+        IntraGroupCLJFFBase_exposer.def( "clone", &__copy__<SireFF::Intra2B2GFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> >>);
         IntraGroupCLJFFBase_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireFF::Intra2B2GFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         IntraGroupCLJFFBase_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireFF::Intra2B2GFF<SireMM::CLJPotentialInterface<SireMM::IntraCLJPotential> > >,

--- a/wrapper/MM/IntraGroupCoulombFF.pypp.cpp
+++ b/wrapper/MM/IntraGroupCoulombFF.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireFF::Intra2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > __copy__(const SireFF::Intra2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > &other){ return SireFF::Intra2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -257,9 +259,9 @@ void register_IntraGroupCoulombFF_class(){
         
         }
         IntraGroupCoulombFF_exposer.staticmethod( "typeName" );
-        IntraGroupCoulombFF_exposer.def( "__copy__", &__copy__);
-        IntraGroupCoulombFF_exposer.def( "__deepcopy__", &__copy__);
-        IntraGroupCoulombFF_exposer.def( "clone", &__copy__);
+        IntraGroupCoulombFF_exposer.def( "__copy__", &__copy__<SireFF::Intra2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> >>);
+        IntraGroupCoulombFF_exposer.def( "__deepcopy__", &__copy__<SireFF::Intra2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> >>);
+        IntraGroupCoulombFF_exposer.def( "clone", &__copy__<SireFF::Intra2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> >>);
         IntraGroupCoulombFF_exposer.def( "__str__", &__str__< ::SireFF::Intra2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > > );
         IntraGroupCoulombFF_exposer.def( "__repr__", &__str__< ::SireFF::Intra2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > > );
         IntraGroupCoulombFF_exposer.def( "__len__", &__len_count< ::SireFF::Intra2B2G3DFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > > );

--- a/wrapper/MM/IntraGroupCoulombFFBase.pypp.cpp
+++ b/wrapper/MM/IntraGroupCoulombFFBase.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireFF::Intra2B2GFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > __copy__(const SireFF::Intra2B2GFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > &other){ return SireFF::Intra2B2GFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -158,9 +160,9 @@ void register_IntraGroupCoulombFFBase_class(){
         
         }
         IntraGroupCoulombFFBase_exposer.staticmethod( "typeName" );
-        IntraGroupCoulombFFBase_exposer.def( "__copy__", &__copy__);
-        IntraGroupCoulombFFBase_exposer.def( "__deepcopy__", &__copy__);
-        IntraGroupCoulombFFBase_exposer.def( "clone", &__copy__);
+        IntraGroupCoulombFFBase_exposer.def( "__copy__", &__copy__<SireFF::Intra2B2GFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> >>);
+        IntraGroupCoulombFFBase_exposer.def( "__deepcopy__", &__copy__<SireFF::Intra2B2GFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> >>);
+        IntraGroupCoulombFFBase_exposer.def( "clone", &__copy__<SireFF::Intra2B2GFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> >>);
         IntraGroupCoulombFFBase_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireFF::Intra2B2GFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         IntraGroupCoulombFFBase_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireFF::Intra2B2GFF<SireMM::CoulombPotentialInterface<SireMM::IntraCoulombPotential> > >,

--- a/wrapper/MM/IntraGroupFF.pypp.cpp
+++ b/wrapper/MM/IntraGroupFF.pypp.cpp
@@ -52,6 +52,8 @@ namespace bp = boost::python;
 
 SireMM::IntraGroupFF __copy__(const SireMM::IntraGroupFF &other){ return SireMM::IntraGroupFF(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -417,9 +419,9 @@ void register_IntraGroupFF_class(){
         
         }
         IntraGroupFF_exposer.staticmethod( "typeName" );
-        IntraGroupFF_exposer.def( "__copy__", &__copy__);
-        IntraGroupFF_exposer.def( "__deepcopy__", &__copy__);
-        IntraGroupFF_exposer.def( "clone", &__copy__);
+        IntraGroupFF_exposer.def( "__copy__", &__copy__<SireMM::IntraGroupFF>);
+        IntraGroupFF_exposer.def( "__deepcopy__", &__copy__<SireMM::IntraGroupFF>);
+        IntraGroupFF_exposer.def( "clone", &__copy__<SireMM::IntraGroupFF>);
         IntraGroupFF_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::IntraGroupFF >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         IntraGroupFF_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::IntraGroupFF >,

--- a/wrapper/MM/IntraGroupLJFF.pypp.cpp
+++ b/wrapper/MM/IntraGroupLJFF.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireFF::Intra2B2G3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > __copy__(const SireFF::Intra2B2G3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > &other){ return SireFF::Intra2B2G3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -257,9 +259,9 @@ void register_IntraGroupLJFF_class(){
         
         }
         IntraGroupLJFF_exposer.staticmethod( "typeName" );
-        IntraGroupLJFF_exposer.def( "__copy__", &__copy__);
-        IntraGroupLJFF_exposer.def( "__deepcopy__", &__copy__);
-        IntraGroupLJFF_exposer.def( "clone", &__copy__);
+        IntraGroupLJFF_exposer.def( "__copy__", &__copy__<SireFF::Intra2B2G3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> >>);
+        IntraGroupLJFF_exposer.def( "__deepcopy__", &__copy__<SireFF::Intra2B2G3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> >>);
+        IntraGroupLJFF_exposer.def( "clone", &__copy__<SireFF::Intra2B2G3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> >>);
         IntraGroupLJFF_exposer.def( "__str__", &__str__< ::SireFF::Intra2B2G3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > > );
         IntraGroupLJFF_exposer.def( "__repr__", &__str__< ::SireFF::Intra2B2G3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > > );
         IntraGroupLJFF_exposer.def( "__len__", &__len_count< ::SireFF::Intra2B2G3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > > );

--- a/wrapper/MM/IntraGroupLJFFBase.pypp.cpp
+++ b/wrapper/MM/IntraGroupLJFFBase.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireFF::Intra2B2GFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > __copy__(const SireFF::Intra2B2GFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > &other){ return SireFF::Intra2B2GFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -158,9 +160,9 @@ void register_IntraGroupLJFFBase_class(){
         
         }
         IntraGroupLJFFBase_exposer.staticmethod( "typeName" );
-        IntraGroupLJFFBase_exposer.def( "__copy__", &__copy__);
-        IntraGroupLJFFBase_exposer.def( "__deepcopy__", &__copy__);
-        IntraGroupLJFFBase_exposer.def( "clone", &__copy__);
+        IntraGroupLJFFBase_exposer.def( "__copy__", &__copy__<SireFF::Intra2B2GFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> >>);
+        IntraGroupLJFFBase_exposer.def( "__deepcopy__", &__copy__<SireFF::Intra2B2GFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> >>);
+        IntraGroupLJFFBase_exposer.def( "clone", &__copy__<SireFF::Intra2B2GFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> >>);
         IntraGroupLJFFBase_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireFF::Intra2B2GFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         IntraGroupLJFFBase_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireFF::Intra2B2GFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > >,

--- a/wrapper/MM/IntraGroupSoftCLJFF.pypp.cpp
+++ b/wrapper/MM/IntraGroupSoftCLJFF.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireFF::Intra2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > __copy__(const SireFF::Intra2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > &other){ return SireFF::Intra2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -257,9 +259,9 @@ void register_IntraGroupSoftCLJFF_class(){
         
         }
         IntraGroupSoftCLJFF_exposer.staticmethod( "typeName" );
-        IntraGroupSoftCLJFF_exposer.def( "__copy__", &__copy__);
-        IntraGroupSoftCLJFF_exposer.def( "__deepcopy__", &__copy__);
-        IntraGroupSoftCLJFF_exposer.def( "clone", &__copy__);
+        IntraGroupSoftCLJFF_exposer.def( "__copy__", &__copy__<SireFF::Intra2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> >>);
+        IntraGroupSoftCLJFF_exposer.def( "__deepcopy__", &__copy__<SireFF::Intra2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> >>);
+        IntraGroupSoftCLJFF_exposer.def( "clone", &__copy__<SireFF::Intra2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> >>);
         IntraGroupSoftCLJFF_exposer.def( "__str__", &__str__< ::SireFF::Intra2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > > );
         IntraGroupSoftCLJFF_exposer.def( "__repr__", &__str__< ::SireFF::Intra2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > > );
         IntraGroupSoftCLJFF_exposer.def( "__len__", &__len_count< ::SireFF::Intra2B2G3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > > );

--- a/wrapper/MM/IntraGroupSoftCLJFFBase.pypp.cpp
+++ b/wrapper/MM/IntraGroupSoftCLJFFBase.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireFF::Intra2B2GFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > __copy__(const SireFF::Intra2B2GFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > &other){ return SireFF::Intra2B2GFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -158,9 +160,9 @@ void register_IntraGroupSoftCLJFFBase_class(){
         
         }
         IntraGroupSoftCLJFFBase_exposer.staticmethod( "typeName" );
-        IntraGroupSoftCLJFFBase_exposer.def( "__copy__", &__copy__);
-        IntraGroupSoftCLJFFBase_exposer.def( "__deepcopy__", &__copy__);
-        IntraGroupSoftCLJFFBase_exposer.def( "clone", &__copy__);
+        IntraGroupSoftCLJFFBase_exposer.def( "__copy__", &__copy__<SireFF::Intra2B2GFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> >>);
+        IntraGroupSoftCLJFFBase_exposer.def( "__deepcopy__", &__copy__<SireFF::Intra2B2GFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> >>);
+        IntraGroupSoftCLJFFBase_exposer.def( "clone", &__copy__<SireFF::Intra2B2GFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> >>);
         IntraGroupSoftCLJFFBase_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireFF::Intra2B2GFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         IntraGroupSoftCLJFFBase_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireFF::Intra2B2GFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > >,

--- a/wrapper/MM/IntraLJFF.pypp.cpp
+++ b/wrapper/MM/IntraLJFF.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireFF::Intra2B3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > __copy__(const SireFF::Intra2B3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > &other){ return SireFF::Intra2B3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -257,9 +259,9 @@ void register_IntraLJFF_class(){
         
         }
         IntraLJFF_exposer.staticmethod( "typeName" );
-        IntraLJFF_exposer.def( "__copy__", &__copy__);
-        IntraLJFF_exposer.def( "__deepcopy__", &__copy__);
-        IntraLJFF_exposer.def( "clone", &__copy__);
+        IntraLJFF_exposer.def( "__copy__", &__copy__<SireFF::Intra2B3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> >>);
+        IntraLJFF_exposer.def( "__deepcopy__", &__copy__<SireFF::Intra2B3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> >>);
+        IntraLJFF_exposer.def( "clone", &__copy__<SireFF::Intra2B3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> >>);
         IntraLJFF_exposer.def( "__str__", &__str__< ::SireFF::Intra2B3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > > );
         IntraLJFF_exposer.def( "__repr__", &__str__< ::SireFF::Intra2B3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > > );
         IntraLJFF_exposer.def( "__len__", &__len_count< ::SireFF::Intra2B3DFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > > );

--- a/wrapper/MM/IntraLJFFBase.pypp.cpp
+++ b/wrapper/MM/IntraLJFFBase.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireFF::Intra2BFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > __copy__(const SireFF::Intra2BFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > &other){ return SireFF::Intra2BFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -158,9 +160,9 @@ void register_IntraLJFFBase_class(){
         
         }
         IntraLJFFBase_exposer.staticmethod( "typeName" );
-        IntraLJFFBase_exposer.def( "__copy__", &__copy__);
-        IntraLJFFBase_exposer.def( "__deepcopy__", &__copy__);
-        IntraLJFFBase_exposer.def( "clone", &__copy__);
+        IntraLJFFBase_exposer.def( "__copy__", &__copy__<SireFF::Intra2BFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> >>);
+        IntraLJFFBase_exposer.def( "__deepcopy__", &__copy__<SireFF::Intra2BFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> >>);
+        IntraLJFFBase_exposer.def( "clone", &__copy__<SireFF::Intra2BFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> >>);
         IntraLJFFBase_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireFF::Intra2BFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         IntraLJFFBase_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireFF::Intra2BFF<SireMM::LJPotentialInterface<SireMM::IntraLJPotential> > >,

--- a/wrapper/MM/IntraSoftCLJFF.pypp.cpp
+++ b/wrapper/MM/IntraSoftCLJFF.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireFF::Intra2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > __copy__(const SireFF::Intra2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > &other){ return SireFF::Intra2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -257,9 +259,9 @@ void register_IntraSoftCLJFF_class(){
         
         }
         IntraSoftCLJFF_exposer.staticmethod( "typeName" );
-        IntraSoftCLJFF_exposer.def( "__copy__", &__copy__);
-        IntraSoftCLJFF_exposer.def( "__deepcopy__", &__copy__);
-        IntraSoftCLJFF_exposer.def( "clone", &__copy__);
+        IntraSoftCLJFF_exposer.def( "__copy__", &__copy__<SireFF::Intra2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> >>);
+        IntraSoftCLJFF_exposer.def( "__deepcopy__", &__copy__<SireFF::Intra2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> >>);
+        IntraSoftCLJFF_exposer.def( "clone", &__copy__<SireFF::Intra2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> >>);
         IntraSoftCLJFF_exposer.def( "__str__", &__str__< ::SireFF::Intra2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > > );
         IntraSoftCLJFF_exposer.def( "__repr__", &__str__< ::SireFF::Intra2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > > );
         IntraSoftCLJFF_exposer.def( "__len__", &__len_count< ::SireFF::Intra2B3DFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > > );

--- a/wrapper/MM/IntraSoftCLJFFBase.pypp.cpp
+++ b/wrapper/MM/IntraSoftCLJFFBase.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireFF::Intra2BFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > __copy__(const SireFF::Intra2BFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > &other){ return SireFF::Intra2BFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> >(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -158,9 +160,9 @@ void register_IntraSoftCLJFFBase_class(){
         
         }
         IntraSoftCLJFFBase_exposer.staticmethod( "typeName" );
-        IntraSoftCLJFFBase_exposer.def( "__copy__", &__copy__);
-        IntraSoftCLJFFBase_exposer.def( "__deepcopy__", &__copy__);
-        IntraSoftCLJFFBase_exposer.def( "clone", &__copy__);
+        IntraSoftCLJFFBase_exposer.def( "__copy__", &__copy__<SireFF::Intra2BFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> >>);
+        IntraSoftCLJFFBase_exposer.def( "__deepcopy__", &__copy__<SireFF::Intra2BFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> >>);
+        IntraSoftCLJFFBase_exposer.def( "clone", &__copy__<SireFF::Intra2BFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> >>);
         IntraSoftCLJFFBase_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireFF::Intra2BFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         IntraSoftCLJFFBase_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireFF::Intra2BFF<SireMM::SoftCLJPotentialInterface<SireMM::IntraSoftCLJPotential> > >,

--- a/wrapper/MM/LJ1264Parameter.pypp.cpp
+++ b/wrapper/MM/LJ1264Parameter.pypp.cpp
@@ -19,6 +19,8 @@ namespace bp = boost::python;
 
 SireMM::LJ1264Parameter __copy__(const SireMM::LJ1264Parameter &other){ return SireMM::LJ1264Parameter(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -260,9 +262,9 @@ void register_LJ1264Parameter_class(){
         LJ1264Parameter_exposer.staticmethod( "CUnit" );
         LJ1264Parameter_exposer.staticmethod( "dummy" );
         LJ1264Parameter_exposer.staticmethod( "typeName" );
-        LJ1264Parameter_exposer.def( "__copy__", &__copy__);
-        LJ1264Parameter_exposer.def( "__deepcopy__", &__copy__);
-        LJ1264Parameter_exposer.def( "clone", &__copy__);
+        LJ1264Parameter_exposer.def( "__copy__", &__copy__<SireMM::LJ1264Parameter>);
+        LJ1264Parameter_exposer.def( "__deepcopy__", &__copy__<SireMM::LJ1264Parameter>);
+        LJ1264Parameter_exposer.def( "clone", &__copy__<SireMM::LJ1264Parameter>);
         LJ1264Parameter_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::LJ1264Parameter >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         LJ1264Parameter_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::LJ1264Parameter >,

--- a/wrapper/MM/LJComponent.pypp.cpp
+++ b/wrapper/MM/LJComponent.pypp.cpp
@@ -16,6 +16,8 @@ namespace bp = boost::python;
 
 SireMM::LJComponent __copy__(const SireMM::LJComponent &other){ return SireMM::LJComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -106,9 +108,9 @@ void register_LJComponent_class(){
         
         }
         LJComponent_exposer.staticmethod( "typeName" );
-        LJComponent_exposer.def( "__copy__", &__copy__);
-        LJComponent_exposer.def( "__deepcopy__", &__copy__);
-        LJComponent_exposer.def( "clone", &__copy__);
+        LJComponent_exposer.def( "__copy__", &__copy__<SireMM::LJComponent>);
+        LJComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::LJComponent>);
+        LJComponent_exposer.def( "clone", &__copy__<SireMM::LJComponent>);
         LJComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::LJComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         LJComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::LJComponent >,

--- a/wrapper/MM/LJException.pypp.cpp
+++ b/wrapper/MM/LJException.pypp.cpp
@@ -31,6 +31,8 @@ namespace bp = boost::python;
 
 SireMM::LJException __copy__(const SireMM::LJException &other){ return SireMM::LJException(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -147,9 +149,9 @@ void register_LJException_class(){
         
         }
         LJException_exposer.staticmethod( "typeName" );
-        LJException_exposer.def( "__copy__", &__copy__);
-        LJException_exposer.def( "__deepcopy__", &__copy__);
-        LJException_exposer.def( "clone", &__copy__);
+        LJException_exposer.def( "__copy__", &__copy__<SireMM::LJException>);
+        LJException_exposer.def( "__deepcopy__", &__copy__<SireMM::LJException>);
+        LJException_exposer.def( "clone", &__copy__<SireMM::LJException>);
         LJException_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::LJException >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         LJException_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::LJException >,

--- a/wrapper/MM/LJExceptionID.pypp.cpp
+++ b/wrapper/MM/LJExceptionID.pypp.cpp
@@ -31,6 +31,8 @@ namespace bp = boost::python;
 
 SireMM::LJExceptionID __copy__(const SireMM::LJExceptionID &other){ return SireMM::LJExceptionID(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -134,9 +136,9 @@ void register_LJExceptionID_class(){
         }
         LJExceptionID_exposer.staticmethod( "generate" );
         LJExceptionID_exposer.staticmethod( "typeName" );
-        LJExceptionID_exposer.def( "__copy__", &__copy__);
-        LJExceptionID_exposer.def( "__deepcopy__", &__copy__);
-        LJExceptionID_exposer.def( "clone", &__copy__);
+        LJExceptionID_exposer.def( "__copy__", &__copy__<SireMM::LJExceptionID>);
+        LJExceptionID_exposer.def( "__deepcopy__", &__copy__<SireMM::LJExceptionID>);
+        LJExceptionID_exposer.def( "clone", &__copy__<SireMM::LJExceptionID>);
         LJExceptionID_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::LJExceptionID >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         LJExceptionID_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::LJExceptionID >,

--- a/wrapper/MM/LJNBPairs.pypp.cpp
+++ b/wrapper/MM/LJNBPairs.pypp.cpp
@@ -19,6 +19,8 @@ namespace bp = boost::python;
 
 SireMM::LJNBPairs __copy__(const SireMM::LJNBPairs &other){ return SireMM::LJNBPairs(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -76,9 +78,9 @@ void register_LJNBPairs_class(){
         
         }
         LJNBPairs_exposer.staticmethod( "typeName" );
-        LJNBPairs_exposer.def( "__copy__", &__copy__);
-        LJNBPairs_exposer.def( "__deepcopy__", &__copy__);
-        LJNBPairs_exposer.def( "clone", &__copy__);
+        LJNBPairs_exposer.def( "__copy__", &__copy__<SireMM::LJNBPairs>);
+        LJNBPairs_exposer.def( "__deepcopy__", &__copy__<SireMM::LJNBPairs>);
+        LJNBPairs_exposer.def( "clone", &__copy__<SireMM::LJNBPairs>);
         LJNBPairs_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::LJNBPairs >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         LJNBPairs_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::LJNBPairs >,

--- a/wrapper/MM/LJParameter.pypp.cpp
+++ b/wrapper/MM/LJParameter.pypp.cpp
@@ -19,6 +19,8 @@ namespace bp = boost::python;
 
 SireMM::LJParameter __copy__(const SireMM::LJParameter &other){ return SireMM::LJParameter(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -280,9 +282,9 @@ void register_LJParameter_class(){
         LJParameter_exposer.staticmethod( "fromRMinAndEpsilon" );
         LJParameter_exposer.staticmethod( "fromSigmaAndEpsilon" );
         LJParameter_exposer.staticmethod( "typeName" );
-        LJParameter_exposer.def( "__copy__", &__copy__);
-        LJParameter_exposer.def( "__deepcopy__", &__copy__);
-        LJParameter_exposer.def( "clone", &__copy__);
+        LJParameter_exposer.def( "__copy__", &__copy__<SireMM::LJParameter>);
+        LJParameter_exposer.def( "__deepcopy__", &__copy__<SireMM::LJParameter>);
+        LJParameter_exposer.def( "clone", &__copy__<SireMM::LJParameter>);
         LJParameter_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::LJParameter >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         LJParameter_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::LJParameter >,

--- a/wrapper/MM/LJParameterName.pypp.cpp
+++ b/wrapper/MM/LJParameterName.pypp.cpp
@@ -45,6 +45,8 @@ namespace bp = boost::python;
 
 SireMM::LJParameterName __copy__(const SireMM::LJParameterName &other){ return SireMM::LJParameterName(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::LJParameterName&){ return "SireMM::LJParameterName";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -67,9 +69,9 @@ void register_LJParameterName_class(){
                 , "" );
         
         }
-        LJParameterName_exposer.def( "__copy__", &__copy__);
-        LJParameterName_exposer.def( "__deepcopy__", &__copy__);
-        LJParameterName_exposer.def( "clone", &__copy__);
+        LJParameterName_exposer.def( "__copy__", &__copy__<SireMM::LJParameterName>);
+        LJParameterName_exposer.def( "__deepcopy__", &__copy__<SireMM::LJParameterName>);
+        LJParameterName_exposer.def( "clone", &__copy__<SireMM::LJParameterName>);
         LJParameterName_exposer.def( "__str__", &pvt_get_name);
         LJParameterName_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/LJParameterName3D.pypp.cpp
+++ b/wrapper/MM/LJParameterName3D.pypp.cpp
@@ -45,6 +45,8 @@ namespace bp = boost::python;
 
 SireMM::LJParameterName3D __copy__(const SireMM::LJParameterName3D &other){ return SireMM::LJParameterName3D(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::LJParameterName3D&){ return "SireMM::LJParameterName3D";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -55,9 +57,9 @@ void register_LJParameterName3D_class(){
         typedef bp::class_< SireMM::LJParameterName3D, bp::bases< SireMM::LJParameterName > > LJParameterName3D_exposer_t;
         LJParameterName3D_exposer_t LJParameterName3D_exposer = LJParameterName3D_exposer_t( "LJParameterName3D", "This class provides the default name of the properties\nthat contain the LJ and 3D coordinates properties", bp::init< >("") );
         bp::scope LJParameterName3D_scope( LJParameterName3D_exposer );
-        LJParameterName3D_exposer.def( "__copy__", &__copy__);
-        LJParameterName3D_exposer.def( "__deepcopy__", &__copy__);
-        LJParameterName3D_exposer.def( "clone", &__copy__);
+        LJParameterName3D_exposer.def( "__copy__", &__copy__<SireMM::LJParameterName3D>);
+        LJParameterName3D_exposer.def( "__deepcopy__", &__copy__<SireMM::LJParameterName3D>);
+        LJParameterName3D_exposer.def( "clone", &__copy__<SireMM::LJParameterName3D>);
         LJParameterName3D_exposer.def( "__str__", &pvt_get_name);
         LJParameterName3D_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/LJPerturbation.pypp.cpp
+++ b/wrapper/MM/LJPerturbation.pypp.cpp
@@ -31,6 +31,8 @@ namespace bp = boost::python;
 
 SireMM::LJPerturbation __copy__(const SireMM::LJPerturbation &other){ return SireMM::LJPerturbation(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -267,9 +269,9 @@ void register_LJPerturbation_class(){
         
         }
         LJPerturbation_exposer.staticmethod( "typeName" );
-        LJPerturbation_exposer.def( "__copy__", &__copy__);
-        LJPerturbation_exposer.def( "__deepcopy__", &__copy__);
-        LJPerturbation_exposer.def( "clone", &__copy__);
+        LJPerturbation_exposer.def( "__copy__", &__copy__<SireMM::LJPerturbation>);
+        LJPerturbation_exposer.def( "__deepcopy__", &__copy__<SireMM::LJPerturbation>);
+        LJPerturbation_exposer.def( "clone", &__copy__<SireMM::LJPerturbation>);
         LJPerturbation_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::LJPerturbation >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         LJPerturbation_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::LJPerturbation >,

--- a/wrapper/MM/LJProbe.pypp.cpp
+++ b/wrapper/MM/LJProbe.pypp.cpp
@@ -17,6 +17,8 @@ namespace bp = boost::python;
 
 SireMM::LJProbe __copy__(const SireMM::LJProbe &other){ return SireMM::LJProbe(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -73,9 +75,9 @@ void register_LJProbe_class(){
         
         }
         LJProbe_exposer.staticmethod( "typeName" );
-        LJProbe_exposer.def( "__copy__", &__copy__);
-        LJProbe_exposer.def( "__deepcopy__", &__copy__);
-        LJProbe_exposer.def( "clone", &__copy__);
+        LJProbe_exposer.def( "__copy__", &__copy__<SireMM::LJProbe>);
+        LJProbe_exposer.def( "__deepcopy__", &__copy__<SireMM::LJProbe>);
+        LJProbe_exposer.def( "clone", &__copy__<SireMM::LJProbe>);
         LJProbe_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::LJProbe >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         LJProbe_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::LJProbe >,

--- a/wrapper/MM/LJScaleFactor.pypp.cpp
+++ b/wrapper/MM/LJScaleFactor.pypp.cpp
@@ -19,6 +19,8 @@ namespace bp = boost::python;
 
 SireMM::LJScaleFactor __copy__(const SireMM::LJScaleFactor &other){ return SireMM::LJScaleFactor(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 const char* pvt_get_name(const SireMM::LJScaleFactor&){ return "SireMM::LJScaleFactor";}
@@ -84,9 +86,9 @@ void register_LJScaleFactor_class(){
         
         }
         LJScaleFactor_exposer.staticmethod( "typeName" );
-        LJScaleFactor_exposer.def( "__copy__", &__copy__);
-        LJScaleFactor_exposer.def( "__deepcopy__", &__copy__);
-        LJScaleFactor_exposer.def( "clone", &__copy__);
+        LJScaleFactor_exposer.def( "__copy__", &__copy__<SireMM::LJScaleFactor>);
+        LJScaleFactor_exposer.def( "__deepcopy__", &__copy__<SireMM::LJScaleFactor>);
+        LJScaleFactor_exposer.def( "clone", &__copy__<SireMM::LJScaleFactor>);
         LJScaleFactor_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::LJScaleFactor >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         LJScaleFactor_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::LJScaleFactor >,

--- a/wrapper/MM/MMDetail.pypp.cpp
+++ b/wrapper/MM/MMDetail.pypp.cpp
@@ -21,6 +21,8 @@ namespace bp = boost::python;
 
 SireMM::MMDetail __copy__(const SireMM::MMDetail &other){ return SireMM::MMDetail(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -330,9 +332,9 @@ void register_MMDetail_class(){
         }
         MMDetail_exposer.staticmethod( "guessFrom" );
         MMDetail_exposer.staticmethod( "typeName" );
-        MMDetail_exposer.def( "__copy__", &__copy__);
-        MMDetail_exposer.def( "__deepcopy__", &__copy__);
-        MMDetail_exposer.def( "clone", &__copy__);
+        MMDetail_exposer.def( "__copy__", &__copy__<SireMM::MMDetail>);
+        MMDetail_exposer.def( "__deepcopy__", &__copy__<SireMM::MMDetail>);
+        MMDetail_exposer.def( "clone", &__copy__<SireMM::MMDetail>);
         MMDetail_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::MMDetail >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         MMDetail_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::MMDetail >,

--- a/wrapper/MM/Mover_Angle_.pypp.cpp
+++ b/wrapper/MM/Mover_Angle_.pypp.cpp
@@ -87,6 +87,8 @@ namespace bp = boost::python;
 
 SireMol::Mover<SireMM::Angle> __copy__(const SireMol::Mover<SireMM::Angle> &other){ return SireMol::Mover<SireMM::Angle>(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -478,9 +480,9 @@ void register_Mover_Angle__class(){
         
         }
         Mover_Angle__exposer.staticmethod( "typeName" );
-        Mover_Angle__exposer.def( "__copy__", &__copy__);
-        Mover_Angle__exposer.def( "__deepcopy__", &__copy__);
-        Mover_Angle__exposer.def( "clone", &__copy__);
+        Mover_Angle__exposer.def( "__copy__", &__copy__<SireMol::Mover<SireMM::Angle>>);
+        Mover_Angle__exposer.def( "__deepcopy__", &__copy__<SireMol::Mover<SireMM::Angle>>);
+        Mover_Angle__exposer.def( "clone", &__copy__<SireMol::Mover<SireMM::Angle>>);
         Mover_Angle__exposer.def( "__str__", &__str__< ::SireMol::Mover<SireMM::Angle> > );
         Mover_Angle__exposer.def( "__repr__", &__str__< ::SireMol::Mover<SireMM::Angle> > );
         Mover_Angle__exposer.def( "__len__", &__len_size< ::SireMol::Mover<SireMM::Angle> > );

--- a/wrapper/MM/Mover_Bond_.pypp.cpp
+++ b/wrapper/MM/Mover_Bond_.pypp.cpp
@@ -87,6 +87,8 @@ namespace bp = boost::python;
 
 SireMol::Mover<SireMM::Bond> __copy__(const SireMol::Mover<SireMM::Bond> &other){ return SireMol::Mover<SireMM::Bond>(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -478,9 +480,9 @@ void register_Mover_Bond__class(){
         
         }
         Mover_Bond__exposer.staticmethod( "typeName" );
-        Mover_Bond__exposer.def( "__copy__", &__copy__);
-        Mover_Bond__exposer.def( "__deepcopy__", &__copy__);
-        Mover_Bond__exposer.def( "clone", &__copy__);
+        Mover_Bond__exposer.def( "__copy__", &__copy__<SireMol::Mover<SireMM::Bond>>);
+        Mover_Bond__exposer.def( "__deepcopy__", &__copy__<SireMol::Mover<SireMM::Bond>>);
+        Mover_Bond__exposer.def( "clone", &__copy__<SireMol::Mover<SireMM::Bond>>);
         Mover_Bond__exposer.def( "__str__", &__str__< ::SireMol::Mover<SireMM::Bond> > );
         Mover_Bond__exposer.def( "__repr__", &__str__< ::SireMol::Mover<SireMM::Bond> > );
         Mover_Bond__exposer.def( "__len__", &__len_size< ::SireMol::Mover<SireMM::Bond> > );

--- a/wrapper/MM/Mover_Dihedral_.pypp.cpp
+++ b/wrapper/MM/Mover_Dihedral_.pypp.cpp
@@ -87,6 +87,8 @@ namespace bp = boost::python;
 
 SireMol::Mover<SireMM::Dihedral> __copy__(const SireMol::Mover<SireMM::Dihedral> &other){ return SireMol::Mover<SireMM::Dihedral>(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -478,9 +480,9 @@ void register_Mover_Dihedral__class(){
         
         }
         Mover_Dihedral__exposer.staticmethod( "typeName" );
-        Mover_Dihedral__exposer.def( "__copy__", &__copy__);
-        Mover_Dihedral__exposer.def( "__deepcopy__", &__copy__);
-        Mover_Dihedral__exposer.def( "clone", &__copy__);
+        Mover_Dihedral__exposer.def( "__copy__", &__copy__<SireMol::Mover<SireMM::Dihedral>>);
+        Mover_Dihedral__exposer.def( "__deepcopy__", &__copy__<SireMol::Mover<SireMM::Dihedral>>);
+        Mover_Dihedral__exposer.def( "clone", &__copy__<SireMol::Mover<SireMM::Dihedral>>);
         Mover_Dihedral__exposer.def( "__str__", &__str__< ::SireMol::Mover<SireMM::Dihedral> > );
         Mover_Dihedral__exposer.def( "__repr__", &__str__< ::SireMol::Mover<SireMM::Dihedral> > );
         Mover_Dihedral__exposer.def( "__len__", &__len_size< ::SireMol::Mover<SireMM::Dihedral> > );

--- a/wrapper/MM/Mover_Improper_.pypp.cpp
+++ b/wrapper/MM/Mover_Improper_.pypp.cpp
@@ -89,6 +89,8 @@ namespace bp = boost::python;
 
 SireMol::Mover<SireMM::Improper> __copy__(const SireMol::Mover<SireMM::Improper> &other){ return SireMol::Mover<SireMM::Improper>(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -480,9 +482,9 @@ void register_Mover_Improper__class(){
         
         }
         Mover_Improper__exposer.staticmethod( "typeName" );
-        Mover_Improper__exposer.def( "__copy__", &__copy__);
-        Mover_Improper__exposer.def( "__deepcopy__", &__copy__);
-        Mover_Improper__exposer.def( "clone", &__copy__);
+        Mover_Improper__exposer.def( "__copy__", &__copy__<SireMol::Mover<SireMM::Improper>>);
+        Mover_Improper__exposer.def( "__deepcopy__", &__copy__<SireMol::Mover<SireMM::Improper>>);
+        Mover_Improper__exposer.def( "clone", &__copy__<SireMol::Mover<SireMM::Improper>>);
         Mover_Improper__exposer.def( "__str__", &__str__< ::SireMol::Mover<SireMM::Improper> > );
         Mover_Improper__exposer.def( "__repr__", &__str__< ::SireMol::Mover<SireMM::Improper> > );
         Mover_Improper__exposer.def( "__len__", &__len_size< ::SireMol::Mover<SireMM::Improper> > );

--- a/wrapper/MM/Mover_SelectorAngle_.pypp.cpp
+++ b/wrapper/MM/Mover_SelectorAngle_.pypp.cpp
@@ -87,6 +87,8 @@ namespace bp = boost::python;
 
 SireMol::Mover<SireMM::SelectorAngle> __copy__(const SireMol::Mover<SireMM::SelectorAngle> &other){ return SireMol::Mover<SireMM::SelectorAngle>(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -478,9 +480,9 @@ void register_Mover_SelectorAngle__class(){
         
         }
         Mover_SelectorAngle__exposer.staticmethod( "typeName" );
-        Mover_SelectorAngle__exposer.def( "__copy__", &__copy__);
-        Mover_SelectorAngle__exposer.def( "__deepcopy__", &__copy__);
-        Mover_SelectorAngle__exposer.def( "clone", &__copy__);
+        Mover_SelectorAngle__exposer.def( "__copy__", &__copy__<SireMol::Mover<SireMM::SelectorAngle>>);
+        Mover_SelectorAngle__exposer.def( "__deepcopy__", &__copy__<SireMol::Mover<SireMM::SelectorAngle>>);
+        Mover_SelectorAngle__exposer.def( "clone", &__copy__<SireMol::Mover<SireMM::SelectorAngle>>);
         Mover_SelectorAngle__exposer.def( "__str__", &__str__< ::SireMol::Mover<SireMM::SelectorAngle> > );
         Mover_SelectorAngle__exposer.def( "__repr__", &__str__< ::SireMol::Mover<SireMM::SelectorAngle> > );
         Mover_SelectorAngle__exposer.def( "__len__", &__len_size< ::SireMol::Mover<SireMM::SelectorAngle> > );

--- a/wrapper/MM/Mover_SelectorBond_.pypp.cpp
+++ b/wrapper/MM/Mover_SelectorBond_.pypp.cpp
@@ -85,6 +85,8 @@ namespace bp = boost::python;
 
 SireMol::Mover<SireMM::SelectorBond> __copy__(const SireMol::Mover<SireMM::SelectorBond> &other){ return SireMol::Mover<SireMM::SelectorBond>(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -476,9 +478,9 @@ void register_Mover_SelectorBond__class(){
         
         }
         Mover_SelectorBond__exposer.staticmethod( "typeName" );
-        Mover_SelectorBond__exposer.def( "__copy__", &__copy__);
-        Mover_SelectorBond__exposer.def( "__deepcopy__", &__copy__);
-        Mover_SelectorBond__exposer.def( "clone", &__copy__);
+        Mover_SelectorBond__exposer.def( "__copy__", &__copy__<SireMol::Mover<SireMM::SelectorBond>>);
+        Mover_SelectorBond__exposer.def( "__deepcopy__", &__copy__<SireMol::Mover<SireMM::SelectorBond>>);
+        Mover_SelectorBond__exposer.def( "clone", &__copy__<SireMol::Mover<SireMM::SelectorBond>>);
         Mover_SelectorBond__exposer.def( "__str__", &__str__< ::SireMol::Mover<SireMM::SelectorBond> > );
         Mover_SelectorBond__exposer.def( "__repr__", &__str__< ::SireMol::Mover<SireMM::SelectorBond> > );
         Mover_SelectorBond__exposer.def( "__len__", &__len_size< ::SireMol::Mover<SireMM::SelectorBond> > );

--- a/wrapper/MM/Mover_SelectorDihedral_.pypp.cpp
+++ b/wrapper/MM/Mover_SelectorDihedral_.pypp.cpp
@@ -85,6 +85,8 @@ namespace bp = boost::python;
 
 SireMol::Mover<SireMM::SelectorDihedral> __copy__(const SireMol::Mover<SireMM::SelectorDihedral> &other){ return SireMol::Mover<SireMM::SelectorDihedral>(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -476,9 +478,9 @@ void register_Mover_SelectorDihedral__class(){
         
         }
         Mover_SelectorDihedral__exposer.staticmethod( "typeName" );
-        Mover_SelectorDihedral__exposer.def( "__copy__", &__copy__);
-        Mover_SelectorDihedral__exposer.def( "__deepcopy__", &__copy__);
-        Mover_SelectorDihedral__exposer.def( "clone", &__copy__);
+        Mover_SelectorDihedral__exposer.def( "__copy__", &__copy__<SireMol::Mover<SireMM::SelectorDihedral>>);
+        Mover_SelectorDihedral__exposer.def( "__deepcopy__", &__copy__<SireMol::Mover<SireMM::SelectorDihedral>>);
+        Mover_SelectorDihedral__exposer.def( "clone", &__copy__<SireMol::Mover<SireMM::SelectorDihedral>>);
         Mover_SelectorDihedral__exposer.def( "__str__", &__str__< ::SireMol::Mover<SireMM::SelectorDihedral> > );
         Mover_SelectorDihedral__exposer.def( "__repr__", &__str__< ::SireMol::Mover<SireMM::SelectorDihedral> > );
         Mover_SelectorDihedral__exposer.def( "__len__", &__len_size< ::SireMol::Mover<SireMM::SelectorDihedral> > );

--- a/wrapper/MM/Mover_SelectorImproper_.pypp.cpp
+++ b/wrapper/MM/Mover_SelectorImproper_.pypp.cpp
@@ -85,6 +85,8 @@ namespace bp = boost::python;
 
 SireMol::Mover<SireMM::SelectorImproper> __copy__(const SireMol::Mover<SireMM::SelectorImproper> &other){ return SireMol::Mover<SireMM::SelectorImproper>(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Helpers/str.hpp"
 
 #include "Helpers/release_gil_policy.hpp"
@@ -476,9 +478,9 @@ void register_Mover_SelectorImproper__class(){
         
         }
         Mover_SelectorImproper__exposer.staticmethod( "typeName" );
-        Mover_SelectorImproper__exposer.def( "__copy__", &__copy__);
-        Mover_SelectorImproper__exposer.def( "__deepcopy__", &__copy__);
-        Mover_SelectorImproper__exposer.def( "clone", &__copy__);
+        Mover_SelectorImproper__exposer.def( "__copy__", &__copy__<SireMol::Mover<SireMM::SelectorImproper>>);
+        Mover_SelectorImproper__exposer.def( "__deepcopy__", &__copy__<SireMol::Mover<SireMM::SelectorImproper>>);
+        Mover_SelectorImproper__exposer.def( "clone", &__copy__<SireMol::Mover<SireMM::SelectorImproper>>);
         Mover_SelectorImproper__exposer.def( "__str__", &__str__< ::SireMol::Mover<SireMM::SelectorImproper> > );
         Mover_SelectorImproper__exposer.def( "__repr__", &__str__< ::SireMol::Mover<SireMM::SelectorImproper> > );
         Mover_SelectorImproper__exposer.def( "__len__", &__len_size< ::SireMol::Mover<SireMM::SelectorImproper> > );

--- a/wrapper/MM/MultiCLJComponent.pypp.cpp
+++ b/wrapper/MM/MultiCLJComponent.pypp.cpp
@@ -20,6 +20,8 @@ namespace bp = boost::python;
 
 SireMM::MultiCLJComponent __copy__(const SireMM::MultiCLJComponent &other){ return SireMM::MultiCLJComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -325,9 +327,9 @@ void register_MultiCLJComponent_class(){
         
         }
         MultiCLJComponent_exposer.staticmethod( "typeName" );
-        MultiCLJComponent_exposer.def( "__copy__", &__copy__);
-        MultiCLJComponent_exposer.def( "__deepcopy__", &__copy__);
-        MultiCLJComponent_exposer.def( "clone", &__copy__);
+        MultiCLJComponent_exposer.def( "__copy__", &__copy__<SireMM::MultiCLJComponent>);
+        MultiCLJComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::MultiCLJComponent>);
+        MultiCLJComponent_exposer.def( "clone", &__copy__<SireMM::MultiCLJComponent>);
         MultiCLJComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::MultiCLJComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         MultiCLJComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::MultiCLJComponent >,

--- a/wrapper/MM/NoCutoff.pypp.cpp
+++ b/wrapper/MM/NoCutoff.pypp.cpp
@@ -29,6 +29,8 @@ namespace bp = boost::python;
 
 SireMM::NoCutoff __copy__(const SireMM::NoCutoff &other){ return SireMM::NoCutoff(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -134,9 +136,9 @@ void register_NoCutoff_class(){
         
         }
         NoCutoff_exposer.staticmethod( "typeName" );
-        NoCutoff_exposer.def( "__copy__", &__copy__);
-        NoCutoff_exposer.def( "__deepcopy__", &__copy__);
-        NoCutoff_exposer.def( "clone", &__copy__);
+        NoCutoff_exposer.def( "__copy__", &__copy__<SireMM::NoCutoff>);
+        NoCutoff_exposer.def( "__deepcopy__", &__copy__<SireMM::NoCutoff>);
+        NoCutoff_exposer.def( "clone", &__copy__<SireMM::NoCutoff>);
         NoCutoff_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::NoCutoff >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         NoCutoff_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::NoCutoff >,

--- a/wrapper/MM/NullCLJFunction.pypp.cpp
+++ b/wrapper/MM/NullCLJFunction.pypp.cpp
@@ -53,6 +53,8 @@ namespace bp = boost::python;
 
 SireMM::NullCLJFunction __copy__(const SireMM::NullCLJFunction &other){ return SireMM::NullCLJFunction(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -106,9 +108,9 @@ void register_NullCLJFunction_class(){
         
         }
         NullCLJFunction_exposer.staticmethod( "typeName" );
-        NullCLJFunction_exposer.def( "__copy__", &__copy__);
-        NullCLJFunction_exposer.def( "__deepcopy__", &__copy__);
-        NullCLJFunction_exposer.def( "clone", &__copy__);
+        NullCLJFunction_exposer.def( "__copy__", &__copy__<SireMM::NullCLJFunction>);
+        NullCLJFunction_exposer.def( "__deepcopy__", &__copy__<SireMM::NullCLJFunction>);
+        NullCLJFunction_exposer.def( "clone", &__copy__<SireMM::NullCLJFunction>);
         NullCLJFunction_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::NullCLJFunction >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         NullCLJFunction_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::NullCLJFunction >,

--- a/wrapper/MM/NullRestraint.pypp.cpp
+++ b/wrapper/MM/NullRestraint.pypp.cpp
@@ -37,6 +37,8 @@ namespace bp = boost::python;
 
 SireMM::NullRestraint __copy__(const SireMM::NullRestraint &other){ return SireMM::NullRestraint(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -340,9 +342,9 @@ void register_NullRestraint_class(){
         
         }
         NullRestraint_exposer.staticmethod( "typeName" );
-        NullRestraint_exposer.def( "__copy__", &__copy__);
-        NullRestraint_exposer.def( "__deepcopy__", &__copy__);
-        NullRestraint_exposer.def( "clone", &__copy__);
+        NullRestraint_exposer.def( "__copy__", &__copy__<SireMM::NullRestraint>);
+        NullRestraint_exposer.def( "__deepcopy__", &__copy__<SireMM::NullRestraint>);
+        NullRestraint_exposer.def( "clone", &__copy__<SireMM::NullRestraint>);
         NullRestraint_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::NullRestraint >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         NullRestraint_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::NullRestraint >,

--- a/wrapper/MM/PositionalRestraint.pypp.cpp
+++ b/wrapper/MM/PositionalRestraint.pypp.cpp
@@ -25,6 +25,8 @@ namespace bp = boost::python;
 
 SireMM::PositionalRestraint __copy__(const SireMM::PositionalRestraint &other){ return SireMM::PositionalRestraint(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -190,9 +192,9 @@ void register_PositionalRestraint_class(){
         
         }
         PositionalRestraint_exposer.staticmethod( "typeName" );
-        PositionalRestraint_exposer.def( "__copy__", &__copy__);
-        PositionalRestraint_exposer.def( "__deepcopy__", &__copy__);
-        PositionalRestraint_exposer.def( "clone", &__copy__);
+        PositionalRestraint_exposer.def( "__copy__", &__copy__<SireMM::PositionalRestraint>);
+        PositionalRestraint_exposer.def( "__deepcopy__", &__copy__<SireMM::PositionalRestraint>);
+        PositionalRestraint_exposer.def( "clone", &__copy__<SireMM::PositionalRestraint>);
         PositionalRestraint_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::PositionalRestraint >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         PositionalRestraint_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::PositionalRestraint >,

--- a/wrapper/MM/PositionalRestraints.pypp.cpp
+++ b/wrapper/MM/PositionalRestraints.pypp.cpp
@@ -26,6 +26,8 @@ namespace bp = boost::python;
 
 SireMM::PositionalRestraints __copy__(const SireMM::PositionalRestraints &other){ return SireMM::PositionalRestraints(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -296,9 +298,9 @@ void register_PositionalRestraints_class(){
         
         }
         PositionalRestraints_exposer.staticmethod( "typeName" );
-        PositionalRestraints_exposer.def( "__copy__", &__copy__);
-        PositionalRestraints_exposer.def( "__deepcopy__", &__copy__);
-        PositionalRestraints_exposer.def( "clone", &__copy__);
+        PositionalRestraints_exposer.def( "__copy__", &__copy__<SireMM::PositionalRestraints>);
+        PositionalRestraints_exposer.def( "__deepcopy__", &__copy__<SireMM::PositionalRestraints>);
+        PositionalRestraints_exposer.def( "clone", &__copy__<SireMM::PositionalRestraints>);
         PositionalRestraints_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::PositionalRestraints >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         PositionalRestraints_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::PositionalRestraints >,

--- a/wrapper/MM/RestraintComponent.pypp.cpp
+++ b/wrapper/MM/RestraintComponent.pypp.cpp
@@ -16,6 +16,8 @@ namespace bp = boost::python;
 
 SireMM::RestraintComponent __copy__(const SireMM::RestraintComponent &other){ return SireMM::RestraintComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -106,9 +108,9 @@ void register_RestraintComponent_class(){
         
         }
         RestraintComponent_exposer.staticmethod( "typeName" );
-        RestraintComponent_exposer.def( "__copy__", &__copy__);
-        RestraintComponent_exposer.def( "__deepcopy__", &__copy__);
-        RestraintComponent_exposer.def( "clone", &__copy__);
+        RestraintComponent_exposer.def( "__copy__", &__copy__<SireMM::RestraintComponent>);
+        RestraintComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::RestraintComponent>);
+        RestraintComponent_exposer.def( "clone", &__copy__<SireMM::RestraintComponent>);
         RestraintComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::RestraintComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         RestraintComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::RestraintComponent >,

--- a/wrapper/MM/RestraintFF.pypp.cpp
+++ b/wrapper/MM/RestraintFF.pypp.cpp
@@ -40,6 +40,8 @@ namespace bp = boost::python;
 
 SireMM::RestraintFF __copy__(const SireMM::RestraintFF &other){ return SireMM::RestraintFF(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -517,9 +519,9 @@ void register_RestraintFF_class(){
         
         }
         RestraintFF_exposer.staticmethod( "typeName" );
-        RestraintFF_exposer.def( "__copy__", &__copy__);
-        RestraintFF_exposer.def( "__deepcopy__", &__copy__);
-        RestraintFF_exposer.def( "clone", &__copy__);
+        RestraintFF_exposer.def( "__copy__", &__copy__<SireMM::RestraintFF>);
+        RestraintFF_exposer.def( "__deepcopy__", &__copy__<SireMM::RestraintFF>);
+        RestraintFF_exposer.def( "clone", &__copy__<SireMM::RestraintFF>);
         RestraintFF_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::RestraintFF >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         RestraintFF_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::RestraintFF >,

--- a/wrapper/MM/ScaledCLJParameterNames3D.pypp.cpp
+++ b/wrapper/MM/ScaledCLJParameterNames3D.pypp.cpp
@@ -43,6 +43,8 @@ namespace bp = boost::python;
 
 SireMM::ScaledCLJParameterNames3D __copy__(const SireMM::ScaledCLJParameterNames3D &other){ return SireMM::ScaledCLJParameterNames3D(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::ScaledCLJParameterNames3D&){ return "SireMM::ScaledCLJParameterNames3D";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -53,9 +55,9 @@ void register_ScaledCLJParameterNames3D_class(){
         typedef bp::class_< SireMM::ScaledCLJParameterNames3D, bp::bases< SireMM::CLJParameterNames3D, SireMM::CLJParameterNames, SireMM::LJParameterName, SireMM::ChargeParameterName > > ScaledCLJParameterNames3D_exposer_t;
         ScaledCLJParameterNames3D_exposer_t ScaledCLJParameterNames3D_exposer = ScaledCLJParameterNames3D_exposer_t( "ScaledCLJParameterNames3D", "This class provides the default name of the properties\nthat contain the charge, LJ, intramolecular NB scale parameters and\n3D coordinates properties", bp::init< >("") );
         bp::scope ScaledCLJParameterNames3D_scope( ScaledCLJParameterNames3D_exposer );
-        ScaledCLJParameterNames3D_exposer.def( "__copy__", &__copy__);
-        ScaledCLJParameterNames3D_exposer.def( "__deepcopy__", &__copy__);
-        ScaledCLJParameterNames3D_exposer.def( "clone", &__copy__);
+        ScaledCLJParameterNames3D_exposer.def( "__copy__", &__copy__<SireMM::ScaledCLJParameterNames3D>);
+        ScaledCLJParameterNames3D_exposer.def( "__deepcopy__", &__copy__<SireMM::ScaledCLJParameterNames3D>);
+        ScaledCLJParameterNames3D_exposer.def( "clone", &__copy__<SireMM::ScaledCLJParameterNames3D>);
         ScaledCLJParameterNames3D_exposer.def( "__str__", &pvt_get_name);
         ScaledCLJParameterNames3D_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/ScaledChargeParameterNames3D.pypp.cpp
+++ b/wrapper/MM/ScaledChargeParameterNames3D.pypp.cpp
@@ -41,6 +41,8 @@ namespace bp = boost::python;
 
 SireMM::ScaledChargeParameterNames3D __copy__(const SireMM::ScaledChargeParameterNames3D &other){ return SireMM::ScaledChargeParameterNames3D(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::ScaledChargeParameterNames3D&){ return "SireMM::ScaledChargeParameterNames3D";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -51,9 +53,9 @@ void register_ScaledChargeParameterNames3D_class(){
         typedef bp::class_< SireMM::ScaledChargeParameterNames3D, bp::bases< SireMM::ChargeParameterName3D, SireMM::ChargeParameterName > > ScaledChargeParameterNames3D_exposer_t;
         ScaledChargeParameterNames3D_exposer_t ScaledChargeParameterNames3D_exposer = ScaledChargeParameterNames3D_exposer_t( "ScaledChargeParameterNames3D", "This class provides the default name of the properties\nthat contain the charge and intramolecular NB scale parameters and\n3D coordinates properties", bp::init< >("") );
         bp::scope ScaledChargeParameterNames3D_scope( ScaledChargeParameterNames3D_exposer );
-        ScaledChargeParameterNames3D_exposer.def( "__copy__", &__copy__);
-        ScaledChargeParameterNames3D_exposer.def( "__deepcopy__", &__copy__);
-        ScaledChargeParameterNames3D_exposer.def( "clone", &__copy__);
+        ScaledChargeParameterNames3D_exposer.def( "__copy__", &__copy__<SireMM::ScaledChargeParameterNames3D>);
+        ScaledChargeParameterNames3D_exposer.def( "__deepcopy__", &__copy__<SireMM::ScaledChargeParameterNames3D>);
+        ScaledChargeParameterNames3D_exposer.def( "clone", &__copy__<SireMM::ScaledChargeParameterNames3D>);
         ScaledChargeParameterNames3D_exposer.def( "__str__", &pvt_get_name);
         ScaledChargeParameterNames3D_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/ScaledLJParameterNames3D.pypp.cpp
+++ b/wrapper/MM/ScaledLJParameterNames3D.pypp.cpp
@@ -45,6 +45,8 @@ namespace bp = boost::python;
 
 SireMM::ScaledLJParameterNames3D __copy__(const SireMM::ScaledLJParameterNames3D &other){ return SireMM::ScaledLJParameterNames3D(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::ScaledLJParameterNames3D&){ return "SireMM::ScaledLJParameterNames3D";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -55,9 +57,9 @@ void register_ScaledLJParameterNames3D_class(){
         typedef bp::class_< SireMM::ScaledLJParameterNames3D, bp::bases< SireMM::LJParameterName3D, SireMM::LJParameterName > > ScaledLJParameterNames3D_exposer_t;
         ScaledLJParameterNames3D_exposer_t ScaledLJParameterNames3D_exposer = ScaledLJParameterNames3D_exposer_t( "ScaledLJParameterNames3D", "This class provides the default name of the properties\nthat contain the LJ, intramolecular NB scale parameters and\n3D coordinates properties", bp::init< >("") );
         bp::scope ScaledLJParameterNames3D_scope( ScaledLJParameterNames3D_exposer );
-        ScaledLJParameterNames3D_exposer.def( "__copy__", &__copy__);
-        ScaledLJParameterNames3D_exposer.def( "__deepcopy__", &__copy__);
-        ScaledLJParameterNames3D_exposer.def( "clone", &__copy__);
+        ScaledLJParameterNames3D_exposer.def( "__copy__", &__copy__<SireMM::ScaledLJParameterNames3D>);
+        ScaledLJParameterNames3D_exposer.def( "__deepcopy__", &__copy__<SireMM::ScaledLJParameterNames3D>);
+        ScaledLJParameterNames3D_exposer.def( "clone", &__copy__<SireMM::ScaledLJParameterNames3D>);
         ScaledLJParameterNames3D_exposer.def( "__str__", &pvt_get_name);
         ScaledLJParameterNames3D_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/SelectorAngle.pypp.cpp
+++ b/wrapper/MM/SelectorAngle.pypp.cpp
@@ -41,6 +41,8 @@ namespace bp = boost::python;
 
 SireMM::SelectorAngle __copy__(const SireMM::SelectorAngle &other){ return SireMM::SelectorAngle(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -677,9 +679,9 @@ void register_SelectorAngle_class(){
         
         }
         SelectorAngle_exposer.staticmethod( "typeName" );
-        SelectorAngle_exposer.def( "__copy__", &__copy__);
-        SelectorAngle_exposer.def( "__deepcopy__", &__copy__);
-        SelectorAngle_exposer.def( "clone", &__copy__);
+        SelectorAngle_exposer.def( "__copy__", &__copy__<SireMM::SelectorAngle>);
+        SelectorAngle_exposer.def( "__deepcopy__", &__copy__<SireMM::SelectorAngle>);
+        SelectorAngle_exposer.def( "clone", &__copy__<SireMM::SelectorAngle>);
         SelectorAngle_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::SelectorAngle >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         SelectorAngle_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::SelectorAngle >,

--- a/wrapper/MM/SelectorBond.pypp.cpp
+++ b/wrapper/MM/SelectorBond.pypp.cpp
@@ -39,6 +39,8 @@ namespace bp = boost::python;
 
 SireMM::SelectorBond __copy__(const SireMM::SelectorBond &other){ return SireMM::SelectorBond(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -672,9 +674,9 @@ void register_SelectorBond_class(){
         
         }
         SelectorBond_exposer.staticmethod( "typeName" );
-        SelectorBond_exposer.def( "__copy__", &__copy__);
-        SelectorBond_exposer.def( "__deepcopy__", &__copy__);
-        SelectorBond_exposer.def( "clone", &__copy__);
+        SelectorBond_exposer.def( "__copy__", &__copy__<SireMM::SelectorBond>);
+        SelectorBond_exposer.def( "__deepcopy__", &__copy__<SireMM::SelectorBond>);
+        SelectorBond_exposer.def( "clone", &__copy__<SireMM::SelectorBond>);
         SelectorBond_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::SelectorBond >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         SelectorBond_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::SelectorBond >,

--- a/wrapper/MM/SelectorDihedral.pypp.cpp
+++ b/wrapper/MM/SelectorDihedral.pypp.cpp
@@ -39,6 +39,8 @@ namespace bp = boost::python;
 
 SireMM::SelectorDihedral __copy__(const SireMM::SelectorDihedral &other){ return SireMM::SelectorDihedral(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -678,9 +680,9 @@ void register_SelectorDihedral_class(){
         
         }
         SelectorDihedral_exposer.staticmethod( "typeName" );
-        SelectorDihedral_exposer.def( "__copy__", &__copy__);
-        SelectorDihedral_exposer.def( "__deepcopy__", &__copy__);
-        SelectorDihedral_exposer.def( "clone", &__copy__);
+        SelectorDihedral_exposer.def( "__copy__", &__copy__<SireMM::SelectorDihedral>);
+        SelectorDihedral_exposer.def( "__deepcopy__", &__copy__<SireMM::SelectorDihedral>);
+        SelectorDihedral_exposer.def( "clone", &__copy__<SireMM::SelectorDihedral>);
         SelectorDihedral_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::SelectorDihedral >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         SelectorDihedral_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::SelectorDihedral >,

--- a/wrapper/MM/SelectorImproper.pypp.cpp
+++ b/wrapper/MM/SelectorImproper.pypp.cpp
@@ -39,6 +39,8 @@ namespace bp = boost::python;
 
 SireMM::SelectorImproper __copy__(const SireMM::SelectorImproper &other){ return SireMM::SelectorImproper(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -678,9 +680,9 @@ void register_SelectorImproper_class(){
         
         }
         SelectorImproper_exposer.staticmethod( "typeName" );
-        SelectorImproper_exposer.def( "__copy__", &__copy__);
-        SelectorImproper_exposer.def( "__deepcopy__", &__copy__);
-        SelectorImproper_exposer.def( "clone", &__copy__);
+        SelectorImproper_exposer.def( "__copy__", &__copy__<SireMM::SelectorImproper>);
+        SelectorImproper_exposer.def( "__deepcopy__", &__copy__<SireMM::SelectorImproper>);
+        SelectorImproper_exposer.def( "clone", &__copy__<SireMM::SelectorImproper>);
         SelectorImproper_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::SelectorImproper >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         SelectorImproper_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::SelectorImproper >,

--- a/wrapper/MM/SelectorMAngle.pypp.cpp
+++ b/wrapper/MM/SelectorMAngle.pypp.cpp
@@ -29,6 +29,8 @@ namespace bp = boost::python;
 
 SireMM::SelectorMAngle __copy__(const SireMM::SelectorMAngle &other){ return SireMM::SelectorMAngle(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -1566,9 +1568,9 @@ void register_SelectorMAngle_class(){
         
         }
         SelectorMAngle_exposer.staticmethod( "typeName" );
-        SelectorMAngle_exposer.def( "__copy__", &__copy__);
-        SelectorMAngle_exposer.def( "__deepcopy__", &__copy__);
-        SelectorMAngle_exposer.def( "clone", &__copy__);
+        SelectorMAngle_exposer.def( "__copy__", &__copy__<SireMM::SelectorMAngle>);
+        SelectorMAngle_exposer.def( "__deepcopy__", &__copy__<SireMM::SelectorMAngle>);
+        SelectorMAngle_exposer.def( "clone", &__copy__<SireMM::SelectorMAngle>);
         SelectorMAngle_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::SelectorMAngle >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         SelectorMAngle_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::SelectorMAngle >,

--- a/wrapper/MM/SelectorMBond.pypp.cpp
+++ b/wrapper/MM/SelectorMBond.pypp.cpp
@@ -29,6 +29,8 @@ namespace bp = boost::python;
 
 SireMM::SelectorMBond __copy__(const SireMM::SelectorMBond &other){ return SireMM::SelectorMBond(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -1565,9 +1567,9 @@ void register_SelectorMBond_class(){
         
         }
         SelectorMBond_exposer.staticmethod( "typeName" );
-        SelectorMBond_exposer.def( "__copy__", &__copy__);
-        SelectorMBond_exposer.def( "__deepcopy__", &__copy__);
-        SelectorMBond_exposer.def( "clone", &__copy__);
+        SelectorMBond_exposer.def( "__copy__", &__copy__<SireMM::SelectorMBond>);
+        SelectorMBond_exposer.def( "__deepcopy__", &__copy__<SireMM::SelectorMBond>);
+        SelectorMBond_exposer.def( "clone", &__copy__<SireMM::SelectorMBond>);
         SelectorMBond_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::SelectorMBond >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         SelectorMBond_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::SelectorMBond >,

--- a/wrapper/MM/SelectorMDihedral.pypp.cpp
+++ b/wrapper/MM/SelectorMDihedral.pypp.cpp
@@ -27,6 +27,8 @@ namespace bp = boost::python;
 
 SireMM::SelectorMDihedral __copy__(const SireMM::SelectorMDihedral &other){ return SireMM::SelectorMDihedral(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -1565,9 +1567,9 @@ void register_SelectorMDihedral_class(){
         
         }
         SelectorMDihedral_exposer.staticmethod( "typeName" );
-        SelectorMDihedral_exposer.def( "__copy__", &__copy__);
-        SelectorMDihedral_exposer.def( "__deepcopy__", &__copy__);
-        SelectorMDihedral_exposer.def( "clone", &__copy__);
+        SelectorMDihedral_exposer.def( "__copy__", &__copy__<SireMM::SelectorMDihedral>);
+        SelectorMDihedral_exposer.def( "__deepcopy__", &__copy__<SireMM::SelectorMDihedral>);
+        SelectorMDihedral_exposer.def( "clone", &__copy__<SireMM::SelectorMDihedral>);
         SelectorMDihedral_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::SelectorMDihedral >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         SelectorMDihedral_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::SelectorMDihedral >,

--- a/wrapper/MM/SelectorMImproper.pypp.cpp
+++ b/wrapper/MM/SelectorMImproper.pypp.cpp
@@ -29,6 +29,8 @@ namespace bp = boost::python;
 
 SireMM::SelectorMImproper __copy__(const SireMM::SelectorMImproper &other){ return SireMM::SelectorMImproper(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -1567,9 +1569,9 @@ void register_SelectorMImproper_class(){
         
         }
         SelectorMImproper_exposer.staticmethod( "typeName" );
-        SelectorMImproper_exposer.def( "__copy__", &__copy__);
-        SelectorMImproper_exposer.def( "__deepcopy__", &__copy__);
-        SelectorMImproper_exposer.def( "clone", &__copy__);
+        SelectorMImproper_exposer.def( "__copy__", &__copy__<SireMM::SelectorMImproper>);
+        SelectorMImproper_exposer.def( "__deepcopy__", &__copy__<SireMM::SelectorMImproper>);
+        SelectorMImproper_exposer.def( "clone", &__copy__<SireMM::SelectorMImproper>);
         SelectorMImproper_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::SelectorMImproper >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         SelectorMImproper_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::SelectorMImproper >,

--- a/wrapper/MM/SoftCLJComponent.pypp.cpp
+++ b/wrapper/MM/SoftCLJComponent.pypp.cpp
@@ -22,6 +22,8 @@ namespace bp = boost::python;
 
 SireMM::SoftCLJComponent __copy__(const SireMM::SoftCLJComponent &other){ return SireMM::SoftCLJComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -227,9 +229,9 @@ void register_SoftCLJComponent_class(){
         }
         SoftCLJComponent_exposer.staticmethod( "nAlphaValues" );
         SoftCLJComponent_exposer.staticmethod( "typeName" );
-        SoftCLJComponent_exposer.def( "__copy__", &__copy__);
-        SoftCLJComponent_exposer.def( "__deepcopy__", &__copy__);
-        SoftCLJComponent_exposer.def( "clone", &__copy__);
+        SoftCLJComponent_exposer.def( "__copy__", &__copy__<SireMM::SoftCLJComponent>);
+        SoftCLJComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::SoftCLJComponent>);
+        SoftCLJComponent_exposer.def( "clone", &__copy__<SireMM::SoftCLJComponent>);
         SoftCLJComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::SoftCLJComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         SoftCLJComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::SoftCLJComponent >,

--- a/wrapper/MM/StretchBendComponent.pypp.cpp
+++ b/wrapper/MM/StretchBendComponent.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireMM::StretchBendComponent __copy__(const SireMM::StretchBendComponent &other){ return SireMM::StretchBendComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -107,9 +109,9 @@ void register_StretchBendComponent_class(){
         
         }
         StretchBendComponent_exposer.staticmethod( "typeName" );
-        StretchBendComponent_exposer.def( "__copy__", &__copy__);
-        StretchBendComponent_exposer.def( "__deepcopy__", &__copy__);
-        StretchBendComponent_exposer.def( "clone", &__copy__);
+        StretchBendComponent_exposer.def( "__copy__", &__copy__<SireMM::StretchBendComponent>);
+        StretchBendComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::StretchBendComponent>);
+        StretchBendComponent_exposer.def( "clone", &__copy__<SireMM::StretchBendComponent>);
         StretchBendComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::StretchBendComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         StretchBendComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::StretchBendComponent >,

--- a/wrapper/MM/StretchBendParameterName.pypp.cpp
+++ b/wrapper/MM/StretchBendParameterName.pypp.cpp
@@ -49,6 +49,8 @@ namespace bp = boost::python;
 
 SireMM::StretchBendParameterName __copy__(const SireMM::StretchBendParameterName &other){ return SireMM::StretchBendParameterName(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::StretchBendParameterName&){ return "SireMM::StretchBendParameterName";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -71,9 +73,9 @@ void register_StretchBendParameterName_class(){
                 , "" );
         
         }
-        StretchBendParameterName_exposer.def( "__copy__", &__copy__);
-        StretchBendParameterName_exposer.def( "__deepcopy__", &__copy__);
-        StretchBendParameterName_exposer.def( "clone", &__copy__);
+        StretchBendParameterName_exposer.def( "__copy__", &__copy__<SireMM::StretchBendParameterName>);
+        StretchBendParameterName_exposer.def( "__deepcopy__", &__copy__<SireMM::StretchBendParameterName>);
+        StretchBendParameterName_exposer.def( "clone", &__copy__<SireMM::StretchBendParameterName>);
         StretchBendParameterName_exposer.def( "__str__", &pvt_get_name);
         StretchBendParameterName_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/StretchBendSymbols.pypp.cpp
+++ b/wrapper/MM/StretchBendSymbols.pypp.cpp
@@ -34,6 +34,8 @@ namespace bp = boost::python;
 
 SireMM::StretchBendSymbols __copy__(const SireMM::StretchBendSymbols &other){ return SireMM::StretchBendSymbols(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::StretchBendSymbols&){ return "SireMM::StretchBendSymbols";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -92,9 +94,9 @@ void register_StretchBendSymbols_class(){
                 , "Return the symbol representing the angle, theta" );
         
         }
-        StretchBendSymbols_exposer.def( "__copy__", &__copy__);
-        StretchBendSymbols_exposer.def( "__deepcopy__", &__copy__);
-        StretchBendSymbols_exposer.def( "clone", &__copy__);
+        StretchBendSymbols_exposer.def( "__copy__", &__copy__<SireMM::StretchBendSymbols>);
+        StretchBendSymbols_exposer.def( "__deepcopy__", &__copy__<SireMM::StretchBendSymbols>);
+        StretchBendSymbols_exposer.def( "clone", &__copy__<SireMM::StretchBendSymbols>);
         StretchBendSymbols_exposer.def( "__str__", &pvt_get_name);
         StretchBendSymbols_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/StretchBendTorsionComponent.pypp.cpp
+++ b/wrapper/MM/StretchBendTorsionComponent.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireMM::StretchBendTorsionComponent __copy__(const SireMM::StretchBendTorsionComponent &other){ return SireMM::StretchBendTorsionComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -107,9 +109,9 @@ void register_StretchBendTorsionComponent_class(){
         
         }
         StretchBendTorsionComponent_exposer.staticmethod( "typeName" );
-        StretchBendTorsionComponent_exposer.def( "__copy__", &__copy__);
-        StretchBendTorsionComponent_exposer.def( "__deepcopy__", &__copy__);
-        StretchBendTorsionComponent_exposer.def( "clone", &__copy__);
+        StretchBendTorsionComponent_exposer.def( "__copy__", &__copy__<SireMM::StretchBendTorsionComponent>);
+        StretchBendTorsionComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::StretchBendTorsionComponent>);
+        StretchBendTorsionComponent_exposer.def( "clone", &__copy__<SireMM::StretchBendTorsionComponent>);
         StretchBendTorsionComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::StretchBendTorsionComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         StretchBendTorsionComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::StretchBendTorsionComponent >,

--- a/wrapper/MM/StretchBendTorsionParameterName.pypp.cpp
+++ b/wrapper/MM/StretchBendTorsionParameterName.pypp.cpp
@@ -49,6 +49,8 @@ namespace bp = boost::python;
 
 SireMM::StretchBendTorsionParameterName __copy__(const SireMM::StretchBendTorsionParameterName &other){ return SireMM::StretchBendTorsionParameterName(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::StretchBendTorsionParameterName&){ return "SireMM::StretchBendTorsionParameterName";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -71,9 +73,9 @@ void register_StretchBendTorsionParameterName_class(){
                 , "" );
         
         }
-        StretchBendTorsionParameterName_exposer.def( "__copy__", &__copy__);
-        StretchBendTorsionParameterName_exposer.def( "__deepcopy__", &__copy__);
-        StretchBendTorsionParameterName_exposer.def( "clone", &__copy__);
+        StretchBendTorsionParameterName_exposer.def( "__copy__", &__copy__<SireMM::StretchBendTorsionParameterName>);
+        StretchBendTorsionParameterName_exposer.def( "__deepcopy__", &__copy__<SireMM::StretchBendTorsionParameterName>);
+        StretchBendTorsionParameterName_exposer.def( "clone", &__copy__<SireMM::StretchBendTorsionParameterName>);
         StretchBendTorsionParameterName_exposer.def( "__str__", &pvt_get_name);
         StretchBendTorsionParameterName_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/StretchBendTorsionSymbols.pypp.cpp
+++ b/wrapper/MM/StretchBendTorsionSymbols.pypp.cpp
@@ -34,6 +34,8 @@ namespace bp = boost::python;
 
 SireMM::StretchBendTorsionSymbols __copy__(const SireMM::StretchBendTorsionSymbols &other){ return SireMM::StretchBendTorsionSymbols(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::StretchBendTorsionSymbols&){ return "SireMM::StretchBendTorsionSymbols";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -128,9 +130,9 @@ void register_StretchBendTorsionSymbols_class(){
                 , "Return the symbol representing the angle between atoms 3-2-1, theta_\n{321}" );
         
         }
-        StretchBendTorsionSymbols_exposer.def( "__copy__", &__copy__);
-        StretchBendTorsionSymbols_exposer.def( "__deepcopy__", &__copy__);
-        StretchBendTorsionSymbols_exposer.def( "clone", &__copy__);
+        StretchBendTorsionSymbols_exposer.def( "__copy__", &__copy__<SireMM::StretchBendTorsionSymbols>);
+        StretchBendTorsionSymbols_exposer.def( "__deepcopy__", &__copy__<SireMM::StretchBendTorsionSymbols>);
+        StretchBendTorsionSymbols_exposer.def( "clone", &__copy__<SireMM::StretchBendTorsionSymbols>);
         StretchBendTorsionSymbols_exposer.def( "__str__", &pvt_get_name);
         StretchBendTorsionSymbols_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/StretchStretchComponent.pypp.cpp
+++ b/wrapper/MM/StretchStretchComponent.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireMM::StretchStretchComponent __copy__(const SireMM::StretchStretchComponent &other){ return SireMM::StretchStretchComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -107,9 +109,9 @@ void register_StretchStretchComponent_class(){
         
         }
         StretchStretchComponent_exposer.staticmethod( "typeName" );
-        StretchStretchComponent_exposer.def( "__copy__", &__copy__);
-        StretchStretchComponent_exposer.def( "__deepcopy__", &__copy__);
-        StretchStretchComponent_exposer.def( "clone", &__copy__);
+        StretchStretchComponent_exposer.def( "__copy__", &__copy__<SireMM::StretchStretchComponent>);
+        StretchStretchComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::StretchStretchComponent>);
+        StretchStretchComponent_exposer.def( "clone", &__copy__<SireMM::StretchStretchComponent>);
         StretchStretchComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::StretchStretchComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         StretchStretchComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::StretchStretchComponent >,

--- a/wrapper/MM/StretchStretchParameterName.pypp.cpp
+++ b/wrapper/MM/StretchStretchParameterName.pypp.cpp
@@ -49,6 +49,8 @@ namespace bp = boost::python;
 
 SireMM::StretchStretchParameterName __copy__(const SireMM::StretchStretchParameterName &other){ return SireMM::StretchStretchParameterName(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::StretchStretchParameterName&){ return "SireMM::StretchStretchParameterName";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -71,9 +73,9 @@ void register_StretchStretchParameterName_class(){
                 , "" );
         
         }
-        StretchStretchParameterName_exposer.def( "__copy__", &__copy__);
-        StretchStretchParameterName_exposer.def( "__deepcopy__", &__copy__);
-        StretchStretchParameterName_exposer.def( "clone", &__copy__);
+        StretchStretchParameterName_exposer.def( "__copy__", &__copy__<SireMM::StretchStretchParameterName>);
+        StretchStretchParameterName_exposer.def( "__deepcopy__", &__copy__<SireMM::StretchStretchParameterName>);
+        StretchStretchParameterName_exposer.def( "clone", &__copy__<SireMM::StretchStretchParameterName>);
         StretchStretchParameterName_exposer.def( "__str__", &pvt_get_name);
         StretchStretchParameterName_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/StretchStretchSymbols.pypp.cpp
+++ b/wrapper/MM/StretchStretchSymbols.pypp.cpp
@@ -34,6 +34,8 @@ namespace bp = boost::python;
 
 SireMM::StretchStretchSymbols __copy__(const SireMM::StretchStretchSymbols &other){ return SireMM::StretchStretchSymbols(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::StretchStretchSymbols&){ return "SireMM::StretchStretchSymbols";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -80,9 +82,9 @@ void register_StretchStretchSymbols_class(){
                 , "Return the symbol representing the bond length r_\n{21}" );
         
         }
-        StretchStretchSymbols_exposer.def( "__copy__", &__copy__);
-        StretchStretchSymbols_exposer.def( "__deepcopy__", &__copy__);
-        StretchStretchSymbols_exposer.def( "clone", &__copy__);
+        StretchStretchSymbols_exposer.def( "__copy__", &__copy__<SireMM::StretchStretchSymbols>);
+        StretchStretchSymbols_exposer.def( "__deepcopy__", &__copy__<SireMM::StretchStretchSymbols>);
+        StretchStretchSymbols_exposer.def( "clone", &__copy__<SireMM::StretchStretchSymbols>);
         StretchStretchSymbols_exposer.def( "__str__", &pvt_get_name);
         StretchStretchSymbols_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/TestFF.pypp.cpp
+++ b/wrapper/MM/TestFF.pypp.cpp
@@ -31,6 +31,8 @@ namespace bp = boost::python;
 
 SireMM::TestFF __copy__(const SireMM::TestFF &other){ return SireMM::TestFF(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::TestFF&){ return "SireMM::TestFF";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -106,9 +108,9 @@ void register_TestFF_class(){
                 , "" );
         
         }
-        TestFF_exposer.def( "__copy__", &__copy__);
-        TestFF_exposer.def( "__deepcopy__", &__copy__);
-        TestFF_exposer.def( "clone", &__copy__);
+        TestFF_exposer.def( "__copy__", &__copy__<SireMM::TestFF>);
+        TestFF_exposer.def( "__deepcopy__", &__copy__<SireMM::TestFF>);
+        TestFF_exposer.def( "clone", &__copy__<SireMM::TestFF>);
         TestFF_exposer.def( "__str__", &pvt_get_name);
         TestFF_exposer.def( "__repr__", &pvt_get_name);
     }

--- a/wrapper/MM/ThreeAtomFunction.pypp.cpp
+++ b/wrapper/MM/ThreeAtomFunction.pypp.cpp
@@ -34,6 +34,8 @@ namespace bp = boost::python;
 
 SireMM::ThreeAtomFunction __copy__(const SireMM::ThreeAtomFunction &other){ return SireMM::ThreeAtomFunction(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -111,9 +113,9 @@ void register_ThreeAtomFunction_class(){
                 , "Return a string representation" );
         
         }
-        ThreeAtomFunction_exposer.def( "__copy__", &__copy__);
-        ThreeAtomFunction_exposer.def( "__deepcopy__", &__copy__);
-        ThreeAtomFunction_exposer.def( "clone", &__copy__);
+        ThreeAtomFunction_exposer.def( "__copy__", &__copy__<SireMM::ThreeAtomFunction>);
+        ThreeAtomFunction_exposer.def( "__deepcopy__", &__copy__<SireMM::ThreeAtomFunction>);
+        ThreeAtomFunction_exposer.def( "clone", &__copy__<SireMM::ThreeAtomFunction>);
         ThreeAtomFunction_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::ThreeAtomFunction >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         ThreeAtomFunction_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::ThreeAtomFunction >,

--- a/wrapper/MM/ThreeAtomFunctions.pypp.cpp
+++ b/wrapper/MM/ThreeAtomFunctions.pypp.cpp
@@ -35,6 +35,8 @@ namespace bp = boost::python;
 
 SireMM::ThreeAtomFunctions __copy__(const SireMM::ThreeAtomFunctions &other){ return SireMM::ThreeAtomFunctions(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -394,9 +396,9 @@ void register_ThreeAtomFunctions_class(){
         
         }
         ThreeAtomFunctions_exposer.staticmethod( "typeName" );
-        ThreeAtomFunctions_exposer.def( "__copy__", &__copy__);
-        ThreeAtomFunctions_exposer.def( "__deepcopy__", &__copy__);
-        ThreeAtomFunctions_exposer.def( "clone", &__copy__);
+        ThreeAtomFunctions_exposer.def( "__copy__", &__copy__<SireMM::ThreeAtomFunctions>);
+        ThreeAtomFunctions_exposer.def( "__deepcopy__", &__copy__<SireMM::ThreeAtomFunctions>);
+        ThreeAtomFunctions_exposer.def( "clone", &__copy__<SireMM::ThreeAtomFunctions>);
         ThreeAtomFunctions_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::ThreeAtomFunctions >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         ThreeAtomFunctions_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::ThreeAtomFunctions >,

--- a/wrapper/MM/ThreeAtomPerturbation.pypp.cpp
+++ b/wrapper/MM/ThreeAtomPerturbation.pypp.cpp
@@ -34,6 +34,8 @@ namespace bp = boost::python;
 
 SireMM::ThreeAtomPerturbation __copy__(const SireMM::ThreeAtomPerturbation &other){ return SireMM::ThreeAtomPerturbation(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -152,9 +154,9 @@ void register_ThreeAtomPerturbation_class(){
         
         }
         ThreeAtomPerturbation_exposer.staticmethod( "typeName" );
-        ThreeAtomPerturbation_exposer.def( "__copy__", &__copy__);
-        ThreeAtomPerturbation_exposer.def( "__deepcopy__", &__copy__);
-        ThreeAtomPerturbation_exposer.def( "clone", &__copy__);
+        ThreeAtomPerturbation_exposer.def( "__copy__", &__copy__<SireMM::ThreeAtomPerturbation>);
+        ThreeAtomPerturbation_exposer.def( "__deepcopy__", &__copy__<SireMM::ThreeAtomPerturbation>);
+        ThreeAtomPerturbation_exposer.def( "clone", &__copy__<SireMM::ThreeAtomPerturbation>);
         ThreeAtomPerturbation_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::ThreeAtomPerturbation >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         ThreeAtomPerturbation_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::ThreeAtomPerturbation >,

--- a/wrapper/MM/TripleDistanceRestraint.pypp.cpp
+++ b/wrapper/MM/TripleDistanceRestraint.pypp.cpp
@@ -32,6 +32,8 @@ namespace bp = boost::python;
 
 SireMM::TripleDistanceRestraint __copy__(const SireMM::TripleDistanceRestraint &other){ return SireMM::TripleDistanceRestraint(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -411,9 +413,9 @@ void register_TripleDistanceRestraint_class(){
         TripleDistanceRestraint_exposer.staticmethod( "r23" );
         TripleDistanceRestraint_exposer.staticmethod( "r45" );
         TripleDistanceRestraint_exposer.staticmethod( "typeName" );
-        TripleDistanceRestraint_exposer.def( "__copy__", &__copy__);
-        TripleDistanceRestraint_exposer.def( "__deepcopy__", &__copy__);
-        TripleDistanceRestraint_exposer.def( "clone", &__copy__);
+        TripleDistanceRestraint_exposer.def( "__copy__", &__copy__<SireMM::TripleDistanceRestraint>);
+        TripleDistanceRestraint_exposer.def( "__deepcopy__", &__copy__<SireMM::TripleDistanceRestraint>);
+        TripleDistanceRestraint_exposer.def( "clone", &__copy__<SireMM::TripleDistanceRestraint>);
         TripleDistanceRestraint_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::TripleDistanceRestraint >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         TripleDistanceRestraint_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::TripleDistanceRestraint >,

--- a/wrapper/MM/TwoAtomFunction.pypp.cpp
+++ b/wrapper/MM/TwoAtomFunction.pypp.cpp
@@ -34,6 +34,8 @@ namespace bp = boost::python;
 
 SireMM::TwoAtomFunction __copy__(const SireMM::TwoAtomFunction &other){ return SireMM::TwoAtomFunction(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -99,9 +101,9 @@ void register_TwoAtomFunction_class(){
                 , "Return a string representation" );
         
         }
-        TwoAtomFunction_exposer.def( "__copy__", &__copy__);
-        TwoAtomFunction_exposer.def( "__deepcopy__", &__copy__);
-        TwoAtomFunction_exposer.def( "clone", &__copy__);
+        TwoAtomFunction_exposer.def( "__copy__", &__copy__<SireMM::TwoAtomFunction>);
+        TwoAtomFunction_exposer.def( "__deepcopy__", &__copy__<SireMM::TwoAtomFunction>);
+        TwoAtomFunction_exposer.def( "clone", &__copy__<SireMM::TwoAtomFunction>);
         TwoAtomFunction_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::TwoAtomFunction >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         TwoAtomFunction_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::TwoAtomFunction >,

--- a/wrapper/MM/TwoAtomFunctions.pypp.cpp
+++ b/wrapper/MM/TwoAtomFunctions.pypp.cpp
@@ -35,6 +35,8 @@ namespace bp = boost::python;
 
 SireMM::TwoAtomFunctions __copy__(const SireMM::TwoAtomFunctions &other){ return SireMM::TwoAtomFunctions(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -394,9 +396,9 @@ void register_TwoAtomFunctions_class(){
         
         }
         TwoAtomFunctions_exposer.staticmethod( "typeName" );
-        TwoAtomFunctions_exposer.def( "__copy__", &__copy__);
-        TwoAtomFunctions_exposer.def( "__deepcopy__", &__copy__);
-        TwoAtomFunctions_exposer.def( "clone", &__copy__);
+        TwoAtomFunctions_exposer.def( "__copy__", &__copy__<SireMM::TwoAtomFunctions>);
+        TwoAtomFunctions_exposer.def( "__deepcopy__", &__copy__<SireMM::TwoAtomFunctions>);
+        TwoAtomFunctions_exposer.def( "clone", &__copy__<SireMM::TwoAtomFunctions>);
         TwoAtomFunctions_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::TwoAtomFunctions >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         TwoAtomFunctions_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::TwoAtomFunctions >,

--- a/wrapper/MM/TwoAtomPerturbation.pypp.cpp
+++ b/wrapper/MM/TwoAtomPerturbation.pypp.cpp
@@ -34,6 +34,8 @@ namespace bp = boost::python;
 
 SireMM::TwoAtomPerturbation __copy__(const SireMM::TwoAtomPerturbation &other){ return SireMM::TwoAtomPerturbation(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -140,9 +142,9 @@ void register_TwoAtomPerturbation_class(){
         
         }
         TwoAtomPerturbation_exposer.staticmethod( "typeName" );
-        TwoAtomPerturbation_exposer.def( "__copy__", &__copy__);
-        TwoAtomPerturbation_exposer.def( "__deepcopy__", &__copy__);
-        TwoAtomPerturbation_exposer.def( "clone", &__copy__);
+        TwoAtomPerturbation_exposer.def( "__copy__", &__copy__<SireMM::TwoAtomPerturbation>);
+        TwoAtomPerturbation_exposer.def( "__deepcopy__", &__copy__<SireMM::TwoAtomPerturbation>);
+        TwoAtomPerturbation_exposer.def( "clone", &__copy__<SireMM::TwoAtomPerturbation>);
         TwoAtomPerturbation_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::TwoAtomPerturbation >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         TwoAtomPerturbation_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::TwoAtomPerturbation >,

--- a/wrapper/MM/UreyBradleyComponent.pypp.cpp
+++ b/wrapper/MM/UreyBradleyComponent.pypp.cpp
@@ -18,6 +18,8 @@ namespace bp = boost::python;
 
 SireMM::UreyBradleyComponent __copy__(const SireMM::UreyBradleyComponent &other){ return SireMM::UreyBradleyComponent(other); }
 
+#include "Helpers/copy.hpp"
+
 #include "Qt/qdatastream.hpp"
 
 #include "Helpers/str.hpp"
@@ -107,9 +109,9 @@ void register_UreyBradleyComponent_class(){
         
         }
         UreyBradleyComponent_exposer.staticmethod( "typeName" );
-        UreyBradleyComponent_exposer.def( "__copy__", &__copy__);
-        UreyBradleyComponent_exposer.def( "__deepcopy__", &__copy__);
-        UreyBradleyComponent_exposer.def( "clone", &__copy__);
+        UreyBradleyComponent_exposer.def( "__copy__", &__copy__<SireMM::UreyBradleyComponent>);
+        UreyBradleyComponent_exposer.def( "__deepcopy__", &__copy__<SireMM::UreyBradleyComponent>);
+        UreyBradleyComponent_exposer.def( "clone", &__copy__<SireMM::UreyBradleyComponent>);
         UreyBradleyComponent_exposer.def( "__rlshift__", &__rlshift__QDataStream< ::SireMM::UreyBradleyComponent >,
                             bp::return_internal_reference<1, bp::with_custodian_and_ward<1,2> >() );
         UreyBradleyComponent_exposer.def( "__rrshift__", &__rrshift__QDataStream< ::SireMM::UreyBradleyComponent >,

--- a/wrapper/MM/UreyBradleyParameterName.pypp.cpp
+++ b/wrapper/MM/UreyBradleyParameterName.pypp.cpp
@@ -49,6 +49,8 @@ namespace bp = boost::python;
 
 SireMM::UreyBradleyParameterName __copy__(const SireMM::UreyBradleyParameterName &other){ return SireMM::UreyBradleyParameterName(other); }
 
+#include "Helpers/copy.hpp"
+
 const char* pvt_get_name(const SireMM::UreyBradleyParameterName&){ return "SireMM::UreyBradleyParameterName";}
 
 #include "Helpers/release_gil_policy.hpp"
@@ -71,9 +73,9 @@ void register_UreyBradleyParameterName_class(){
                 , "" );
         
         }
-        UreyBradleyParameterName_exposer.def( "__copy__", &__copy__);
-        UreyBradleyParameterName_exposer.def( "__deepcopy__", &__copy__);
-        UreyBradleyParameterName_exposer.def( "clone", &__copy__);
+        UreyBradleyParameterName_exposer.def( "__copy__", &__copy__<SireMM::UreyBradleyParameterName>);
+        UreyBradleyParameterName_exposer.def( "__deepcopy__", &__copy__<SireMM::UreyBradleyParameterName>);
+        UreyBradleyParameterName_exposer.def( "clone", &__copy__<SireMM::UreyBradleyParameterName>);
         UreyBradleyParameterName_exposer.def( "__str__", &pvt_get_name);
         UreyBradleyParameterName_exposer.def( "__repr__", &pvt_get_name);
     }


### PR DESCRIPTION
This PR adds a `fix_ghost_sigmas` map option that can be used to disable perturbation of the LJ sigma parameter, e.g. when creating a perturbable molecule using a SOMD1 pert file, where both sigma and epsilon will have been zeroed for ghost atoms. This PR supersedes #195.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods