### PR TITLE
Fix issue #200

### DIFF
--- a/recipes/sire/template.yaml
+++ b/recipes/sire/template.yaml
@@ -21,7 +21,7 @@ requirements:
   run:
     SIRE_RUN_REQUIREMENTS
   run_constrained:
-    - {{ pin_compatible('rdkit', max_pin='x.x') }}
+    - {{ pin_compatible('rdkit', max_pin='x.x.x') }}
 
 test:
   script_env:


### PR DESCRIPTION
This PR makes the RDKit pin stricter by extending the `max_pin` to the patch level, i.e. `max_pin='x.x.x'`. Currently BioSimSpace CI is failing since the version of RDKit pulled in (2024.03.3) is newer than the one that the last Sire development package was built against (2024.03.2).

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods