### PR TITLE
Fix 202

### DIFF
--- a/corelib/src/libs/SireSystem/merge.cpp
+++ b/corelib/src/libs/SireSystem/merge.cpp
@@ -390,11 +390,25 @@ namespace SireSystem
 
                 auto res = mol.residue(residx);
 
+                // get the AtomIdx of the last atom in this residue
+                AtomIdx last_atomidx(0);
+
+                if (res.nAtoms() > 0)
+                {
+                    last_atomidx = res.atom(res.nAtoms() - 1).index();
+                }
+
                 // add the atom - it has the name "Xxx" as it doesn't exist
                 // in the reference state
                 auto atom = res.add(AtomName("Xxx"));
                 largest_atomnum = AtomNum(largest_atomnum.value() + 1);
                 atom.renumber(largest_atomnum);
+
+                // ensure that its index follows on from the index of the
+                // last atom in the residue - this is so that we keep
+                // the AtomIdx and CGAtomIdx orders in sync, and don't
+                // force a complex reordering of the atoms when we commit
+                atom.reindex(last_atomidx + 1);
 
                 // reparent this atom to the CutGroup for this residue
                 atom.reparent(cgidx);

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -55,6 +55,19 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Added a map option (fix_perturbable_zero_sigmas) to prevent perturbation of
   the Lennard-Jones sigma parameter for ghost atoms during alchemical free energy simulations.
 
+* [CHANGE IN BEHAVIOUR] - added code that ensures that, when editing molecules,
+  the CGAtomIdx order will always follow the AtomIdx order of atoms. This is
+  because a lot of code had implicitly assumed this, and so it was a cause
+  of bugs when this wasn't the case. Now, when you edit a molecule, on committing,
+  the orders will be checked. If they don't agree, then the CutGroups will be
+  reordered, with atoms reordered as necessary to make the CGAtomIdx order match
+  the AtomIdx order. If this isn't possible (e.g. because atoms in CutGroups
+  are not contiguous), then the molecule will be converted to a single-cutgroup
+  molecule, with the atoms placed in AtomIdx order. As part of this change,
+  the merge code will now also ensure that added atoms are added with the
+  correct AtomIdx, rather than added as the last atoms in the molecule. This
+  is also more natural. This fixes issue #202.
+
 * Please add an item to this changelog when you create your PR
 
 `2024.1.0 <https://github.com/openbiosim/sire/compare/2023.5.2...2024.1.0>`__ - April 2024

--- a/tests/mol/test_reorder.py
+++ b/tests/mol/test_reorder.py
@@ -1,0 +1,36 @@
+def test_reorder_atoms(ala_mols):
+    mols = ala_mols
+
+    mol = mols[0]
+
+    # check that reorder preserves residue cutting
+    mol = mol.edit()
+    atom = mol.atom(2)
+    atom = atom.reindex(0)
+    mol = atom.molecule().commit()
+
+    assert mol.num_residues() == 3
+    assert mol.num_cutgroups() == mol.num_residues()
+
+    atomidx = 0
+
+    for cutgroup in mol.cutgroups():
+        for atom in cutgroup.atoms():
+            assert atom.index().value() == atomidx
+            atomidx += 1
+
+    # now check with reordering that break residue cutting
+    mol = mols[0]
+
+    mol = mol.edit()
+    atom = mol.atom("HA")
+    atom = atom.reindex(0)
+    mol = atom.molecule().commit()
+
+    assert mol.num_cutgroups() == 1
+
+    atomidx = 0
+
+    for atom in mol.cutgroups()[0].atoms():
+        assert atom.index().value() == atomidx
+        atomidx += 1


### PR DESCRIPTION
This pull request fixes issue #202.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@lohedges

## Any additional context of information?

This should have fixed the bug - the code now ensures that the CGAtomIdx order will always match the AtomIdx order. I fixed the issues this caused in the protein merge code by making sure that added atoms were given their correct AtomIdx based on their added location in the molecule. Could you test this to see if this solves all the problems (and doesn't introduce other ones in BioSimSpace).