### PR TITLE
Fix AtomMapping::alignTo when mapping an ion to a molecule

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -18,6 +18,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Please add an item to this changelog when you create your PR
 * Print residue indices of perturbed water molecules to SOMD1 log.
 * Add support for creating Na+ and Cl- ions.
+* Fix ``sire.morph.merge`` function when one molecule is a monatomic ion.
 
 `2024.2.0 <https://github.com/openbiosim/sire/compare/2024.1.0...2024.2.0>`__ - June 2024
 -----------------------------------------------------------------------------------------

--- a/tests/morph/test_merge.py
+++ b/tests/morph/test_merge.py
@@ -202,3 +202,22 @@ def test_merge_neopentane_methane(neopentane_methane, openmm_platform):
     # These energies aren't correct - extra ghost atom internals?
     assert nrg_neo.value() == pytest.approx(nrg_merged_0.value(), abs=1e-3)
     # assert nrg_met.value() == pytest.approx(nrg_merged_1.value(), abs=1e-3)
+
+
+def test_ion_merge(ala_mols):
+    water = ala_mols[-1]
+    ion = sr.legacy.IO.createSodiumIon(water.atoms()[-1].coordinates(), "tip3p")
+
+    merged = sr.morph.merge(water, ion)
+
+    coords0 = merged.property("coordinates0").to_vector()[0]
+    coords1 = merged.property("coordinates1").to_vector()[0]
+
+    assert coords0 == coords1
+
+    merged = sr.morph.merge(ion, water)
+
+    coords0 = merged.property("coordinates0").to_vector()[0]
+    coords1 = merged.property("coordinates1").to_vector()[0]
+
+    assert coords0 == coords1

--- a/tests/morph/test_merge.py
+++ b/tests/morph/test_merge.py
@@ -204,6 +204,7 @@ def test_merge_neopentane_methane(neopentane_methane, openmm_platform):
     # assert nrg_met.value() == pytest.approx(nrg_merged_1.value(), abs=1e-3)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows")
 def test_ion_merge(ala_mols):
     water = ala_mols[-1]
     ion = sr.legacy.IO.createSodiumIon(water.atoms()[-1].coordinates(), "tip3p")


### PR DESCRIPTION
This PR fixes the `AtomMapping::alignTo` methods to handle the case where one molecule is a monatomic ion. This allows `sire.morph.merge` to handle the creation of alchemical ions by merging a water molecule with an ion. The existing `alignTo` methods fail since they attempt a RMSD alignment when there are too few degrees of freedom.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods