### PR TITLE
Fix missing is_mechanical from (de)serialization and assignment opera…

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -15,7 +15,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 `2024.3.0 <https://github.com/openbiosim/sire/compare/2024.2.0...2024.3.0>`__ - September 2024
 ----------------------------------------------------------------------------------------------
 
-* Please add an item to this changelog when you create your PR
+* Fixed missing `is_mechanical`` from (de)serialization and assignment operators.
 
 `2024.2.0 <https://github.com/openbiosim/sire/compare/2024.1.0...2024.2.0>`__ - June 2024
 -----------------------------------------------------------------------------------------

--- a/wrapper/Convert/SireOpenMM/pyqm.cpp
+++ b/wrapper/Convert/SireOpenMM/pyqm.cpp
@@ -240,7 +240,7 @@ QDataStream &operator>>(QDataStream &ds, PyQMForce &pyqmforce)
         SharedDataStream sds(ds);
 
         sds >> pyqmforce.callback >> pyqmforce.cutoff >> pyqmforce.neighbour_list_frequency
-            >> pyqmforce.is_mechanical >> >> pyqmforce.lambda >> pyqmforce.atoms 
+            >> pyqmforce.is_mechanical >> pyqmforce.lambda >> pyqmforce.atoms 
             >> pyqmforce.mm1_to_qm >> pyqmforce.mm1_to_mm2 >> pyqmforce.bond_scale_factors 
             >> pyqmforce.mm2_atoms >> pyqmforce.numbers >> pyqmforce.charges;
     }

--- a/wrapper/Convert/SireOpenMM/pyqm.cpp
+++ b/wrapper/Convert/SireOpenMM/pyqm.cpp
@@ -224,9 +224,9 @@ QDataStream &operator<<(QDataStream &ds, const PyQMForce &pyqmforce)
     SharedDataStream sds(ds);
 
     sds << pyqmforce.callback << pyqmforce.cutoff << pyqmforce.neighbour_list_frequency
-        << pyqmforce.lambda << pyqmforce.atoms << pyqmforce.mm1_to_qm
-        << pyqmforce.mm1_to_mm2 << pyqmforce.bond_scale_factors << pyqmforce.mm2_atoms
-        << pyqmforce.numbers << pyqmforce.charges;
+        << pyqmforce.is_mechanical <<  pyqmforce.lambda << pyqmforce.atoms 
+        << pyqmforce.mm1_to_qm << pyqmforce.mm1_to_mm2 << pyqmforce.bond_scale_factors 
+        << pyqmforce.mm2_atoms << pyqmforce.numbers << pyqmforce.charges;
 
     return ds;
 }
@@ -240,9 +240,9 @@ QDataStream &operator>>(QDataStream &ds, PyQMForce &pyqmforce)
         SharedDataStream sds(ds);
 
         sds >> pyqmforce.callback >> pyqmforce.cutoff >> pyqmforce.neighbour_list_frequency
-            >> pyqmforce.lambda >> pyqmforce.atoms >> pyqmforce.mm1_to_qm
-            >> pyqmforce.mm1_to_mm2 >> pyqmforce.bond_scale_factors >> pyqmforce.mm2_atoms
-            >> pyqmforce.numbers >> pyqmforce.charges;
+            >> pyqmforce.is_mechanical >> >> pyqmforce.lambda >> pyqmforce.atoms 
+            >> pyqmforce.mm1_to_qm >> pyqmforce.mm1_to_mm2 >> pyqmforce.bond_scale_factors 
+            >> pyqmforce.mm2_atoms >> pyqmforce.numbers >> pyqmforce.charges;
     }
     else
         throw version_error(v, "1", r_pyqmforce, CODELOC);
@@ -303,6 +303,7 @@ PyQMForce &PyQMForce::operator=(const PyQMForce &other)
     this->callback = other.callback;
     this->cutoff = other.cutoff;
     this->neighbour_list_frequency = other.neighbour_list_frequency;
+    this->is_mechanical = other.is_mechanical;
     this->lambda = other.lambda;
     this->atoms = other.atoms;
     this->mm1_to_qm = other.mm1_to_qm;
@@ -918,6 +919,7 @@ PyQMEngine &PyQMEngine::operator=(const PyQMEngine &other)
     this->callback = other.callback;
     this->cutoff = other.cutoff;
     this->neighbour_list_frequency = other.neighbour_list_frequency;
+    this->is_mechanical = other.is_mechanical;
     this->lambda = other.lambda;
     this->atoms = other.atoms;
     this->mm1_to_qm = other.mm1_to_qm;


### PR DESCRIPTION
This PR addresses a bug where information about the embedding scheme was lost, causing Sire to assume that mechanical embedding was being used. Consequently, the neighbors list was not calculated when it should have been. This issue occurred when using the [`get_forces` method](https://github.com/JMorado/sire/blob/feature_emle/src/sire/qm/_emle.py#L41), as deepcopying serialized and deserialized the `PyQMForce` object, leading to the loss of the embedding scheme information.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): 
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): y
* I confirm that I have permission to release this code under the GPL3 license: y


## Suggested reviewers:
@lohedges
