### PR TITLE
Port RF torsion fix to PME code

### DIFF
--- a/corelib/src/libs/SireMove/openmmpmefep.cpp
+++ b/corelib/src/libs/SireMove/openmmpmefep.cpp
@@ -1853,7 +1853,7 @@ void OpenMMPMEFEP::initialise(bool fullPME)
 
                         dihedral_pert_list.append(DihedralID(four.atom0(), four.atom1(), four.atom2(), four.atom3()));
                         dihedral_pert_swap_list.append(
-                            DihedralID(four.atom3(), four.atom1(), four.atom2(), four.atom0()));
+                            DihedralID(four.atom3(), four.atom2(), four.atom1(), four.atom0()));
 
                         improper_pert_list.append(ImproperID(four.atom0(), four.atom1(), four.atom2(), four.atom3()));
                         improper_pert_swap_list.append(

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -24,6 +24,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Only excluded nonbonded interactions between from_ghost and to_ghost atoms if they are in the same molecule.
 * Add Docker support for building wrappers on Linux x86.
 * Add support for boresch restraints to PME.
+* Port SOMD torsion fix to PME code.
 
 
 `2024.2.0 <https://github.com/openbiosim/sire/compare/2024.1.0...2024.2.0>`__ - June 2024


### PR DESCRIPTION
I hadn't realised that the PME implementation existed in a completely separate class, so the torsion fix is missing there.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods