### PR TITLE
Fix #232

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -26,7 +26,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Add support for boresch restraints to PME.
 * Port SOMD torsion fix to PME code.
 * Fix issues with ``atomtype`` and ``atom`` records for dummy atoms in GROMACS topology files.
-* Fix issues with positionally restrainted atoms in perturbable systems.
+* Fix issues with positionally restrained atoms in perturbable systems.
 
 
 `2024.2.0 <https://github.com/openbiosim/sire/compare/2024.1.0...2024.2.0>`__ - June 2024

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -26,6 +26,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Add support for boresch restraints to PME.
 * Port SOMD torsion fix to PME code.
 * Fix issues with ``atomtype`` and ``atom`` records for dummy atoms in GROMACS topology files.
+* Fix issues with positionally restrainted atoms in perturbable systems.
 
 
 `2024.2.0 <https://github.com/openbiosim/sire/compare/2024.1.0...2024.2.0>`__ - June 2024

--- a/tests/convert/test_openmm_restraints.py
+++ b/tests/convert/test_openmm_restraints.py
@@ -6,8 +6,12 @@ import pytest
     "openmm" not in sr.convert.supported_formats(),
     reason="openmm support is not available",
 )
-def test_openmm_positional_restraints(kigaki_mols, openmm_platform):
-    mols = kigaki_mols
+@pytest.mark.parametrize("molecules", ["kigaki_mols", "merged_ethane_methanol"])
+def test_openmm_positional_restraints(molecules, openmm_platform, request):
+    mols = request.getfixturevalue(molecules)
+
+    if mols[0].is_perturbable():
+        mols = sr.morph.link_to_reference(mols)
 
     mol = mols[0]
 

--- a/wrapper/Convert/SireOpenMM/sire_to_openmm_system.cpp
+++ b/wrapper/Convert/SireOpenMM/sire_to_openmm_system.cpp
@@ -315,7 +315,8 @@ void _add_positional_restraints(const SireMM::PositionalRestraints &restraints,
     auto ghost_nonghostff = lambda_lever.getForce<OpenMM::CustomNonbondedForce>("ghost/non-ghost", system);
 
     std::vector<double> custom_params = {1.0, 0.0, 0.0};
-    std::vector<double> custom_clj_params = {0.0, 0.0, 0.0, 0.0};
+    // Define null parameters used to add these particles to the ghost forces (5 total)
+    std::vector<double> custom_clj_params = {0.0, 0.0, 0.0, 0.0, 0.0};
 
     // we need to add all of the positions as anchor particles
     for (const auto &restraint : atom_restraints)


### PR DESCRIPTION
This PR closes #232. Changes the length of the parameter vector used to add ghost atoms (specifically those used for positional restraints) from 3 to the required length of 5.
* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): y
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y/n]
* I confirm that I have permission to release this code under the GPL3 license: [y/n]

