### PR TITLE
Fix #234

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -26,6 +26,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Add support for boresch restraints to PME.
 * Port SOMD torsion fix to PME code.
 * Fix issues with ``atomtype`` and ``atom`` records for dummy atoms in GROMACS topology files.
+* Fixes issue with runnning ``sire.morph.replica_exchange`` on systems in an NPT ensemble.
 
 
 `2024.2.0 <https://github.com/openbiosim/sire/compare/2024.1.0...2024.2.0>`__ - June 2024

--- a/src/sire/morph/_repex.py
+++ b/src/sire/morph/_repex.py
@@ -103,10 +103,9 @@ def replica_exchange(
         pressure0 = ensemble0.pressure()
         pressure1 = ensemble1.pressure()
 
-        delta = -1.0 * (
-            beta1 * (nrgs1[0] - nrgs1[1] + (pressure1 * (volume1 - volume0) * N_A))
-            + beta0 * (nrgs0[1] - nrgs0[0] + (pressure0 * (volume0 - volume1) * N_A))
-        )
+        delta = beta1 * (
+            nrgs1[1] - nrgs1[0] - (pressure1 * (volume1 - volume0) * N_A)
+        ) + beta0 * (nrgs0[0] - nrgs0[1] - (pressure0 * (volume0 - volume1) * N_A))
 
     from math import exp
 

--- a/src/sire/morph/_repex.py
+++ b/src/sire/morph/_repex.py
@@ -95,7 +95,7 @@ def replica_exchange(
     beta1 = 1.0 / (k_boltz * temperature1)
 
     if not ensemble0.is_constant_pressure():
-        delta = beta1 * (nrgs1[0] - nrgs1[1]) + beta0 * (nrgs0[0] - nrgs0[1])
+        delta = beta1 * (nrgs1[1] - nrgs1[0]) + beta0 * (nrgs0[0] - nrgs0[1])
     else:
         volume0 = replica0.current_space().volume()
         volume1 = replica1.current_space().volume()
@@ -103,9 +103,10 @@ def replica_exchange(
         pressure0 = ensemble0.pressure()
         pressure1 = ensemble1.pressure()
 
-        delta = beta1 * (
-            nrgs1[0] - nrgs1[1] + (pressure1 * (volume1 - volume0) * N_A)
-        ) + beta0 * (nrgs0[0] - nrgs0[1] + (pressure0 * (volume0 - volume1) * N_A))
+        delta = -1.0 * (
+            beta1 * (nrgs1[0] - nrgs1[1] + (pressure1 * (volume1 - volume0) * N_A))
+            + beta0 * (nrgs0[1] - nrgs0[0] + (pressure0 * (volume0 - volume1) * N_A))
+        )
 
     from math import exp
 

--- a/src/sire/morph/_repex.py
+++ b/src/sire/morph/_repex.py
@@ -87,7 +87,9 @@ def replica_exchange(
     # delta = beta_b * [ H_b_i - H_b_j + P_b (V_b_i - V_b_j) ] +
     #         beta_a * [ H_a_i - H_a_j + P_a (V_a_i - V_a_j) ]
 
-    from ..units import k_boltz
+    from ..units import k_boltz, mole
+
+    N_A = 6.02214076e23 / mole
 
     beta0 = 1.0 / (k_boltz * temperature0)
     beta1 = 1.0 / (k_boltz * temperature1)
@@ -102,8 +104,8 @@ def replica_exchange(
         pressure1 = ensemble1.pressure()
 
         delta = beta1 * (
-            nrgs1[0] - nrgs1[1] + pressure1 * (volume1 - volume0)
-        ) + beta0 * (nrgs0[0] - nrgs0[1] + pressure0 * (volume0 - volume1))
+            nrgs1[0] - nrgs1[1] + (pressure1 * (volume1 - volume0) * N_A)
+        ) + beta0 * (nrgs0[0] - nrgs0[1] + (pressure0 * (volume0 - volume1) * N_A))
 
     from math import exp
 
@@ -118,12 +120,8 @@ def replica_exchange(
             replica1.set_lambda(lam0)
 
         if ensemble0 != ensemble1:
-            replica0.set_ensemble(
-                ensemble1, rescale_velocities=rescale_velocities
-            )
-            replica1.set_ensemble(
-                ensemble0, rescale_velocities=rescale_velocities
-            )
+            replica0.set_ensemble(ensemble1, rescale_velocities=rescale_velocities)
+            replica1.set_ensemble(ensemble0, rescale_velocities=rescale_velocities)
 
         return (replica1, replica0, True)
     else:

--- a/src/sire/morph/_repex.py
+++ b/src/sire/morph/_repex.py
@@ -104,8 +104,8 @@ def replica_exchange(
         pressure1 = ensemble1.pressure()
 
         delta = beta1 * (
-            nrgs1[1] - nrgs1[0] - (pressure1 * (volume1 - volume0) * N_A)
-        ) + beta0 * (nrgs0[0] - nrgs0[1] - (pressure0 * (volume0 - volume1) * N_A))
+            (nrgs1[1] - nrgs1[0]) + (pressure1 * (volume1 - volume0) * N_A)
+        ) + beta0 * ((nrgs0[0] - nrgs0[1]) + (pressure0 * (volume0 - volume1) * N_A))
 
     from math import exp
 


### PR DESCRIPTION
This PR closes #234. Adds the required `N_A` for volume correction in `NPT` ensembles.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): y
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): y
* I confirm that I have permission to release this code under the GPL3 license: y
