### PR TITLE
Fix #236

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -29,6 +29,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Fixed buffer overflow when computing molecule indices to excluded to/from ghost atom interactions.
 * Fixed calculation of ``delta^2`` in soft-core Couloumb potential.
 * Excluded to/from ghost atom interactions from ``ghost_14ff``.
+* Fixed description of soft-core alpha parameter in tutorial.
+* Added debugging function to evaluate custom forces in OpenMM XML files.
 
 
 `2024.2.0 <https://github.com/openbiosim/sire/compare/2024.1.0...2024.2.0>`__ - June 2024

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -34,7 +34,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Added a timeout to the OpenMM minimiser function.
 * Exposed the pickle operator on the LambdaLever class.
 * Fix issues with positionally restrained atoms in perturbable systems.
-
+* Fix exchange probability equations in ``sire.morph.replica_exchange`` function.
 
 `2024.2.0 <https://github.com/openbiosim/sire/compare/2024.1.0...2024.2.0>`__ - June 2024
 -----------------------------------------------------------------------------------------

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -35,6 +35,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Exposed the pickle operator on the LambdaLever class.
 * Fix issues with positionally restrained atoms in perturbable systems.
 * Fix exchange probability equations in ``sire.morph.replica_exchange`` function.
+* Fix calculation of energy change following final constraint projection after energy minimisation.
+* Clear internal OpenMM state from dynamics object following a successful minimisation.
 
 `2024.2.0 <https://github.com/openbiosim/sire/compare/2024.1.0...2024.2.0>`__ - June 2024
 -----------------------------------------------------------------------------------------

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -26,6 +26,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Add support for boresch restraints to PME.
 * Port SOMD torsion fix to PME code.
 * Fix issues with ``atomtype`` and ``atom`` records for dummy atoms in GROMACS topology files.
+* Fixed buffer overflow when computing molecule indices to excluded to/from ghost atom interactions.
 
 
 `2024.2.0 <https://github.com/openbiosim/sire/compare/2024.1.0...2024.2.0>`__ - June 2024

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -27,6 +27,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Port SOMD torsion fix to PME code.
 * Fix issues with ``atomtype`` and ``atom`` records for dummy atoms in GROMACS topology files.
 * Fixed buffer overflow when computing molecule indices to excluded to/from ghost atom interactions.
+* Fixed calculation of ``delta^2`` in soft-core Couloumb potential.
+* Excluded to/from ghost atom interactions from ``ghost_14ff``.
 
 
 `2024.2.0 <https://github.com/openbiosim/sire/compare/2024.1.0...2024.2.0>`__ - June 2024

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -33,6 +33,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Added debugging function to evaluate custom forces in OpenMM XML files.
 * Added a timeout to the OpenMM minimiser function.
 * Exposed the pickle operator on the LambdaLever class.
+* Fix issues with positionally restrained atoms in perturbable systems.
 
 
 `2024.2.0 <https://github.com/openbiosim/sire/compare/2024.1.0...2024.2.0>`__ - June 2024

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -31,6 +31,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Excluded to/from ghost atom interactions from ``ghost_14ff``.
 * Fixed description of soft-core alpha parameter in tutorial.
 * Added debugging function to evaluate custom forces in OpenMM XML files.
+* Added a timeout to the OpenMM minimiser function.
+* Exposed the pickle operator on the LambdaLever class.
 
 
 `2024.2.0 <https://github.com/openbiosim/sire/compare/2024.1.0...2024.2.0>`__ - June 2024

--- a/doc/source/tutorial/part07/03_ghosts.rst
+++ b/doc/source/tutorial/part07/03_ghosts.rst
@@ -97,10 +97,10 @@ The soft-core parameters are:
 * ``α_i`` and ``α_j`` control the amount of "softening" of the
   electrostatic and LJ interactions. A value of 0 means no softening
   (fully hard), while a value of 1 means fully soft. Ghost atoms which
-  disappear as a function of λ have a value of α of 0 in the
-  reference state, and 1 in the perturbed state. Ghost atoms which appear
-  as a function of λ have a value of α of 1 in the reference
-  state, and 0 in the perturbed state. These values can be perturbed
+  disappear as a function of λ have a value of α of 1 in the
+  reference state, and 0 in the perturbed state. Ghost atoms which appear
+  as a function of λ have a value of α of 0 in the reference
+  state, and 1 in the perturbed state. These values can be perturbed
   via the ``alpha`` lever in the λ-schedule.
 
 * ``n`` is the "coulomb power", and is set to 0 by default. It can be
@@ -159,10 +159,10 @@ The soft-core parameters are:
 * ``α_i`` and ``α_j`` control the amount of "softening" of the
   electrostatic and LJ interactions. A value of 0 means no softening
   (fully hard), while a value of 1 means fully soft. Ghost atoms which
-  disappear as a function of λ have a value of α of 0 in the
-  reference state, and 1 in the perturbed state. Ghost atoms which appear
-  as a function of λ have a value of α of 1 in the reference
-  state, and 0 in the perturbed state. These values can be perturbed
+  disappear as a function of λ have a value of α of 1 in the
+  reference state, and 0 in the perturbed state. Ghost atoms which appear
+  as a function of λ have a value of α of 0 in the reference
+  state, and 1 in the perturbed state. These values can be perturbed
   via the ``alpha`` lever in the λ-schedule.
 
 * ``m`` is the "taylor power", and is set to 1 by default. It can be

--- a/src/sire/mol/_dynamics.py
+++ b/src/sire/mol/_dynamics.py
@@ -586,7 +586,7 @@ class DynamicsData:
         starting_k: float = 100.0,
         ratchet_scale: float = 2.0,
         max_constraint_error: float = 0.001,
-        timeout: str = "60s",
+        timeout: str = "300s",
     ):
         """
         Internal method that runs minimisation on the molecules.

--- a/src/sire/mol/_dynamics.py
+++ b/src/sire/mol/_dynamics.py
@@ -99,8 +99,7 @@ class DynamicsData:
             from ..convert import to
 
             self._omm_mols = to(self._sire_mols, "openmm", map=self._map)
-            self._omm_state = None
-            self._omm_state_has_cv = (False, False)
+            self._clear_state()
 
             if self._ffinfo.space().is_periodic():
                 self._enforce_periodic_box = True
@@ -174,8 +173,7 @@ class DynamicsData:
             raise SystemError("Cannot start dynamics while it is already running!")
 
         self._is_running = True
-        self._omm_state = None
-        self._omm_state_has_cv = (False, False)
+        self._clear_state()
 
     def _exit_dynamics_block(
         self,
@@ -559,8 +557,7 @@ class DynamicsData:
         if self._is_running:
             raise SystemError("Cannot step dynamics while it is already running!")
 
-        self._omm_state = None
-        self._omm_state_has_cv = (False, False)
+        self._clear_state()
 
         self._omm_mols.getIntegrator().step(num_steps)
 
@@ -637,6 +634,8 @@ class DynamicsData:
                 raise ValueError("'timeout' must have units of time")
         except:
             raise ValueError("Unable to parse 'timeout' as a time")
+
+        self._clear_state()
 
         self._minimisation_log = minimise_openmm_context(
             self._omm_mols,
@@ -976,8 +975,7 @@ class DynamicsData:
             # try to fix this problem by minimising,
             # then running again
             self._is_running = False
-            self._omm_state = None
-            self._omm_state_has_cv = (False, False)
+            self._clear_state()
             self._rebuild_and_minimise()
             orig_args["auto_fix_minimise"] = False
             self.run(**orig_args)

--- a/src/sire/mol/_minimisation.py
+++ b/src/sire/mol/_minimisation.py
@@ -96,6 +96,7 @@ class Minimisation:
         starting_k: float = 400.0,
         ratchet_scale: float = 10.0,
         max_constraint_error: float = 0.001,
+        timeout: str = "60s",
     ):
         """
         Internal method that runs minimisation on the molecules.
@@ -129,6 +130,8 @@ class Minimisation:
         - starting_k (float): The starting value of k for the minimisation
         - ratchet_scale (float): The amount to scale k at each ratchet
         - max_constraint_error (float): The maximum error in the constraint in nm
+        - timeout (float): The maximum time to run the minimisation for in seconds.
+                           A value of <=0 will disable the timeout.
         """
         if not self._d.is_null():
             self._d.run_minimisation(
@@ -140,6 +143,7 @@ class Minimisation:
                 starting_k=starting_k,
                 ratchet_scale=ratchet_scale,
                 max_constraint_error=max_constraint_error,
+                timeout=timeout,
             )
 
         return self

--- a/src/sire/mol/_minimisation.py
+++ b/src/sire/mol/_minimisation.py
@@ -96,7 +96,7 @@ class Minimisation:
         starting_k: float = 400.0,
         ratchet_scale: float = 10.0,
         max_constraint_error: float = 0.001,
-        timeout: str = "60s",
+        timeout: str = "300s",
     ):
         """
         Internal method that runs minimisation on the molecules.

--- a/src/sire/morph/CMakeLists.txt
+++ b/src/sire/morph/CMakeLists.txt
@@ -16,6 +16,7 @@ set ( SCRIPTS
         _pertfile.py
         _perturbation.py
         _repex.py
+        _xml.py
     )
 
 # installation

--- a/src/sire/morph/__init__.py
+++ b/src/sire/morph/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     "zero_ghost_bonds",
     "zero_ghost_angles",
     "zero_ghost_torsions",
+    "evaluate_xml_force",
     "Perturbation",
 ]
 
@@ -48,3 +49,5 @@ from ._merge import merge
 from ._mutate import mutate
 
 from ._decouple import annihilate, decouple
+
+from ._xml import evaluate_xml_force

--- a/src/sire/morph/_xml.py
+++ b/src/sire/morph/_xml.py
@@ -1,0 +1,256 @@
+__all__ = ["evaluate_xml_force"]
+
+
+def evaluate_xml_force(mols, xml, force):
+    """
+    Evaluate the custom force defined in the passed XML file.
+    The passed molecules must be the ones used to create the
+    OpenMM context associated with the XML file.
+
+
+    Parameters
+    ----------
+
+    mols : sire.system.System, sire.mol.Molecule
+        The perturbable molecular system or molecule to evaluate the force on.
+        This should have already been linked to the appropriate end state.
+
+    xml : str
+        The path to the XML file containing the custom force.
+
+    force : str
+        The name of the custom force to evaluate. Options are:
+        "ghost-ghost", "ghost-nonghost", "ghost-14".
+
+    Returns
+    -------
+
+    [((sire.mol.Atom, sr.mol.Atom), (sr.units.GeneralUnit, sr.units.GeneralUnit))]
+        The atom pairs and pairwise Coulomb and Lennard-Jones energies.
+    """
+
+    from math import sqrt
+
+    import xml.etree.ElementTree as ET
+    import sys
+
+    from .._measure import measure
+    from ..legacy.Mol import Molecule
+    from ..system import System
+    from ..units import nanometer, kJ_per_mol
+
+    # Store the name of the current module.
+    module = sys.modules[__name__]
+
+    # Validate the molecules.
+    if not isinstance(mols, (System, Molecule)):
+        raise TypeError(
+            "'mols' must be of type 'sire.system.System' or 'sire.mol.Molecule'."
+        )
+
+    # Validate the XML file.
+    if not isinstance(xml, str):
+        raise TypeError("'xml' must be of type 'str'.")
+
+    # Try to parse the XML file.
+    try:
+        tree = ET.parse(xml)
+    except:
+        raise ValueError(f"Could not parse the XML file: {xml}")
+
+    # Validate the force type.
+    if not isinstance(force, str):
+        raise TypeError("'force' must be of type 'str'.")
+
+    # Sanitize the force name.
+    force = (
+        force.lower()
+        .replace(" ", "")
+        .replace("-", "")
+        .replace("_", "")
+        .replace("/", "")
+    )
+
+    # Validate the force name.
+    if not force in ["ghostghost", "ghostnonghost", "ghost14"]:
+        raise ValueError(
+            "'force' must be one of 'ghost-ghost', 'ghost-nonghost', or 'ghost-14'."
+        )
+
+    # Create the name and index based on the force type.
+    if force == "ghostghost":
+        name = "CustomNonbondedForce"
+        index = 0
+    elif force == "ghostnonghost":
+        name = "CustomNonbondedForce"
+        index = 1
+    elif force == "ghost14":
+        name = "CustomBondForce"
+        index = 0
+
+    # Get the root of the XML tree.
+    root = tree.getroot()
+
+    # Loop over the forces until we find the first CustomNonbondedForce.
+    force_index = 0
+    for force in tree.find("Forces"):
+        if force.get("name") == name:
+            if force_index == index:
+                break
+            force_index += 1
+
+    # Get the energy terms.
+    terms = list(reversed(force.get("energy").split(";")[1:-1]))
+
+    # Create a list to store the results.
+    results = []
+
+    # CustomNonbondedForce: ghost-ghost or ghost-nonghost.
+    if name == "CustomNonbondedForce":
+        # Get the parameters for this force.
+        parameters = [p.get("name") for p in force.find("PerParticleParameters")]
+
+        # Get all the particle parameters.
+        particles = force.find("Particles")
+
+        # Get the two sets of particles that interact.
+        set1 = [
+            int(p.get("index"))
+            for p in force.find("InteractionGroups")
+            .find("InteractionGroup")
+            .find("Set1")
+        ]
+        set2 = [
+            int(p.get("index"))
+            for p in force.find("InteractionGroups")
+            .find("InteractionGroup")
+            .find("Set2")
+        ]
+
+        # Get the exclusions.
+        exclusions = [
+            (int(e.get("p1")), int(e.get("p2")))
+            for e in force.find("Exclusions").findall("Exclusion")
+        ]
+        for x, (i, j) in enumerate(exclusions):
+            if i > j:
+                exclusions[x] = (j, i)
+        exclusions = set(exclusions)
+
+        # Get the cutoff distance.
+        cutoff = float(force.get("cutoff"))
+
+        # Get the list of atoms.
+        atoms = mols.atoms()
+
+        # Loop over all particles in set1.
+        for x in range(len(set1)):
+            # Get the index from set1.
+            i = set1[x]
+
+            # Get the parameters for this particle.
+            particle_i = particles[i]
+
+            # Get the atom.
+            atom_i = atoms[i]
+
+            # Set the parameters for this particle.
+            setattr(module, parameters[0] + "1", float(particle_i.get("param1")))
+            setattr(module, parameters[1] + "1", float(particle_i.get("param2")))
+            setattr(module, parameters[2] + "1", float(particle_i.get("param3")))
+            setattr(module, parameters[3] + "1", float(particle_i.get("param4")))
+            setattr(module, parameters[4] + "1", float(particle_i.get("param5")))
+
+            # Loop over all other particles in set1.
+            for y in range(x + 1, len(set1)):
+                # Get the index from set2.
+                j = set1[y]
+
+                # Check if this pair is excluded.
+                pair = (i, j) if i < j else (j, i)
+                if pair in exclusions:
+                    continue
+
+                # Get the parameters for this particle.
+                particle_j = particles[j]
+
+                # Get the atom.
+                atom_j = atoms[j]
+
+                # Set the parameters for this particle.
+                setattr(module, parameters[0] + "2", float(particle_j.get("param1")))
+                setattr(module, parameters[1] + "2", float(particle_j.get("param2")))
+                setattr(module, parameters[2] + "2", float(particle_j.get("param3")))
+                setattr(module, parameters[3] + "2", float(particle_j.get("param4")))
+                setattr(module, parameters[4] + "2", float(particle_j.get("param5")))
+
+                # Get the distance between the particles.
+                r = measure(atom_i, atom_j).to(nanometer)
+
+                # Atoms are within the cutoff.
+                if r < cutoff:
+                    # Evaluate the energy term by term.
+                    for term in terms:
+                        # Replace any instances of ^ with **.
+                        term = term.replace("^", "**")
+
+                        # Split the term into the result and the expression.
+                        result, expression = term.split("=")
+
+                        # Evaluate the expression.
+                        setattr(module, result, eval(expression))
+
+                    # Give energies units.
+                    coul_nrg = module.coul_nrg * kJ_per_mol
+                    lj_nrg = module.lj_nrg * kJ_per_mol
+
+                    # Append the results for this pair.
+                    results.append(((atom_i, atom_j), (coul_nrg, lj_nrg)))
+
+    # CustomBondForce: ghost-14.
+    else:
+        # Get the parameters for this force.
+        parameters = [p.get("name") for p in force.find("PerBondParameters")]
+
+        # Get all the bond parameters.
+        bonds = force.find("Bonds").findall("Bond")
+
+        # Get the list of atoms.
+        atoms = mols.atoms()
+
+        # Loop over all bonds.
+        for bond in bonds:
+            # Get the atoms involved in the bond.
+            atom_i = atoms[int(bond.get("p1"))]
+            atom_j = atoms[int(bond.get("p2"))]
+
+            # Set the parameters for this bond.
+            setattr(module, parameters[0], float(bond.get("param1")))
+            setattr(module, parameters[1], float(bond.get("param2")))
+            setattr(module, parameters[2], float(bond.get("param3")))
+            setattr(module, parameters[3], float(bond.get("param4")))
+            setattr(module, parameters[4], float(bond.get("param5")))
+
+            # Get the distance between the particles.
+            r = measure(atom_i, atom_j).to(nanometer)
+
+            # Evaluate the energy term by term.
+            for term in terms:
+                # Replace any instances of ^ with **.
+                term = term.replace("^", "**")
+
+                # Split the term into the result and the expression.
+                result, expression = term.split("=")
+
+                # Evaluate the expression.
+                setattr(module, result, eval(expression))
+
+            # Give energies units.
+            coul_nrg = module.coul_nrg * kJ_per_mol
+            lj_nrg = module.lj_nrg * kJ_per_mol
+
+            # Append the results for this bond.
+            results.append(((atom_i, atom_j), (coul_nrg, lj_nrg)))
+
+    # Return the results.
+    return results

--- a/src/sire/morph/_xml.py
+++ b/src/sire/morph/_xml.py
@@ -25,8 +25,14 @@ def evaluate_xml_force(mols, xml, force):
     Returns
     -------
 
-    [((sire.mol.Atom, sr.mol.Atom), (sr.units.GeneralUnit, sr.units.GeneralUnit))]
-        The atom pairs and pairwise Coulomb and Lennard-Jones energies.
+    pairs : [(sire.mol.Atom, sire.mol.Atom)]
+        The atom pairs that interacted.
+
+    nrg_coul : [sr.units.GeneralUnit]
+        The Coulomb energies for each atom pair.
+
+    nrg_lj : [sr.units.GeneralUnit]
+        The Lennard-Jones energies for each atom pair.
     """
 
     from math import sqrt
@@ -103,7 +109,9 @@ def evaluate_xml_force(mols, xml, force):
     terms = list(reversed(force.get("energy").split(";")[1:-1]))
 
     # Create a list to store the results.
-    results = []
+    pairs = []
+    nrg_coul_list = []
+    nrg_lj_list = []
 
     # CustomNonbondedForce: ghost-ghost or ghost-nonghost.
     if name == "CustomNonbondedForce":
@@ -205,7 +213,9 @@ def evaluate_xml_force(mols, xml, force):
                     lj_nrg = module.lj_nrg * kJ_per_mol
 
                     # Append the results for this pair.
-                    results.append(((atom_i, atom_j), (coul_nrg, lj_nrg)))
+                    pairs.append((atom_i, atom_j))
+                    nrg_coul_list.append(coul_nrg)
+                    nrg_lj_list.append(lj_nrg)
 
     # CustomBondForce: ghost-14.
     else:
@@ -250,7 +260,9 @@ def evaluate_xml_force(mols, xml, force):
             lj_nrg = module.lj_nrg * kJ_per_mol
 
             # Append the results for this bond.
-            results.append(((atom_i, atom_j), (coul_nrg, lj_nrg)))
+            pairs.append((atom_i, atom_j))
+            nrg_coul_list.append(coul_nrg)
+            nrg_lj_list.append(lj_nrg)
 
     # Return the results.
-    return results
+    return pairs, nrg_coul_list, nrg_lj_list

--- a/tests/convert/test_openmm_constraints.py
+++ b/tests/convert/test_openmm_constraints.py
@@ -451,3 +451,73 @@ def test_auto_constraints(ala_mols, openmm_platform):
                     constraint[0].atom(0).index(), constraint[0].atom(1).index()
                 )
                 assert bond in constrained
+
+
+@pytest.mark.xfail(reason="Unresolved bug.")
+def test_asymmetric_constraints():
+    # This test is for debugging a peculiar issue with one of the perturbations
+    # from the MCL1 test suite. Here there are no ghost atoms and a single atom
+    # changes type during the perturbation, from H to Cl. The constraints are
+    # different for the two end states. Currently, the minimised energy at
+    # lambda=1 does not match the minimised energy at lambda=0 when the end
+    # states are swapped. From debugging, it seems that this is the caused by
+    # calling context.applyConstraints() for the final constraint projection
+    # following succesful minimisation. It's not clear if the bug lies in Sire,
+    # or OpenMM.
+
+    from math import isclose
+
+    # Load the MCL1 perturbation. (Perturbable ligand is the last molecule.)
+    mol = sr.load_test_files("mcl1_60_61.s3")[-1]
+
+    # Create dynamics objects for the forward and backward perturbations.
+    d_forwards = mol.dynamics(
+        perturbable_constraint="h_bonds_not_heavy_perturbed",
+        dynamic_constraints=True,
+        include_constrained_energies=False,
+    )
+    d_backwards = mol.dynamics(
+        perturbable_constraint="h_bonds_not_heavy_perturbed",
+        include_constrained_energies=False,
+        dynamic_constraints=True,
+        swap_end_states=True,
+    )
+
+    # Set lambda so the dynamics states are equivalent.
+    d_forwards.set_lambda(1.0, update_constraints=True)
+    d_backwards.set_lambda(0.0, update_constraints=True)
+
+    # Get the initial potential energies.
+    nrg_forwards = d_forwards.current_potential_energy().value()
+    nrg_backwards = d_backwards.current_potential_energy().value()
+
+    # Check the potential energies are the same.
+    assert isclose(nrg_forwards, nrg_backwards, rel_tol=1e-5)
+
+    # Minimise both dynamics objects.
+    d_forwards.minimise()
+    d_backwards.minimise()
+
+    # Get the minimisation logs.
+    log_forwards = d_forwards._d.get_minimisation_log()
+    log_backwards = d_backwards._d.get_minimisation_log()
+
+    lines_forward = log_forwards.split("\n")
+    for line in lines_forward:
+        if "Final energy" in line:
+            nrg_forwards = float(line.split()[2])
+
+    lines_backward = log_backwards.split("\n")
+    for line in lines_backward:
+        if "Final energy" in line:
+            nrg_backwards = float(line.split()[2])
+
+    # Check the final energies from the logs are the same.
+    assert isclose(nrg_forwards, nrg_backwards, rel_tol=1e-3)
+
+    # Now get the final potential energies. (Post constraint projection.)
+    nrg_forwards = d_forwards.current_potential_energy().value()
+    nrg_backwards = d_backwards.current_potential_energy().value()
+
+    # Check the minimised potential energies are the same.
+    assert isclose(nrg_forwards, nrg_backwards, rel_tol=1e-3)

--- a/tests/convert/test_openmm_restraints.py
+++ b/tests/convert/test_openmm_restraints.py
@@ -6,8 +6,12 @@ import pytest
     "openmm" not in sr.convert.supported_formats(),
     reason="openmm support is not available",
 )
-def test_openmm_positional_restraints(kigaki_mols, openmm_platform):
-    mols = kigaki_mols
+@pytest.mark.parametrize("molecules", ["kigaki_mols", "merged_ethane_methanol"])
+def test_openmm_positional_restraints(molecules, openmm_platform, request):
+    mols = request.getfixturevalue(molecules)
+
+    if mols[0].is_perturbable():
+        mols = sr.morph.link_to_reference(mols)
 
     mol = mols[0]
 

--- a/wrapper/Convert/SireOpenMM/LambdaLever.pypp.cpp
+++ b/wrapper/Convert/SireOpenMM/LambdaLever.pypp.cpp
@@ -35,6 +35,8 @@ SireOpenMM::LambdaLever __copy__(const SireOpenMM::LambdaLever &other){ return S
 
 #include "Helpers/release_gil_policy.hpp"
 
+#include "Qt/qdatastream.hpp"
+
 void register_LambdaLever_class(){
 
     { //::SireOpenMM::LambdaLever
@@ -275,6 +277,7 @@ void register_LambdaLever_class(){
         LambdaLever_exposer.staticmethod( "typeName" );
         LambdaLever_exposer.def( "__copy__", &__copy__<SireOpenMM::LambdaLever>);
         LambdaLever_exposer.def( "__deepcopy__", &__copy__<SireOpenMM::LambdaLever>);
+        LambdaLever_exposer.def_pickle(sire_pickle_suite< ::SireOpenMM::LambdaLever >());
         LambdaLever_exposer.def( "clone", &__copy__<SireOpenMM::LambdaLever>);
         LambdaLever_exposer.def( "__str__", &__str__< ::SireOpenMM::LambdaLever > );
         LambdaLever_exposer.def( "__repr__", &__str__< ::SireOpenMM::LambdaLever > );

--- a/wrapper/Convert/SireOpenMM/_SireOpenMM_free_functions.pypp.cpp
+++ b/wrapper/Convert/SireOpenMM/_SireOpenMM_free_functions.pypp.cpp
@@ -2149,7 +2149,7 @@ void register_free_functions(){
         bp::def( 
             "minimise_openmm_context"
             , minimise_openmm_context_function_value
-            , ( bp::arg("context"), bp::arg("tolerance")=10., bp::arg("max_iterations")=(int)(-1), bp::arg("max_restarts")=(int)(10), bp::arg("max_ratchets")=(int)(20), bp::arg("ratchet_frequency")=(int)(500), bp::arg("starting_k")=100., bp::arg("ratchet_scale")=2., bp::arg("max_constraint_error")=0.01, bp::arg("timeout")=60. )
+            , ( bp::arg("context"), bp::arg("tolerance")=10., bp::arg("max_iterations")=(int)(-1), bp::arg("max_restarts")=(int)(10), bp::arg("max_ratchets")=(int)(20), bp::arg("ratchet_frequency")=(int)(500), bp::arg("starting_k")=100., bp::arg("ratchet_scale")=2., bp::arg("max_constraint_error")=0.01, bp::arg("timeout")=300. )
             , "This is a minimiser heavily inspired by the\nLocalEnergyMinimizer included in OpenMM. This is re-written\nfor sire to;\n\n1. Better integrate minimisation into the sire progress\nmonitoring  interupting framework.\n2. Avoid errors caused by OpenMM switching from the desired\ncontext to the CPU context, thus triggering spurious exceptions\nrelated to exclusions  exceptions not matching\n\nThis exposes more controls from the underlying minimisation\nlibrary, and also logs events and progress, which is returned\nas a string.\n\nThis raises an exception if minimisation fails.\n" );
     
     }

--- a/wrapper/Convert/SireOpenMM/_SireOpenMM_free_functions.pypp.cpp
+++ b/wrapper/Convert/SireOpenMM/_SireOpenMM_free_functions.pypp.cpp
@@ -2143,13 +2143,13 @@ void register_free_functions(){
 
     { //::SireOpenMM::minimise_openmm_context
     
-        typedef ::QString ( *minimise_openmm_context_function_type )( ::OpenMM::Context &,double,int,int,int,int,double,double,double );
+        typedef ::QString ( *minimise_openmm_context_function_type )( ::OpenMM::Context &,double,int,int,int,int,double,double,double,double );
         minimise_openmm_context_function_type minimise_openmm_context_function_value( &::SireOpenMM::minimise_openmm_context );
         
         bp::def( 
             "minimise_openmm_context"
             , minimise_openmm_context_function_value
-            , ( bp::arg("context"), bp::arg("tolerance")=10., bp::arg("max_iterations")=(int)(-1), bp::arg("max_restarts")=(int)(10), bp::arg("max_ratchets")=(int)(20), bp::arg("ratchet_frequency")=(int)(500), bp::arg("starting_k")=100., bp::arg("ratchet_scale")=2., bp::arg("max_constraint_error")=0.01 )
+            , ( bp::arg("context"), bp::arg("tolerance")=10., bp::arg("max_iterations")=(int)(-1), bp::arg("max_restarts")=(int)(10), bp::arg("max_ratchets")=(int)(20), bp::arg("ratchet_frequency")=(int)(500), bp::arg("starting_k")=100., bp::arg("ratchet_scale")=2., bp::arg("max_constraint_error")=0.01, bp::arg("timeout")=60. )
             , "This is a minimiser heavily inspired by the\nLocalEnergyMinimizer included in OpenMM. This is re-written\nfor sire to;\n\n1. Better integrate minimisation into the sire progress\nmonitoring  interupting framework.\n2. Avoid errors caused by OpenMM switching from the desired\ncontext to the CPU context, thus triggering spurious exceptions\nrelated to exclusions  exceptions not matching\n\nThis exposes more controls from the underlying minimisation\nlibrary, and also logs events and progress, which is returned\nas a string.\n\nThis raises an exception if minimisation fails.\n" );
     
     }

--- a/wrapper/Convert/SireOpenMM/lambdalever.cpp
+++ b/wrapper/Convert/SireOpenMM/lambdalever.cpp
@@ -1438,12 +1438,23 @@ double LambdaLever::setLambda(OpenMM::Context &context,
                     // don't set LJ terms for ghost atoms
                     if (atom0_is_ghost or atom1_is_ghost)
                     {
+                        // are the atoms perturbing from ghosts?
+                        const auto from_ghost0 = perturbable_mol.getFromGhostIdxs().contains(atom0);
+                        const auto from_ghost1 = perturbable_mol.getFromGhostIdxs().contains(atom1);
+                        // are the atoms perturbing to ghosts?
+                        const auto to_ghost0 = perturbable_mol.getToGhostIdxs().contains(atom0);
+                        const auto to_ghost1 = perturbable_mol.getToGhostIdxs().contains(atom1);
+
+                        // is this interaction between an to/from ghost atom?
+                        const auto to_from_ghost = (from_ghost0 and to_ghost1) or (from_ghost1 and to_ghost0);
+
                         cljff->setExceptionParameters(
                             boost::get<0>(idxs[j]),
                             boost::get<0>(p), boost::get<1>(p),
                             boost::get<2>(p), 1e-9, 1e-9);
 
-                        if (ghost_14ff != 0)
+                        // exclude 14s for to/from ghost interactions
+                        if (not to_from_ghost and ghost_14ff != 0)
                         {
                             // this is a 1-4 parameter - need to update
                             // the ghost 1-4 forcefield

--- a/wrapper/Convert/SireOpenMM/openmmminimise.cpp
+++ b/wrapper/Convert/SireOpenMM/openmmminimise.cpp
@@ -1031,7 +1031,7 @@ namespace SireOpenMM
 
                     const auto delta_energy = energy_after - energy_before;
 
-                    data.addLog(QString("Change in energy: %1 kJ mol-1").arg(delta_energy));
+                    data.addLog(QString("Change in energy following constraint projection: %1 kJ mol-1").arg(delta_energy));
 
                     if (std::abs(delta_energy) < 1000.0)
                     {

--- a/wrapper/Convert/SireOpenMM/openmmminimise.cpp
+++ b/wrapper/Convert/SireOpenMM/openmmminimise.cpp
@@ -1095,7 +1095,6 @@ namespace SireOpenMM
         {
             data.addLog("Minimisation failed!");
             bar.failure("Minimisation failed! Could not satisfy constraints!");
-            qDebug() << data.getLog().join("\n");
             throw SireError::invalid_state(QObject::tr(
                                                "Despite repeated attempts, the minimiser could not minimise the system "
                                                "while simultaneously satisfying the constraints."),

--- a/wrapper/Convert/SireOpenMM/openmmminimise.cpp
+++ b/wrapper/Convert/SireOpenMM/openmmminimise.cpp
@@ -42,6 +42,7 @@
 
 // COPIED FROM SO POST - https://stackoverflow.com/questions/570669/checking-if-a-double-or-float-is-nan-in-c
 
+#include <chrono>
 #include <cmath> // std::isnan, std::fpclassify
 #include <iostream>
 #include <iomanip> // std::setw
@@ -616,11 +617,16 @@ namespace SireOpenMM
                                     int max_restarts, int max_ratchets,
                                     int ratchet_frequency,
                                     double starting_k, double ratchet_scale,
-                                    double max_constraint_error)
+                                    double max_constraint_error, double timeout)
     {
         if (max_iterations < 0)
         {
             max_iterations = std::numeric_limits<int>::max();
+        }
+
+        if (timeout <= 0)
+        {
+            timeout = std::numeric_limits<double>::max();
         }
 
         auto gil = SireBase::release_gil();
@@ -650,6 +656,7 @@ namespace SireOpenMM
 
         data.addLog(QString("Minimising with a tolerance of %1").arg(tolerance));
         data.addLog(QString("Minimising with constraint tolerance %1").arg(working_constraint_tol));
+        data.addLog(QString("Minimising with a timeout of %1 seconds").arg(timeout));
         data.addLog(QString("Minimising with k = %1").arg(k));
         data.addLog(QString("Minimising with %1 particles").arg(num_particles));
         data.addLog(QString("Minimising with a maximum of %1 iterations").arg(max_iterations));
@@ -679,6 +686,9 @@ namespace SireOpenMM
         int max_linesearch = 100;
         const int max_linesearch_delta = 100;
 
+        // Store the starting time.
+        auto start_time = std::chrono::high_resolution_clock::now();
+
         while (data.getIteration() < data.getMaxIterations())
         {
             if (not is_success)
@@ -686,6 +696,16 @@ namespace SireOpenMM
                 // try one more time with the real starting positions
                 if (not have_hard_reset)
                 {
+                    // Check the current time and see if we've exceeded the timeout.
+                    auto current_time = std::chrono::high_resolution_clock::now();
+                    auto elapsed_time = std::chrono::duration_cast<std::chrono::seconds>(current_time - start_time).count();
+
+                    if (elapsed_time > timeout)
+                    {
+                        data.addLog("Minimisation timed out!");
+                        break;
+                    }
+
                     data.hardReset();
 
                     context.setPositions(starting_pos);
@@ -708,6 +728,7 @@ namespace SireOpenMM
                     break;
                 }
             }
+
 
             data.addLog(QString("Minimisation loop - %1 steps from %2").arg(data.getIteration()).arg(data.getMaxIterations()));
 
@@ -762,6 +783,17 @@ namespace SireOpenMM
                 // Repeatedly minimize, steadily increasing the strength of the springs until all constraints are satisfied.
                 while (data.getIteration() < data.getMaxIterations())
                 {
+                    // Check the current time and see if we've exceeded the timeout.
+                    auto current_time = std::chrono::high_resolution_clock::now();
+                    auto elapsed_time = std::chrono::duration_cast<std::chrono::seconds>(current_time - start_time).count();
+
+                    if (elapsed_time > timeout)
+                    {
+                        data.addLog("Minimisation timed out!");
+                        is_success = false;
+                        break;
+                    }
+
                     param.max_iterations = data.getMaxIterations() - data.getIteration();
                     lbfgsfloatval_t fx; // final energy
                     auto last_it = data.getIteration();

--- a/wrapper/Convert/SireOpenMM/openmmminimise.cpp
+++ b/wrapper/Convert/SireOpenMM/openmmminimise.cpp
@@ -1025,6 +1025,10 @@ namespace SireOpenMM
                     // to the full precision requested by the user.
                     context.applyConstraints(working_constraint_tol);
 
+                    // Recalculate the energy after the constraints have been applied.
+                    energy_before = energy_after;
+                    energy_after = context.getState(OpenMM::State::Energy).getPotentialEnergy();
+
                     const auto delta_energy = energy_after - energy_before;
 
                     data.addLog(QString("Change in energy: %1 kJ mol-1").arg(delta_energy));

--- a/wrapper/Convert/SireOpenMM/openmmminimise.h
+++ b/wrapper/Convert/SireOpenMM/openmmminimise.h
@@ -33,7 +33,8 @@ namespace SireOpenMM
                                     int ratchet_frequency = 500,
                                     double starting_k = 100.0,
                                     double ratchet_scale = 2.0,
-                                    double max_constraint_error = 0.01);
+                                    double max_constraint_error = 0.01,
+                                    double timeout = 60.0);
 
 }
 

--- a/wrapper/Convert/SireOpenMM/openmmminimise.h
+++ b/wrapper/Convert/SireOpenMM/openmmminimise.h
@@ -34,7 +34,7 @@ namespace SireOpenMM
                                     double starting_k = 100.0,
                                     double ratchet_scale = 2.0,
                                     double max_constraint_error = 0.01,
-                                    double timeout = 60.0);
+                                    double timeout = 300.0);
 
 }
 

--- a/wrapper/Convert/SireOpenMM/sire_to_openmm_system.cpp
+++ b/wrapper/Convert/SireOpenMM/sire_to_openmm_system.cpp
@@ -315,7 +315,8 @@ void _add_positional_restraints(const SireMM::PositionalRestraints &restraints,
     auto ghost_nonghostff = lambda_lever.getForce<OpenMM::CustomNonbondedForce>("ghost/non-ghost", system);
 
     std::vector<double> custom_params = {1.0, 0.0, 0.0};
-    std::vector<double> custom_clj_params = {0.0, 0.0, 0.0, 0.0};
+    // Define null parameters used to add these particles to the ghost forces (5 total)
+    std::vector<double> custom_clj_params = {0.0, 0.0, 0.0, 0.0, 0.0};
 
     // we need to add all of the positions as anchor particles
     for (const auto &restraint : atom_restraints)

--- a/wrapper/Convert/SireOpenMM/sire_to_openmm_system.cpp
+++ b/wrapper/Convert/SireOpenMM/sire_to_openmm_system.cpp
@@ -1578,14 +1578,14 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
     {
         // work out the molecule index for the from ghost atom
         int mol_from = 0;
-        while (start_indexes[mol_from] <= from_ghost_idx)
+        while (start_indexes[mol_from] <= from_ghost_idx and mol_from < nmols)
             mol_from++;
 
         for (const auto &to_ghost_idx : to_ghost_idxs)
         {
             // work out the molecule index for the to ghost atom
             int mol_to = 0;
-            while (start_indexes[mol_to] <= to_ghost_idx)
+            while (start_indexes[mol_to] <= to_ghost_idx and mol_to < nmols)
                 mol_to++;
 
             if (not excluded_ghost_pairs.contains(IndexPair(from_ghost_idx, to_ghost_idx)))

--- a/wrapper/Convert/SireOpenMM/sire_to_openmm_system.cpp
+++ b/wrapper/Convert/SireOpenMM/sire_to_openmm_system.cpp
@@ -1503,7 +1503,11 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
                                               boost::get<2>(p), 1e-9,
                                               1e-9, true);
 
-                    if (coul_14_scl != 0 or lj_14_scl != 0)
+                    // Whether this is a to/from ghost interaction.
+                    auto to_from_ghost = (from_ghost_idxs.contains(atom0) and to_ghost_idxs.contains(atom1)) or
+                                         (from_ghost_idxs.contains(atom1) and to_ghost_idxs.contains(atom0));
+
+                    if (not to_from_ghost and (coul_14_scl != 0 or lj_14_scl != 0))
                     {
                         // this is a 1-4 interaction that should be added
                         // to the ghost-14 forcefield

--- a/wrapper/Convert/SireOpenMM/sire_to_openmm_system.cpp
+++ b/wrapper/Convert/SireOpenMM/sire_to_openmm_system.cpp
@@ -916,7 +916,7 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
         {
             nb14_expression = QString(
                                   "coul_nrg+lj_nrg;"
-                                  "coul_nrg=138.9354558466661*q*(((%1)/sqrt((%2*alpha)+r_safe^2))-(kappa/r_safe));"
+                                  "coul_nrg=138.9354558466661*q*(((%1)/sqrt((%2*alpha*alpha)+r_safe^2))-(kappa/r_safe));"
                                   "lj_nrg=four_epsilon*sig6*(sig6-1);"
                                   "sig6=(sigma^6)/(%3*sigma^6 + r_safe^6);"
                                   "r_safe=max(r, 0.001);")
@@ -929,7 +929,7 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
         {
             nb14_expression = QString(
                                   "coul_nrg+lj_nrg;"
-                                  "coul_nrg=138.9354558466661*q*(((%1)/sqrt((%2*alpha)+r_safe^2))-(kappa/r_safe));"
+                                  "coul_nrg=138.9354558466661*q*(((%1)/sqrt((%2*alpha*alpha)+r_safe^2))-(kappa/r_safe));"
                                   "lj_nrg=four_epsilon*sig6*(sig6-1);"
                                   "sig6=(sigma^6)/(((sigma*delta) + r_safe^2)^3);"
                                   "r_safe=max(r, 0.001);"
@@ -976,7 +976,7 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
             // kJ mol-1 given the units of charge (|e|) and distance (nm)
             //
             clj_expression = QString("coul_nrg+lj_nrg;"
-                                     "coul_nrg=138.9354558466661*q1*q2*(((%1)/sqrt((%2*max_alpha)+r_safe^2))-(max_kappa/r_safe));"
+                                     "coul_nrg=138.9354558466661*q1*q2*(((%1)/sqrt((%2*max_alpha*max_alpha)+r_safe^2))-(max_kappa/r_safe));"
                                      "lj_nrg=two_sqrt_epsilon1*two_sqrt_epsilon2*sig6*(sig6-1);"
                                      "sig6=(sigma^6)/(%3*sigma^6 + r_safe^6);"
                                      "r_safe=max(r, 0.001);"
@@ -1014,7 +1014,7 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
             // kJ mol-1 given the units of charge (|e|) and distance (nm)
             //
             clj_expression = QString("coul_nrg+lj_nrg;"
-                                     "coul_nrg=138.9354558466661*q1*q2*(((%1)/sqrt((%2*max_alpha)+r_safe^2))-(max_kappa/r_safe));"
+                                     "coul_nrg=138.9354558466661*q1*q2*(((%1)/sqrt((%2*max_alpha*max_alpha)+r_safe^2))-(max_kappa/r_safe));"
                                      "lj_nrg=two_sqrt_epsilon1*two_sqrt_epsilon2*sig6*(sig6-1);"
                                      "sig6=(sigma^6)/(((sigma*delta) + r_safe^2)^3);"
                                      "delta=%3*max_alpha;"

--- a/wrapper/Convert/__init__.py
+++ b/wrapper/Convert/__init__.py
@@ -492,7 +492,7 @@ try:
         starting_k: float = 100.0,
         ratchet_scale: float = 2.0,
         max_constraint_error: float = 0.01,
-        timeout: str = "60s",
+        timeout: str = "300s",
     ):
         return _minimise_openmm_context(
             context,

--- a/wrapper/Convert/__init__.py
+++ b/wrapper/Convert/__init__.py
@@ -492,6 +492,7 @@ try:
         starting_k: float = 100.0,
         ratchet_scale: float = 2.0,
         max_constraint_error: float = 0.01,
+        timeout: str = "60s",
     ):
         return _minimise_openmm_context(
             context,
@@ -503,6 +504,7 @@ try:
             starting_k=starting_k,
             ratchet_scale=ratchet_scale,
             max_constraint_error=max_constraint_error,
+            timeout=timeout,
         )
 
 except Exception as e:


### PR DESCRIPTION
This PR closes #236 by restricting the loop over the `start_indexes` vector to the number of molecules in the system.

Also closes #238 by fixing the calculation of `delta^2` used in the Coulomb term of the nonbonded expressions.

Also closes #239 by excluding to/from ghost interactions from the `ghost_14ff`.

Also closes #230 by adding a crude timeout to the OpenMM minimiser. This just checks to see if a maximum number of seconds has been exceeded in both the inner and outer loops of the code. This obviously doesn't check the timing within the internal line search algorithm itself. The main point of this is allow the user a single lever to control the max time (roughly) before the minimiser exits, rather than needing to adjust the number of iterations, ratchets, etc. (And even then, those might still lead to a hang.)

Also closes #241 by re-computing the energy _after_ performing the final constraint projection in order to get the correct delta energy.

Also closes #242 by clearing the internal OpenMM state of the dynamics object when performing a minimisation.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]