### PR TITLE
Improve annihilate docstring

### DIFF
--- a/src/sire/morph/_decouple.py
+++ b/src/sire/morph/_decouple.py
@@ -6,7 +6,10 @@ def annihilate(mol, as_new_molecule: bool = True, map=None):
     Return a merged molecule that represents the perturbation that
     completely annihilates the molecule. The returned merged molecule
     will be suitable for using in a double-annihilation free energy
-    simulation, e.g. to calculate absolute binding free energies.
+    simulation, e.g. to calculate absolute binding free energies. Note that
+    this perturbation will remove all intramolecular interactions, not just
+    nonbonded intramolecular interactions. You should add positional restraints
+    to all atoms in the molecule to prevent to prevent it drifting apart.
 
     Parameters
     ----------


### PR DESCRIPTION
In the `annihilate` docstring, make it clear that annihilate removes intramolecular bonded interactions, not just intramolecular nonbonded interactions, as might be expected from some of the ABFE literature.

See the discussion in https://github.com/OpenBioSim/sire/issues/245.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [n] 
(Tiny change, but happy to add one if it would still be helpful)
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods, @lohedges
