### PR TITLE
Fix issue #253

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -19,6 +19,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Fixed instantiaton of ``QByteArray`` in ``Sire::Mol::Frame::toByteArray`` and count bytes with ``QByteArray::size``.
 * Increase timeout before terminating ``QThread`` objects during ``PageCache`` cleanup.
 * Expose missing ``timeout`` kwarg in :meth:`dynamics.minimise()` method.
+* Expose missing ``include_constrained_energies`` kwarg in minimisation function.
+* Make minimisation function settings consistent across API.
 
 `2024.3.0 <https://github.com/openbiosim/sire/compare/2024.2.0...2024.3.0>`__ - October 2024
 --------------------------------------------------------------------------------------------

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -18,6 +18,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Please add an item to this CHANGELOG for any new features or bug fixes when creating a PR.
 * Fixed instantiaton of ``QByteArray`` in ``Sire::Mol::Frame::toByteArray`` and count bytes with ``QByteArray::size``.
 * Increase timeout before terminating ``QThread`` objects during ``PageCache`` cleanup.
+* Expose missing ``timeout`` kwarg in :meth:`dynamics.minimise()` method.
 
 `2024.3.0 <https://github.com/openbiosim/sire/compare/2024.2.0...2024.3.0>`__ - October 2024
 --------------------------------------------------------------------------------------------

--- a/src/sire/mol/__init__.py
+++ b/src/sire/mol/__init__.py
@@ -2156,6 +2156,9 @@ def _minimisation(
     if platform is not None:
         map.set("platform", str(platform))
 
+    if include_constrained_energies is not None:
+        map.set("include_constrained_energies", include_constrained_energies)
+
     return Minimisation(
         view,
         cutoff=cutoff,

--- a/src/sire/mol/_dynamics.py
+++ b/src/sire/mol/_dynamics.py
@@ -700,8 +700,8 @@ class DynamicsData:
         max_restarts: int = 10,
         max_ratchets: int = 20,
         ratchet_frequency: int = 500,
-        starting_k: float = 100.0,
-        ratchet_scale: float = 2.0,
+        starting_k: float = 400.0,
+        ratchet_scale: float = 10.0,
         max_constraint_error: float = 0.001,
         timeout: str = "300s",
     ):
@@ -1254,8 +1254,8 @@ class Dynamics:
         max_restarts: int = 10,
         max_ratchets: int = 20,
         ratchet_frequency: int = 500,
-        starting_k: float = 100.0,
-        ratchet_scale: float = 2.0,
+        starting_k: float = 400.0,
+        ratchet_scale: float = 10.0,
         max_constraint_error: float = 0.001,
         timeout: str = "300s",
     ):

--- a/src/sire/mol/_dynamics.py
+++ b/src/sire/mol/_dynamics.py
@@ -1257,6 +1257,7 @@ class Dynamics:
         starting_k: float = 100.0,
         ratchet_scale: float = 2.0,
         max_constraint_error: float = 0.001,
+        timeout: str = "300s",
     ):
         """
         Internal method that runs minimisation on the molecules.
@@ -1290,6 +1291,8 @@ class Dynamics:
         - starting_k (float): The starting value of k for the minimisation
         - ratchet_scale (float): The amount to scale k at each ratchet
         - max_constraint_error (float): The maximum error in the constraints in nm
+        - timeout (float): The maximum time to run the minimisation for in seconds.
+                           A value of <=0 will disable the timeout.
         """
         if not self._d.is_null():
             self._d.run_minimisation(
@@ -1301,6 +1304,7 @@ class Dynamics:
                 starting_k=starting_k,
                 ratchet_scale=ratchet_scale,
                 max_constraint_error=max_constraint_error,
+                timeout=timeout,
             )
 
         return self


### PR DESCRIPTION
This PR closes #253 by exposing the `timeout` kwarg in `dynamics.minimise()`.

Also closes #255 by adding the `include_constrained_energies` kwarg to the map and standardising minimisation settings across all API functions.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

