### PR TITLE
Fix issue #265

### DIFF
--- a/corelib/src/libs/SireMove/openmmfrenergydt.cpp
+++ b/corelib/src/libs/SireMove/openmmfrenergydt.cpp
@@ -1228,9 +1228,9 @@ void OpenMMFrEnergyDT::integrate(IntegratorWorkspace &workspace, const Symbol &n
 
             // Set Periodic Box Condition
 
-            context_openmm.setPeriodicBoxVectors(OpenMM::Vec3(Box_x_Edge_Length, 0, 0),
-                                                 OpenMM::Vec3(0, Box_y_Edge_Length, 0),
-                                                 OpenMM::Vec3(0, 0, Box_z_Edge_Length));
+            system_openmm->setDefaultPeriodicBoxVectors(OpenMM::Vec3(Box_x_Edge_Length, 0, 0),
+                                                        OpenMM::Vec3(0, Box_y_Edge_Length, 0),
+                                                        OpenMM::Vec3(0, 0, Box_z_Edge_Length));
         }
         // TriclinicBox.
         else if (ptr_sys.property(space_property).isA<TriclinicBox>())
@@ -1253,9 +1253,11 @@ void OpenMMFrEnergyDT::integrate(IntegratorWorkspace &workspace, const Symbol &n
             const double zy = v2.y() * OpenMM::NmPerAngstrom;
             const double zz = v2.z() * OpenMM::NmPerAngstrom;
 
-            context_openmm.setPeriodicBoxVectors(OpenMM::Vec3(xx, xy, xz), OpenMM::Vec3(yx, yy, yz),
-                                                 OpenMM::Vec3(zx, zy, zz));
+            system_openmm->setDefaultPeriodicBoxVectors(OpenMM::Vec3(xx, xy, xz), OpenMM::Vec3(yx, yy, yz),
+                                                        OpenMM::Vec3(zx, zy, zz));
         }
+
+        context_openmm.reinitialize();
     }
 
     if (Debug)

--- a/corelib/src/libs/SireMove/openmmfrenergyst.cpp
+++ b/corelib/src/libs/SireMove/openmmfrenergyst.cpp
@@ -3450,10 +3450,6 @@ void OpenMMFrEnergyST::createContext(IntegratorWorkspace &workspace, SireUnits::
             system_openmm->setDefaultPeriodicBoxVectors(OpenMM::Vec3(Box_x_Edge_Length, 0, 0),
                                                         OpenMM::Vec3(0, Box_y_Edge_Length, 0),
                                                         OpenMM::Vec3(0, 0, Box_z_Edge_Length));
-
-            openmm_context->setPeriodicBoxVectors(OpenMM::Vec3(Box_x_Edge_Length, 0, 0),
-                                                  OpenMM::Vec3(0, Box_y_Edge_Length, 0),
-                                                  OpenMM::Vec3(0, 0, Box_z_Edge_Length));
         }
         // TriclinicBox.
         else if (ptr_sys.property(space_property).isA<TriclinicBox>())
@@ -3478,9 +3474,6 @@ void OpenMMFrEnergyST::createContext(IntegratorWorkspace &workspace, SireUnits::
 
             system_openmm->setDefaultPeriodicBoxVectors(OpenMM::Vec3(xx, xy, xz), OpenMM::Vec3(yx, yy, yz),
                                                         OpenMM::Vec3(zx, zy, zz));
-
-            openmm_context->setPeriodicBoxVectors(OpenMM::Vec3(xx, xy, xz), OpenMM::Vec3(yx, yy, yz),
-                                                  OpenMM::Vec3(zx, zy, zz));
         }
 
         openmm_context->reinitialize();

--- a/corelib/src/libs/SireMove/openmmmdintegrator.cpp
+++ b/corelib/src/libs/SireMove/openmmmdintegrator.cpp
@@ -1157,9 +1157,9 @@ void OpenMMMDIntegrator::createContext(IntegratorWorkspace &workspace, SireUnits
 
             // Set Periodic Box Condition
 
-            openmm_context->setPeriodicBoxVectors(OpenMM::Vec3(Box_x_Edge_Length, 0, 0),
-                                                  OpenMM::Vec3(0, Box_y_Edge_Length, 0),
-                                                  OpenMM::Vec3(0, 0, Box_z_Edge_Length));
+            system_openmm->setDefaultPeriodicBoxVectors(OpenMM::Vec3(Box_x_Edge_Length, 0, 0),
+                                                        OpenMM::Vec3(0, Box_y_Edge_Length, 0),
+                                                        OpenMM::Vec3(0, 0, Box_z_Edge_Length));
         }
         // TriclinicBox.
         else if (ptr_sys.property(space_property).isA<TriclinicBox>())
@@ -1182,11 +1182,12 @@ void OpenMMMDIntegrator::createContext(IntegratorWorkspace &workspace, SireUnits
             const double zy = v2.y() * OpenMM::NmPerAngstrom;
             const double zz = v2.z() * OpenMM::NmPerAngstrom;
 
-            openmm_context->setPeriodicBoxVectors(OpenMM::Vec3(xx, xy, xz), OpenMM::Vec3(yx, yy, yz),
-                                                  OpenMM::Vec3(zx, zy, zz));
+            system_openmm->setDefaultPeriodicBoxVectors(OpenMM::Vec3(xx, xy, xz), OpenMM::Vec3(yx, yy, yz),
+                                                        OpenMM::Vec3(zx, zy, zz));
         }
 
         is_periodic = true;
+        openmm_context->reinitialize();
     }
 
     double AKMAPerPs = 0.04888821;

--- a/corelib/src/libs/SireMove/openmmpmefep.cpp
+++ b/corelib/src/libs/SireMove/openmmpmefep.cpp
@@ -2954,10 +2954,6 @@ void OpenMMPMEFEP::createContext(IntegratorWorkspace &workspace, SireUnits::Dime
         system_openmm->setDefaultPeriodicBoxVectors(OpenMM::Vec3(Box_x_Edge_Length, 0, 0),
                                                     OpenMM::Vec3(0, Box_y_Edge_Length, 0),
                                                     OpenMM::Vec3(0, 0, Box_z_Edge_Length));
-
-        openmm_context->setPeriodicBoxVectors(OpenMM::Vec3(Box_x_Edge_Length, 0, 0),
-                                              OpenMM::Vec3(0, Box_y_Edge_Length, 0),
-                                              OpenMM::Vec3(0, 0, Box_z_Edge_Length));
     }
     // TriclinicBox
     else if (ptr_sys.property(space_property).isA<TriclinicBox>())
@@ -2983,9 +2979,6 @@ void OpenMMPMEFEP::createContext(IntegratorWorkspace &workspace, SireUnits::Dime
 
         system_openmm->setDefaultPeriodicBoxVectors(OpenMM::Vec3(xx, xy, xz), OpenMM::Vec3(yx, yy, yz),
                                                     OpenMM::Vec3(zx, zy, zz));
-
-        openmm_context->setPeriodicBoxVectors(OpenMM::Vec3(xx, xy, xz), OpenMM::Vec3(yx, yy, yz),
-                                              OpenMM::Vec3(zx, zy, zz));
     }
 
     openmm_context->reinitialize();

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -16,17 +16,32 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 ---------------------------------------------------------------------------------------------
 
 * Please add an item to this CHANGELOG for any new features or bug fixes when creating a PR.
+
+* Fixed update of triclinic box vectors in ``SOMD`` following ``OpenMM`` bug fix.
+
+`2024.3.1 <https://github.com/openbiosim/sire/compare/2024.3.0...2024.3.1>`__ - December 2024
+--------------------------------------------------------------------------------------------
+
 * Fixed instantiaton of ``QByteArray`` in ``Sire::Mol::Frame::toByteArray`` and count bytes with ``QByteArray::size``.
+
 * Increase timeout before terminating ``QThread`` objects during ``PageCache`` cleanup.
+
 * Expose missing ``timeout`` kwarg in :meth:`dynamics.minimise()` method.
+
 * Expose missing ``include_constrained_energies`` kwarg in minimisation function.
+
 * Make minimisation function settings consistent across API.
+
 * Reload TorchQMForce module if OpenMM platform changes.
+
 * Fix calculation of non-equilibrium work when starting from QM state.
+
 * Fix stereochemistry in RDKit molecule conversion.
+
 * Fixed :func:`sire.restraints.get_standard_state_correction` to be consistent with the definition of
   the "force constanst" as ``F = 2 ** k ** x`` (rather than ``F = k ** x``). Updated docstrings and
   restraints documentation to make it clear how the force constants are defined.
+
 * Fix thread safety issue in Sire OpenMM minimiser.
 
 `2024.3.0 <https://github.com/openbiosim/sire/compare/2024.2.0...2024.3.0>`__ - October 2024


### PR DESCRIPTION
This PR closes #265 by changing the way that periodic box vectors are updated in the SOMD OpenMM context. This change is needed due to [this](https://github.com/openmm/openmm/issues/4548) issue from OpenMM. We now only need to update the default box vectors in the system, then reinitialise the context, after which the updated vectors will be propagated. Without this, calling `setPeriodicBoxVectors()` directly on the context will trigger an exception when using certain platforms, e.g. CUDA.

I've added tests for this update in BioSimSpace [here](https://github.com/OpenBioSim/biosimspace/commit/3f9e852931675eabddbc4bb56a71f9b1be63692c). Note that these will _always_ pass in the CI since the CPU platform is unaffected by this issue. As such, the test will need to be run manually on a GPU enabled device in order to validate. (The CUDA platform is conditionally used in the tests when `CUDA_VISIBLE_DEVICES` is set.)

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
