### PR TITLE
Fix #269

### DIFF
--- a/src/sire/qm/_emle.py
+++ b/src/sire/qm/_emle.py
@@ -225,23 +225,10 @@ def emle(
 
     # Create an engine from an EMLE calculator.
     if isinstance(calculator, _EMLECalculator):
-        # Determine the callback name. Use an optimised version of the callback
-        # if the user has specified "torchani" as the backend and is using
-        # "electrostatic" embedding.
-        if calculator._backend == "torchani" and calculator._method == "electrostatic":
-            try:
-                from emle.models import ANI2xEMLE as _ANI2xEMLE
-
-                callback = "_sire_callback_optimised"
-            except:
-                callback = "_sire_callback"
-        else:
-            callback = "_sire_callback"
-
         # Create the EMLE engine.
         engine = EMLEEngine(
             calculator,
-            callback,
+            "_sire_callback",
             cutoff,
             neighbour_list_frequency,
             False,


### PR DESCRIPTION
This PR closes #269 by removing the redundant "optimised" callback interface between `sire` and `emle-engine`. Since the `emle-engine` calculator now uses the Torch modules internally, there is no need to use the optimised callback. (Which would create a module for you given a specific set of conditions.) I've tested this locally using `emle-engine` within my own environment.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]