### PR TITLE
Exclude alchemical ions from the REST2 region

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -37,6 +37,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 
 * Added support for angle and dihedral restraints which can be used in alchemical and standard simulations.
 
+* Allow user to compute energy trajectory over a subset of the lambda windows for each lambda.
+
 `2024.3.1 <https://github.com/openbiosim/sire/compare/2024.3.0...2024.3.1>`__ - December 2024
 --------------------------------------------------------------------------------------------
 

--- a/src/sire/mol/_dynamics.py
+++ b/src/sire/mol/_dynamics.py
@@ -1609,7 +1609,8 @@ class Dynamics:
             can be achieved by simply removing any lambda values from
             'lambda_windows' that you don't want, but this will result
             in an energy trajectory that only contains results for
-            the specified lambda values.
+            the specified lambda values. If None, then all lambda windows
+            will be used.
 
         null_energy: str
             The energy value to use for lambda windows that are not

--- a/src/sire/mol/_dynamics.py
+++ b/src/sire/mol/_dynamics.py
@@ -390,11 +390,12 @@ class DynamicsData:
         self._current_time += delta
 
         # store the number of lambda windows
-        num_lambda_windows = len(lambda_windows)
+        if lambda_windows is not None:
+            num_lambda_windows = len(lambda_windows)
 
-        # compute energies for all windows
-        if num_energy_neighbours is None:
-            num_energy_neighbours = num_lambda_windows
+            # compute energies for all windows
+            if num_energy_neighbours is None:
+                num_energy_neighbours = num_lambda_windows
 
         if save_energy:
             # should save energy here


### PR DESCRIPTION
This PR applies a small fix by excluding alchemical ions from the REST2 region. These are tagged in `somd2` using the `is_alchemical_ion` property, then excluded via a REST2 mask.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

