### PR TITLE
Fix hasForceSpecificEquation

### DIFF
--- a/corelib/src/libs/SireCAS/lambdaschedule.cpp
+++ b/corelib/src/libs/SireCAS/lambdaschedule.cpp
@@ -1032,8 +1032,12 @@ bool LambdaSchedule::hasForceSpecificEquation(const QString &stage,
 
     if (force == "*")
         return false;
-    else
-        return this->stage_equations[idx].contains(_get_lever_name(force, lever));
+
+    // If there is a default equation for this force, always return true
+    if (this->stage_equations[idx].contains(_get_lever_name(force, "*")))
+        return true;
+
+    return this->stage_equations[idx].contains(_get_lever_name(force, lever));
 }
 
 SireCAS::Expression LambdaSchedule::_getEquation(int stage,

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -37,6 +37,9 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 
 * Added support for angle and dihedral restraints which can be used in alchemical and standard simulations.
 
+* Fix the ``hasForceSpecificEquation`` function in the ``LambdaLever`` class so that it returns true if
+  there is a default equation for the force.
+
 `2024.3.1 <https://github.com/openbiosim/sire/compare/2024.3.0...2024.3.1>`__ - December 2024
 --------------------------------------------------------------------------------------------
 

--- a/tests/cas/test_lambdaschedule.py
+++ b/tests/cas/test_lambdaschedule.py
@@ -145,3 +145,11 @@ def test_lambdaschedule():
     )
 
     _assert_same_equation(l.lam(), l.get_equation(stage="scale_up"), morph5_equation)
+
+@pytest.mark.parametrize("force, lever, contained", [
+    ("ghost-14", "kappa", True),
+    ("ghost-14", "epsilon", True)
+])
+def test_has_force_specific_equation(force, lever, contained):
+    l = sr.cas.LambdaSchedule.standard_decouple()
+    assert l.has_force_specific_equation("decouple", force, lever) == contained


### PR DESCRIPTION
This now returns true if there is a default equation for the force.

## If this is to fix a bug...

This pull request fixes issue #279 (I have confirmed that the script supplied there now shows equal energies at lambda = 0  and lambda = 1).

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): y
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): y
* I confirm that I have permission to release this code under the GPL3 license: y

## Suggested reviewers:
@chryswoods, @lohedges

Thanks!
