### PR TITLE
Add support for OpenMM MonteCarloMembraneBarostat

### DIFF
--- a/corelib/src/libs/SireMove/openmmfrenergydt.h
+++ b/corelib/src/libs/SireMove/openmmfrenergydt.h
@@ -114,6 +114,9 @@ namespace SireMove
         void setMCBarostat_frequency(int);
         int getMCBarostat_frequency(void);
 
+        bool getMCBarostat_membrane(void);
+        void setMCBarostat_membrane(bool);
+
         QString getConstraintType(void);
         void setConstraintType(QString);
 
@@ -180,6 +183,7 @@ namespace SireMove
         double Andersen_frequency;
 
         bool MCBarostat_flag;
+        bool MCBarostat_membrane_flag;
         int MCBarostat_frequency;
 
         QString ConstraintType;

--- a/corelib/src/libs/SireMove/openmmfrenergyst.cpp
+++ b/corelib/src/libs/SireMove/openmmfrenergyst.cpp
@@ -130,7 +130,7 @@ QDataStream &operator<<(QDataStream &ds, const OpenMMFrEnergyST &velver)
     sds << velver.frequent_save_velocities << velver.molgroup << velver.solute << velver.solutehard
         << velver.solutetodummy << velver.solutefromdummy << velver.combiningRules << velver.CutoffType
         << velver.cutoff_distance << velver.field_dielectric << velver.Andersen_flag << velver.Andersen_frequency
-        << velver.MCBarostat_flag << velver.MCBarostat_frequency << velver.ConstraintType << velver.Pressure
+        << velver.MCBarostat_flag << velver.MCBarostat_membrane_flag << velver.MCBarostat_frequency << velver.ConstraintType << velver.Pressure
         << velver.Temperature << velver.platform_type << velver.Restraint_flag << velver.CMMremoval_frequency
         << velver.buffer_frequency << velver.energy_frequency << velver.device_index << velver.precision
         << velver.Alchemical_value << velver.coulomb_power << velver.shift_delta << velver.delta_alchemical
@@ -152,7 +152,7 @@ QDataStream &operator>>(QDataStream &ds, OpenMMFrEnergyST &velver)
         sds >> velver.frequent_save_velocities >> velver.molgroup >> velver.solute >> velver.solutehard >>
             velver.solutetodummy >> velver.solutefromdummy >> velver.combiningRules >> velver.CutoffType >>
             velver.cutoff_distance >> velver.field_dielectric >> velver.Andersen_flag >> velver.Andersen_frequency >>
-            velver.MCBarostat_flag >> velver.MCBarostat_frequency >> velver.ConstraintType >> velver.Pressure >>
+            velver.MCBarostat_flag >> velver.MCBarostat_membrane_flag >> velver.MCBarostat_frequency >> velver.ConstraintType >> velver.Pressure >>
             velver.Temperature >> velver.platform_type >> velver.Restraint_flag >> velver.CMMremoval_frequency >>
             velver.buffer_frequency >> velver.energy_frequency >> velver.device_index >> velver.precision >>
             velver.Alchemical_value >> velver.coulomb_power >> velver.shift_delta >> velver.delta_alchemical >>
@@ -180,7 +180,7 @@ OpenMMFrEnergyST::OpenMMFrEnergyST(bool frequent_save)
       solutefromdummy(MoleculeGroup()), openmm_system(0), openmm_context(0), isSystemInitialised(false),
       isContextInitialised(false), combiningRules("arithmetic"), CutoffType("nocutoff"),
       cutoff_distance(1.0 * nanometer), field_dielectric(78.3), Andersen_flag(false), Andersen_frequency(90.0),
-      MCBarostat_flag(false), MCBarostat_frequency(25), ConstraintType("none"), Pressure(1.0 * bar),
+      MCBarostat_flag(false), MCBarostat_membrane_flag(false), MCBarostat_frequency(25), ConstraintType("none"), Pressure(1.0 * bar),
       Temperature(300.0 * kelvin), platform_type("Reference"), Restraint_flag(false), CMMremoval_frequency(0),
       buffer_frequency(0), energy_frequency(100), device_index("0"), precision("single"), Alchemical_value(0.5),
       coulomb_power(0), shift_delta(2.0), delta_alchemical(0.001), alchemical_array(), finite_diff_gradients(),
@@ -199,7 +199,7 @@ OpenMMFrEnergyST::OpenMMFrEnergyST(const MoleculeGroup &molecule_group, const Mo
       solutefromdummy(solute_fromdummy), openmm_system(0), openmm_context(0), isSystemInitialised(false),
       isContextInitialised(false), combiningRules("arithmetic"), CutoffType("nocutoff"),
       cutoff_distance(1.0 * nanometer), field_dielectric(78.3), Andersen_flag(false), Andersen_frequency(90.0),
-      MCBarostat_flag(false), MCBarostat_frequency(25), ConstraintType("none"), Pressure(1.0 * bar),
+      MCBarostat_flag(false), MCBarostat_membrane_flag(false), MCBarostat_frequency(25), ConstraintType("none"), Pressure(1.0 * bar),
       Temperature(300.0 * kelvin), platform_type("Reference"), Restraint_flag(false), CMMremoval_frequency(0),
       buffer_frequency(0), energy_frequency(100), device_index("0"), precision("single"), Alchemical_value(0.5),
       coulomb_power(0), shift_delta(2.0), delta_alchemical(0.001), alchemical_array(), finite_diff_gradients(),
@@ -217,7 +217,7 @@ OpenMMFrEnergyST::OpenMMFrEnergyST(const OpenMMFrEnergyST &other)
       isSystemInitialised(other.isSystemInitialised), isContextInitialised(other.isContextInitialised),
       combiningRules(other.combiningRules), CutoffType(other.CutoffType), cutoff_distance(other.cutoff_distance),
       field_dielectric(other.field_dielectric), Andersen_flag(other.Andersen_flag),
-      Andersen_frequency(other.Andersen_frequency), MCBarostat_flag(other.MCBarostat_flag),
+      Andersen_frequency(other.Andersen_frequency), MCBarostat_flag(other.MCBarostat_flag), MCBarostat_membrane_flag(other.MCBarostat_membrane_flag),
       MCBarostat_frequency(other.MCBarostat_frequency), ConstraintType(other.ConstraintType), Pressure(other.Pressure),
       Temperature(other.Temperature), platform_type(other.platform_type), Restraint_flag(other.Restraint_flag),
       CMMremoval_frequency(other.CMMremoval_frequency), buffer_frequency(other.buffer_frequency),
@@ -259,6 +259,7 @@ OpenMMFrEnergyST &OpenMMFrEnergyST::operator=(const OpenMMFrEnergyST &other)
     Andersen_flag = other.Andersen_flag;
     Andersen_frequency = other.Andersen_frequency;
     MCBarostat_flag = other.MCBarostat_flag;
+    MCBarostat_membrane_flag = other.MCBarostat_membrane_flag;
     MCBarostat_frequency = other.MCBarostat_frequency;
     ConstraintType = other.ConstraintType;
     Pressure = other.Pressure;
@@ -302,7 +303,7 @@ bool OpenMMFrEnergyST::operator==(const OpenMMFrEnergyST &other) const
            combiningRules == other.combiningRules and CutoffType == other.CutoffType and
            cutoff_distance == other.cutoff_distance and field_dielectric == other.field_dielectric and
            Andersen_flag == other.Andersen_flag and Andersen_frequency == other.Andersen_frequency and
-           MCBarostat_flag == other.MCBarostat_flag and MCBarostat_frequency == other.MCBarostat_frequency and
+           MCBarostat_flag == other.MCBarostat_flag and MCBarostat_membrane_flag == other.MCBarostat_membrane_flag and MCBarostat_frequency == other.MCBarostat_frequency and
            ConstraintType == other.ConstraintType and Pressure == other.Pressure and
            Temperature == other.Temperature and platform_type == other.platform_type and
            Restraint_flag == other.Restraint_flag and CMMremoval_frequency == other.CMMremoval_frequency and
@@ -1241,13 +1242,29 @@ void OpenMMFrEnergyST::initialise()
         const double converted_Temperature = convertTo(Temperature.value(), kelvin);
         const double converted_Pressure = convertTo(Pressure.value(), bar);
 
-        OpenMM::MonteCarloBarostat *barostat =
-            new OpenMM::MonteCarloBarostat(converted_Pressure, converted_Temperature, MCBarostat_frequency);
+        if (MCBarostat_membrane_flag == true)
+        {
+            // Simple options for now: zero surface tension, XY isotropic, Z free
+            const double surface_Tension = 0;
+            OpenMM::MonteCarloMembraneBarostat::XYMode xymode = OpenMM::MonteCarloMembraneBarostat::XYIsotropic;
+            OpenMM::MonteCarloMembraneBarostat::ZMode zmode = OpenMM::MonteCarloMembraneBarostat::ZFree;
+            OpenMM::MonteCarloMembraneBarostat * barostat = new OpenMM::MonteCarloMembraneBarostat(converted_Pressure, surface_Tension, converted_Temperature, xymode, zmode, MCBarostat_frequency);
 
-        // Set The random seed
-        barostat->setRandomNumberSeed(random_seed);
+            //Set The random seed
+            barostat->setRandomNumberSeed(random_seed);
 
-        system_openmm->addForce(barostat);
+            system_openmm->addForce(barostat);
+        }
+        else
+        {
+            OpenMM::MonteCarloBarostat *barostat =
+                new OpenMM::MonteCarloBarostat(converted_Pressure, converted_Temperature, MCBarostat_frequency);
+
+            // Set The random seed
+            barostat->setRandomNumberSeed(random_seed);
+
+            system_openmm->addForce(barostat);
+        }
 
         if (Debug)
         {
@@ -1255,6 +1272,10 @@ void OpenMMFrEnergyST::initialise()
             qDebug() << "Temperature = " << converted_Temperature << " K\n";
             qDebug() << "Pressure = " << converted_Pressure << " bar\n";
             qDebug() << "Frequency every " << MCBarostat_frequency << " steps\n";
+            if (MCBarostat_membrane_flag)
+            {
+                qDebug() << "Membrane barostat, surface tension 0, XY isotropic, Z free\n";
+            }
         }
     }
     /*******************************************************BONDED
@@ -4349,6 +4370,16 @@ void OpenMMFrEnergyST::setMCBarostat(bool MCBarostat)
 bool OpenMMFrEnergyST::getMCBarostat(void)
 {
     return MCBarostat_flag;
+}
+
+void OpenMMFrEnergyST::setMCBarostatMembrane(bool MCBarostat_membrane)
+{
+    MCBarostat_membrane_flag = MCBarostat_membrane;
+}
+
+bool OpenMMFrEnergyST::getMCBarostatMembrane(void)
+{
+    return MCBarostat_membrane_flag;
 }
 
 /** Get the Monte Carlo Barostat frequency in time speps */

--- a/corelib/src/libs/SireMove/openmmfrenergyst.h
+++ b/corelib/src/libs/SireMove/openmmfrenergyst.h
@@ -122,6 +122,9 @@ namespace SireMove
         bool getMCBarostat(void);
         void setMCBarostat(bool);
 
+        bool getMCBarostatMembrane(void);
+        void setMCBarostatMembrane(bool);
+
         void setMCBarostatFrequency(int);
         int getMCBarostatFrequency(void);
 
@@ -247,6 +250,7 @@ namespace SireMove
         double Andersen_frequency;
 
         bool MCBarostat_flag;
+        bool MCBarostat_membrane_flag;
         int MCBarostat_frequency;
 
         QString ConstraintType;

--- a/corelib/src/libs/SireMove/openmmmdintegrator.cpp
+++ b/corelib/src/libs/SireMove/openmmmdintegrator.cpp
@@ -124,7 +124,7 @@ QDataStream &operator<<(QDataStream &ds, const OpenMMMDIntegrator &velver)
 
     sds << velver.frequent_save_velocities << velver.molgroup << velver.Integrator_type << velver.friction
         << velver.CutoffType << velver.cutoff_distance << velver.field_dielectric << velver.tolerance_ewald_pme
-        << velver.Andersen_flag << velver.Andersen_frequency << velver.MCBarostat_flag << velver.MCBarostat_frequency
+        << velver.Andersen_flag << velver.Andersen_frequency << velver.MCBarostat_flag << velver.MCBarostat_membrane_flag << velver.MCBarostat_frequency
         << velver.ConstraintType << velver.Pressure << velver.Temperature << velver.platform_type
         << velver.Restraint_flag << velver.CMMremoval_frequency << velver.buffer_frequency << velver.device_index
         << velver.LJ_dispersion << velver.precision << velver.integration_tol << velver.timeskip
@@ -147,7 +147,7 @@ QDataStream &operator>>(QDataStream &ds, OpenMMMDIntegrator &velver)
 
         sds >> velver.frequent_save_velocities >> velver.molgroup >> velver.Integrator_type >> velver.friction >>
             velver.CutoffType >> velver.cutoff_distance >> velver.field_dielectric >> velver.tolerance_ewald_pme >>
-            velver.Andersen_flag >> velver.Andersen_frequency >> velver.MCBarostat_flag >>
+            velver.Andersen_flag >> velver.Andersen_frequency >> velver.MCBarostat_flag >> velver.MCBarostat_membrane_flag >>
             velver.MCBarostat_frequency >> velver.ConstraintType >> velver.Pressure >> velver.Temperature >>
             velver.platform_type >> velver.Restraint_flag >> velver.CMMremoval_frequency >> velver.buffer_frequency >>
             velver.device_index >> velver.LJ_dispersion >> velver.precision >> velver.integration_tol >>
@@ -195,7 +195,7 @@ OpenMMMDIntegrator::OpenMMMDIntegrator(bool frequent_save)
       molgroup(MoleculeGroup()), openmm_system(0), openmm_context(0), isSystemInitialised(false),
       isContextInitialised(false), Integrator_type("leapfrogverlet"), friction(1.0 / picosecond),
       CutoffType("nocutoff"), cutoff_distance(1.0 * nanometer), field_dielectric(78.3), tolerance_ewald_pme(0.0001),
-      Andersen_flag(false), Andersen_frequency(90.0), MCBarostat_flag(false), MCBarostat_frequency(25),
+      Andersen_flag(false), Andersen_frequency(90.0), MCBarostat_flag(false), MCBarostat_membrane_flag(false), MCBarostat_frequency(25),
       ConstraintType("none"), Pressure(1.0 * bar), Temperature(300.0 * kelvin), platform_type("Reference"),
       Restraint_flag(false), CMMremoval_frequency(0), buffer_frequency(0), device_index("0"), LJ_dispersion(true),
       precision("single"), reinetialise_context(false), integration_tol(0.001), timeskip(0.0 * picosecond),
@@ -211,7 +211,7 @@ OpenMMMDIntegrator::OpenMMMDIntegrator(const MoleculeGroup &molecule_group, bool
       molgroup(molecule_group), openmm_system(0), openmm_context(0), isSystemInitialised(false),
       isContextInitialised(false), Integrator_type("leapfrogverlet"), friction(1.0 / picosecond),
       CutoffType("nocutoff"), cutoff_distance(1.0 * nanometer), field_dielectric(78.3), tolerance_ewald_pme(0.0001),
-      Andersen_flag(false), Andersen_frequency(90.0), MCBarostat_flag(false), MCBarostat_frequency(25),
+      Andersen_flag(false), Andersen_frequency(90.0), MCBarostat_flag(false), MCBarostat_membrane_flag(false), MCBarostat_frequency(25),
       ConstraintType("none"), Pressure(1.0 * bar), Temperature(300.0 * kelvin), platform_type("Reference"),
       Restraint_flag(false), CMMremoval_frequency(0), buffer_frequency(0), device_index("0"), LJ_dispersion(true),
       precision("single"), reinetialise_context(false), integration_tol(0.001), timeskip(0.0 * picosecond),
@@ -229,7 +229,7 @@ OpenMMMDIntegrator::OpenMMMDIntegrator(const OpenMMMDIntegrator &other)
       Integrator_type(other.Integrator_type), friction(other.friction), CutoffType(other.CutoffType),
       cutoff_distance(other.cutoff_distance), field_dielectric(other.field_dielectric),
       tolerance_ewald_pme(other.tolerance_ewald_pme), Andersen_flag(other.Andersen_flag),
-      Andersen_frequency(other.Andersen_frequency), MCBarostat_flag(other.MCBarostat_flag),
+      Andersen_frequency(other.Andersen_frequency), MCBarostat_flag(other.MCBarostat_flag), MCBarostat_membrane_flag(other.MCBarostat_membrane_flag),
       MCBarostat_frequency(other.MCBarostat_frequency), ConstraintType(other.ConstraintType), Pressure(other.Pressure),
       Temperature(other.Temperature), platform_type(other.platform_type), Restraint_flag(other.Restraint_flag),
       CMMremoval_frequency(other.CMMremoval_frequency), buffer_frequency(other.buffer_frequency),
@@ -264,6 +264,7 @@ OpenMMMDIntegrator &OpenMMMDIntegrator::operator=(const OpenMMMDIntegrator &othe
     Andersen_flag = other.Andersen_flag;
     Andersen_frequency = other.Andersen_frequency;
     MCBarostat_flag = other.MCBarostat_flag;
+    MCBarostat_membrane_flag = other.MCBarostat_membrane_flag;
     MCBarostat_frequency = other.MCBarostat_frequency;
     ConstraintType = other.ConstraintType;
     Pressure = other.Pressure;
@@ -291,7 +292,7 @@ bool OpenMMMDIntegrator::operator==(const OpenMMMDIntegrator &other) const
            isSystemInitialised == other.isSystemInitialised and isContextInitialised == other.isContextInitialised and
            CutoffType == other.CutoffType and cutoff_distance == other.cutoff_distance and
            field_dielectric == other.field_dielectric and Andersen_flag == other.Andersen_flag and
-           Andersen_frequency == other.Andersen_frequency and MCBarostat_flag == other.MCBarostat_flag and
+           Andersen_frequency == other.Andersen_frequency and MCBarostat_flag == other.MCBarostat_flag and MCBarostat_membrane_flag == other.MCBarostat_membrane_flag and
            MCBarostat_frequency == other.MCBarostat_frequency and ConstraintType == other.ConstraintType and
            Pressure == other.Pressure and Temperature == other.Temperature and platform_type == other.platform_type and
            Restraint_flag == other.Restraint_flag and CMMremoval_frequency == other.CMMremoval_frequency and
@@ -487,9 +488,21 @@ void OpenMMMDIntegrator::initialise()
         const double converted_Temperature = convertTo(Temperature.value(), kelvin);
         const double converted_Pressure = convertTo(Pressure.value(), bar);
 
-        OpenMM::MonteCarloBarostat *barostat =
-            new OpenMM::MonteCarloBarostat(converted_Pressure, converted_Temperature, MCBarostat_frequency);
-        system_openmm->addForce(barostat);
+        if (MCBarostat_membrane_flag == true)
+        {
+            // Simple options for now: zero surface tension, XY isotropic, Z free
+            const double surface_Tension = 0;
+            OpenMM::MonteCarloMembraneBarostat::XYMode xymode = OpenMM::MonteCarloMembraneBarostat::XYIsotropic;
+            OpenMM::MonteCarloMembraneBarostat::ZMode zmode = OpenMM::MonteCarloMembraneBarostat::ZFree;
+            OpenMM::MonteCarloMembraneBarostat * barostat = new OpenMM::MonteCarloMembraneBarostat(converted_Pressure, surface_Tension, converted_Temperature, xymode, zmode, MCBarostat_frequency);
+            system_openmm->addForce(barostat);
+        }
+        else    // normal barostat
+        {
+            OpenMM::MonteCarloBarostat *barostat =
+                new OpenMM::MonteCarloBarostat(converted_Pressure, converted_Temperature, MCBarostat_frequency);
+            system_openmm->addForce(barostat);
+        }
 
         if (Debug)
         {
@@ -498,6 +511,10 @@ void OpenMMMDIntegrator::initialise()
             qDebug() << "Pressure = " << converted_Pressure << " bar\n";
             qDebug() << "Frequency every " << MCBarostat_frequency << " steps\n";
             qDebug() << "Lennard Jones Dispersion term is set to " << LJ_dispersion << "\n";
+            if (MCBarostat_membrane_flag)
+            {
+                qDebug() << "Membrane barostat, surface tension 0, XY isotropic, Z free\n";
+            }
         }
     }
 
@@ -1926,6 +1943,16 @@ void OpenMMMDIntegrator::setMCBarostat(bool MCBarostat)
 bool OpenMMMDIntegrator::getMCBarostat(void)
 {
     return MCBarostat_flag;
+}
+
+void OpenMMMDIntegrator::setMCBarostatMembrane(bool MCBarostatMembrane)
+{
+    MCBarostat_membrane_flag = MCBarostatMembrane;
+}
+
+bool OpenMMMDIntegrator::getMCBarostatMembrane(void)
+{
+    return MCBarostat_membrane_flag;
 }
 
 /** Get the Monte Carlo Barostat frequency in time speps */

--- a/corelib/src/libs/SireMove/openmmmdintegrator.h
+++ b/corelib/src/libs/SireMove/openmmmdintegrator.h
@@ -127,6 +127,9 @@ namespace SireMove
         bool getMCBarostat(void);
         void setMCBarostat(bool);
 
+        bool getMCBarostatMembrane(void);
+        void setMCBarostatMembrane(bool);
+
         void setMCBarostatFrequency(int);
         int getMCBarostatFrequency(void);
 
@@ -203,6 +206,7 @@ namespace SireMove
         double Andersen_frequency;
 
         bool MCBarostat_flag;
+        bool MCBarostat_membrane_flag;
         int MCBarostat_frequency;
 
         QString ConstraintType;

--- a/corelib/src/libs/SireMove/openmmpmefep.cpp
+++ b/corelib/src/libs/SireMove/openmmpmefep.cpp
@@ -144,7 +144,7 @@ QDataStream &operator<<(QDataStream &ds, const OpenMMPMEFEP &velver)
     sds << velver.frequent_save_velocities << velver.molgroup << velver.solute << velver.solutehard
         << velver.solutetodummy << velver.solutefromdummy << velver.combiningRules << velver.CutoffType
         << velver.cutoff_distance << velver.field_dielectric << velver.Andersen_flag << velver.Andersen_frequency
-        << velver.MCBarostat_flag << velver.MCBarostat_frequency << velver.ConstraintType << velver.Pressure
+        << velver.MCBarostat_flag << velver.MCBarostat_membrane_flag << velver.MCBarostat_frequency << velver.ConstraintType << velver.Pressure
         << velver.Temperature << velver.platform_type << velver.Restraint_flag << velver.CMMremoval_frequency
         << velver.buffer_frequency << velver.energy_frequency << velver.device_index << velver.precision
         << velver.current_lambda << velver.coulomb_power << velver.shift_delta << velver.delta_alchemical
@@ -166,7 +166,7 @@ QDataStream &operator>>(QDataStream &ds, OpenMMPMEFEP &velver)
         sds >> velver.frequent_save_velocities >> velver.molgroup >> velver.solute >> velver.solutehard >>
             velver.solutetodummy >> velver.solutefromdummy >> velver.combiningRules >> velver.CutoffType >>
             velver.cutoff_distance >> velver.field_dielectric >> velver.Andersen_flag >> velver.Andersen_frequency >>
-            velver.MCBarostat_flag >> velver.MCBarostat_frequency >> velver.ConstraintType >> velver.Pressure >>
+            velver.MCBarostat_flag >> velver.MCBarostat_membrane_flag >> velver.MCBarostat_frequency >> velver.ConstraintType >> velver.Pressure >>
             velver.Temperature >> velver.platform_type >> velver.Restraint_flag >> velver.CMMremoval_frequency >>
             velver.buffer_frequency >> velver.energy_frequency >> velver.device_index >> velver.precision >>
             velver.current_lambda >> velver.coulomb_power >> velver.shift_delta >> velver.delta_alchemical >>
@@ -194,7 +194,7 @@ OpenMMPMEFEP::OpenMMPMEFEP(bool frequent_save)
       solutefromdummy(MoleculeGroup()), openmm_system(0), openmm_context(0), isSystemInitialised(false),
       isContextInitialised(false), combiningRules("arithmetic"), CutoffType("PME"), cutoff_distance(1.0 * nanometer),
       field_dielectric(78.3), Andersen_flag(false), Andersen_frequency(90.0), MCBarostat_flag(false),
-      MCBarostat_frequency(25), ConstraintType("none"), Pressure(1.0 * bar), Temperature(300.0 * kelvin),
+      MCBarostat_membrane_flag(false), MCBarostat_frequency(25), ConstraintType("none"), Pressure(1.0 * bar), Temperature(300.0 * kelvin),
       platform_type("Reference"), Restraint_flag(false), CMMremoval_frequency(0), buffer_frequency(0),
       energy_frequency(100), device_index("0"), precision("single"), current_lambda(0.5), coulomb_power(0),
       shift_delta(2.0), delta_alchemical(0.001), alchemical_array(), finite_diff_gradients(), pot_energies(),
@@ -212,7 +212,7 @@ OpenMMPMEFEP::OpenMMPMEFEP(const MoleculeGroup &molecule_group, const MoleculeGr
       solute(solute_group), solutehard(solute_hard), solutetodummy(solute_todummy), solutefromdummy(solute_fromdummy),
       openmm_system(0), openmm_context(0), isSystemInitialised(false), isContextInitialised(false),
       combiningRules("arithmetic"), CutoffType("PME"), cutoff_distance(1.0 * nanometer), field_dielectric(78.3),
-      Andersen_flag(false), Andersen_frequency(90.0), MCBarostat_flag(false), MCBarostat_frequency(25),
+      Andersen_flag(false), Andersen_frequency(90.0), MCBarostat_flag(false), MCBarostat_membrane_flag(false), MCBarostat_frequency(25),
       ConstraintType("none"), Pressure(1.0 * bar), Temperature(300.0 * kelvin), platform_type("Reference"),
       Restraint_flag(false), CMMremoval_frequency(0), buffer_frequency(0), energy_frequency(100), device_index("0"),
       precision("single"), current_lambda(0.5), coulomb_power(0), shift_delta(2.0), delta_alchemical(0.001),
@@ -230,7 +230,7 @@ OpenMMPMEFEP::OpenMMPMEFEP(const OpenMMPMEFEP &other)
       isSystemInitialised(other.isSystemInitialised), isContextInitialised(other.isContextInitialised),
       combiningRules(other.combiningRules), CutoffType(other.CutoffType), cutoff_distance(other.cutoff_distance),
       field_dielectric(other.field_dielectric), Andersen_flag(other.Andersen_flag),
-      Andersen_frequency(other.Andersen_frequency), MCBarostat_flag(other.MCBarostat_flag),
+      Andersen_frequency(other.Andersen_frequency), MCBarostat_flag(other.MCBarostat_flag), MCBarostat_membrane_flag(other.MCBarostat_membrane_flag),
       MCBarostat_frequency(other.MCBarostat_frequency), ConstraintType(other.ConstraintType), Pressure(other.Pressure),
       Temperature(other.Temperature), platform_type(other.platform_type), Restraint_flag(other.Restraint_flag),
       CMMremoval_frequency(other.CMMremoval_frequency), buffer_frequency(other.buffer_frequency),
@@ -272,6 +272,7 @@ OpenMMPMEFEP &OpenMMPMEFEP::operator=(const OpenMMPMEFEP &other)
     Andersen_flag = other.Andersen_flag;
     Andersen_frequency = other.Andersen_frequency;
     MCBarostat_flag = other.MCBarostat_flag;
+    MCBarostat_membrane_flag = other.MCBarostat_membrane_flag;
     MCBarostat_frequency = other.MCBarostat_frequency;
     ConstraintType = other.ConstraintType;
     Pressure = other.Pressure;
@@ -315,7 +316,7 @@ bool OpenMMPMEFEP::operator==(const OpenMMPMEFEP &other) const
            combiningRules == other.combiningRules and CutoffType == other.CutoffType and
            cutoff_distance == other.cutoff_distance and field_dielectric == other.field_dielectric and
            Andersen_flag == other.Andersen_flag and Andersen_frequency == other.Andersen_frequency and
-           MCBarostat_flag == other.MCBarostat_flag and MCBarostat_frequency == other.MCBarostat_frequency and
+           MCBarostat_flag == other.MCBarostat_flag and MCBarostat_membrane_flag == other.MCBarostat_membrane_flag and MCBarostat_frequency == other.MCBarostat_frequency and
            ConstraintType == other.ConstraintType and Pressure == other.Pressure and
            Temperature == other.Temperature and platform_type == other.platform_type and
            Restraint_flag == other.Restraint_flag and CMMremoval_frequency == other.CMMremoval_frequency and
@@ -386,17 +387,39 @@ void OpenMMPMEFEP::addMCBarostat(OpenMM::System &system)
     const double converted_Temperature = convertTo(Temperature.value(), kelvin);
     const double converted_Pressure = convertTo(Pressure.value(), bar);
 
-    auto barostat = new OpenMM::MonteCarloBarostat(converted_Pressure, converted_Temperature, MCBarostat_frequency);
+    if (MCBarostat_membrane_flag == true)
+    {
+        // Simple options for now: zero surface tension, XY isotropic, Z free
+        const double surface_Tension = 0;
+        OpenMM::MonteCarloMembraneBarostat::XYMode xymode = OpenMM::MonteCarloMembraneBarostat::XYIsotropic;
+        OpenMM::MonteCarloMembraneBarostat::ZMode zmode = OpenMM::MonteCarloMembraneBarostat::ZFree;
+        auto barostat = new OpenMM::MonteCarloMembraneBarostat(converted_Pressure, surface_Tension, converted_Temperature, xymode, zmode, MCBarostat_frequency);
 
-    barostat->setRandomNumberSeed(random_seed);
-    system.addForce(barostat);
+        //Set The random seed
+        barostat->setRandomNumberSeed(random_seed);
+
+        system.addForce(barostat);
+    }
+    else
+    {
+        auto barostat = new OpenMM::MonteCarloBarostat(converted_Pressure, converted_Temperature, MCBarostat_frequency);
+
+        // Set The random seed
+        barostat->setRandomNumberSeed(random_seed);
+
+        system.addForce(barostat);
+    }
 
     if (Debug)
     {
-        qDebug() << "Monte Carlo Barostat set";
-        qDebug() << "Temperature =" << converted_Temperature << " K";
-        qDebug() << "Pressure =" << converted_Pressure << " bar";
-        qDebug() << "Frequency every" << MCBarostat_frequency << " steps";
+        qDebug() << "Monte Carlo Barostat set\n";
+        qDebug() << "Temperature = " << converted_Temperature << " K\n";
+        qDebug() << "Pressure = " << converted_Pressure << " bar\n";
+        qDebug() << "Frequency every " << MCBarostat_frequency << " steps\n";
+        if (MCBarostat_membrane_flag)
+        {
+            qDebug() << "Membrane barostat, surface tension 0, XY isotropic, Z free\n";
+        }
     }
 }
 
@@ -3665,8 +3688,8 @@ boost::tuples::tuple<double, double, double> OpenMMPMEFEP::calculateGradient(dou
 {
     double double_increment = incr_plus - incr_minus;
     double gradient = 0;
-    double potential_energy_lambda_plus_delta;
-    double potential_energy_lambda_minus_delta;
+    double potential_energy_lambda_plus_delta = 0;
+    double potential_energy_lambda_minus_delta = 0;
     double forward_m;
     double backward_m;
     if (incr_plus < 1.0)
@@ -3885,6 +3908,16 @@ void OpenMMPMEFEP::setMCBarostat(bool MCBarostat)
 bool OpenMMPMEFEP::getMCBarostat(void)
 {
     return MCBarostat_flag;
+}
+
+void OpenMMPMEFEP::setMCBarostatMembrane(bool MCBarostat_membrane)
+{
+    MCBarostat_membrane_flag = MCBarostat_membrane;
+}
+
+bool OpenMMPMEFEP::getMCBarostatMembrane(void)
+{
+    return MCBarostat_membrane_flag;
 }
 
 /** Get the Monte Carlo Barostat frequency in time speps */

--- a/corelib/src/libs/SireMove/openmmpmefep.h
+++ b/corelib/src/libs/SireMove/openmmpmefep.h
@@ -127,6 +127,9 @@ namespace SireMove
         bool getMCBarostat(void);
         void setMCBarostat(bool);
 
+        bool getMCBarostatMembrane(void);
+        void setMCBarostatMembrane(bool);
+
         void setMCBarostatFrequency(int);
         int getMCBarostatFrequency(void);
 
@@ -250,6 +253,7 @@ namespace SireMove
         double Andersen_frequency;
 
         bool MCBarostat_flag;
+        bool MCBarostat_membrane_flag;
         int MCBarostat_frequency;
 
         QString ConstraintType;

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -42,6 +42,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Fix the ``hasForceSpecificEquation`` function in the ``LambdaLever`` class so that it returns true if
   there is a default equation for the force.
 
+* Added support for the ``OpenMM`` ``MonteCarloMembraneBarostat`` to ``SOMD``.
+
 `2024.3.1 <https://github.com/openbiosim/sire/compare/2024.3.0...2024.3.1>`__ - December 2024
 --------------------------------------------------------------------------------------------
 

--- a/wrapper/Move/OpenMMFrEnergyDT.pypp.cpp
+++ b/wrapper/Move/OpenMMFrEnergyDT.pypp.cpp
@@ -309,6 +309,16 @@ void register_OpenMMFrEnergyDT_class(){
                 , "" );
         
         }
+        { //::SireMove::OpenMMFrEnergyDT::getMCBarostat_membrane
+
+            typedef bool ( ::SireMove::OpenMMFrEnergyDT::*getMCBarostat_membrane_function_type)(  ) ;
+            getMCBarostat_membrane_function_type getMCBarostat_membrane_function_value( &::SireMove::OpenMMFrEnergyDT::getMCBarostat_membrane );
+
+            OpenMMFrEnergyDT_exposer.def(
+                "getMCBarostat_membrane"
+                , getMCBarostat_membrane_function_value
+                , "" );
+        }
         { //::SireMove::OpenMMFrEnergyDT::getMCBarostat_frequency
         
             typedef int ( ::SireMove::OpenMMFrEnergyDT::*getMCBarostat_frequency_function_type)(  ) ;
@@ -614,6 +624,18 @@ void register_OpenMMFrEnergyDT_class(){
                 , bp::release_gil_policy()
                 , "Set Monte Carlo Barostat onoff" );
         
+        }
+        { //::SireMove::OpenMMFrEnergyDT::setMCBarostat_membrane
+
+            typedef void ( ::SireMove::OpenMMFrEnergyDT::*setMCBarostat_membrane_function_type)( bool ) ;
+            setMCBarostat_membrane_function_type setMCBarostat_membrane_function_value( &::SireMove::OpenMMFrEnergyDT::setMCBarostat_membrane );
+
+            OpenMMFrEnergyDT_exposer.def(
+                "setMCBarostat_membrane"
+                , setMCBarostat_membrane_function_value
+                , ( bp::arg("arg0") )
+                , "Set Monte Carlo Membrane Barostat onoff (only has an effect if Monte Carlo Barostat is on)" );
+
         }
         { //::SireMove::OpenMMFrEnergyDT::setMCBarostat_frequency
         

--- a/wrapper/Move/OpenMMFrEnergyST.pypp.cpp
+++ b/wrapper/Move/OpenMMFrEnergyST.pypp.cpp
@@ -412,6 +412,17 @@ void register_OpenMMFrEnergyST_class(){
                 , "" );
         
         }
+        { //::SireMove::OpenMMFrEnergyST::getMCBarostatMembrane
+
+            typedef bool ( ::SireMove::OpenMMFrEnergyST::*getMCBarostatMembrane_function_type)(  ) ;
+            getMCBarostatMembrane_function_type getMCBarostatMembrane_function_value( &::SireMove::OpenMMFrEnergyST::getMCBarostatMembrane );
+
+            OpenMMFrEnergyST_exposer.def(
+                "getMCBarostatMembrane"
+                , getMCBarostatMembrane_function_value
+                , "" );
+
+        }
         { //::SireMove::OpenMMFrEnergyST::getMCBarostatFrequency
         
             typedef int ( ::SireMove::OpenMMFrEnergyST::*getMCBarostatFrequency_function_type)(  ) ;
@@ -870,6 +881,18 @@ void register_OpenMMFrEnergyST_class(){
                 , "Set Monte Carlo Barostat onoff" );
         
         }
+        { //::SireMove::OpenMMFrEnergyST::setMCBarostatMembrane
+
+            typedef void ( ::SireMove::OpenMMFrEnergyST::*setMCBarostatMembrane_function_type)( bool ) ;
+            setMCBarostatMembrane_function_type setMCBarostatMembrane_function_value( &::SireMove::OpenMMFrEnergyST::setMCBarostatMembrane );
+
+            OpenMMFrEnergyST_exposer.def(
+                "setMCBarostatMembrane"
+                , setMCBarostatMembrane_function_value
+                , ( bp::arg("arg0") )
+                , "Set Monte Carlo Membrane Barostat onoff (only has an effect if Monte Carlo Barostat is on)" );
+
+        }
         { //::SireMove::OpenMMFrEnergyST::setMCBarostatFrequency
         
             typedef void ( ::SireMove::OpenMMFrEnergyST::*setMCBarostatFrequency_function_type)( int ) ;
@@ -880,7 +903,7 @@ void register_OpenMMFrEnergyST_class(){
                 , setMCBarostatFrequency_function_value
                 , ( bp::arg("arg0") )
                 , bp::release_gil_policy()
-                , "Set the Monte Carlo Barostat frequency in time speps" );
+                , "Set the Monte Carlo Barostat frequency in time steps" );
         
         }
         { //::SireMove::OpenMMFrEnergyST::setPlatform

--- a/wrapper/Move/OpenMMMDIntegrator.pypp.cpp
+++ b/wrapper/Move/OpenMMMDIntegrator.pypp.cpp
@@ -322,6 +322,17 @@ void register_OpenMMMDIntegrator_class(){
                 , "" );
         
         }
+        { //::SireMove::OpenMMMDIntegrator::getMCBarostatMembrane
+
+            typedef bool ( ::SireMove::OpenMMMDIntegrator::*getMCBarostatMembrane_function_type)(  ) ;
+            getMCBarostatMembrane_function_type getMCBarostatMembrane_function_value( &::SireMove::OpenMMMDIntegrator::getMCBarostatMembrane );
+
+            OpenMMMDIntegrator_exposer.def(
+                "getMCBarostatMembrane"
+                , getMCBarostatMembrane_function_value
+                , "" );
+        }
+
         { //::SireMove::OpenMMMDIntegrator::getMCBarostatFrequency
         
             typedef int ( ::SireMove::OpenMMMDIntegrator::*getMCBarostatFrequency_function_type)(  ) ;
@@ -677,6 +688,18 @@ void register_OpenMMMDIntegrator_class(){
                 , bp::release_gil_policy()
                 , "Set Monte Carlo Barostat onoff" );
         
+        }
+        { //::SireMove::OpenMMMDIntegrator::setMCBarostatMembrane
+
+            typedef void ( ::SireMove::OpenMMMDIntegrator::*setMCBarostatMembrane_function_type)( bool ) ;
+            setMCBarostatMembrane_function_type setMCBarostatMembrane_function_value( &::SireMove::OpenMMMDIntegrator::setMCBarostatMembrane );
+
+            OpenMMMDIntegrator_exposer.def(
+                "setMCBarostatMembrane"
+                , setMCBarostatMembrane_function_value
+                , ( bp::arg("arg0") )
+                , "Set Monte Carlo Membrane Barostat onoff (only has an effect if Monte Carlo Barostat is on)" );
+
         }
         { //::SireMove::OpenMMMDIntegrator::setMCBarostatFrequency
         

--- a/wrapper/Move/OpenMMPMEFEP.pypp.cpp
+++ b/wrapper/Move/OpenMMPMEFEP.pypp.cpp
@@ -414,6 +414,17 @@ void register_OpenMMPMEFEP_class(){
                 , "" );
         
         }
+        { //::SireMove::OpenMMPMEFEP::getMCBarostatMembrane
+
+            typedef bool ( ::SireMove::OpenMMPMEFEP::*getMCBarostatMembrane_function_type)(  ) ;
+            getMCBarostatMembrane_function_type getMCBarostatMembrane_function_value( &::SireMove::OpenMMPMEFEP::getMCBarostatMembrane );
+
+            OpenMMPMEFEP_exposer.def(
+                "getMCBarostatMembrane"
+                , getMCBarostatMembrane_function_value
+                , bp::release_gil_policy()
+                , "" );
+        }
         { //::SireMove::OpenMMPMEFEP::getMCBarostatFrequency
         
             typedef int ( ::SireMove::OpenMMPMEFEP::*getMCBarostatFrequency_function_type)(  ) ;
@@ -858,6 +869,19 @@ void register_OpenMMPMEFEP_class(){
                 , bp::release_gil_policy()
                 , "Set Monte Carlo Barostat onoff" );
         
+        }
+        { //::SireMove::OpenMMPMEFEP::setMCBarostatMembrane
+
+            typedef void ( ::SireMove::OpenMMPMEFEP::*setMCBarostatMembrane_function_type)( bool ) ;
+            setMCBarostatMembrane_function_type setMCBarostatMembrane_function_value( &::SireMove::OpenMMPMEFEP::setMCBarostatMembrane );
+
+            OpenMMPMEFEP_exposer.def(
+                "setMCBarostatMembrane"
+                , setMCBarostatMembrane_function_value
+                , ( bp::arg("arg0") )
+                , bp::release_gil_policy()
+                , "Set Monte Carlo Membrane Barostat onoff (only has an effect if Monte Carlo Barostat is on)" );
+
         }
         { //::SireMove::OpenMMPMEFEP::setMCBarostatFrequency
         

--- a/wrapper/Tools/OpenMMMD.py
+++ b/wrapper/Tools/OpenMMMD.py
@@ -268,6 +268,12 @@ barostat = Parameter(
     """Whether or not to use a barostat (needed for NPT simulation).""",
 )
 
+barostat_membrane = Parameter(
+    "membrane barostat",
+    False,
+    """Whether the barostat is a membrane barostat (needed for membrane simulation).""",
+)
+
 andersen_frequency = Parameter(
     "andersen frequency", 10.0, """Collision frequency in units of (1/ps)"""
 )
@@ -824,6 +830,8 @@ def setupMoves(system, debug_seed, GPUS):
     if barostat.val:
         Integrator_OpenMM.setPressure(pressure.val)
         Integrator_OpenMM.setMCBarostat(barostat.val)
+        if barostat_membrane.val:
+            Integrator_OpenMM.setMCBarostatMembrane(barostat_membrane.val)
         Integrator_OpenMM.setMCBarostatFrequency(barostat_frequency.val)
 
     # print Integrator_OpenMM.getDeviceIndex()
@@ -2145,6 +2153,8 @@ def setupMovesFreeEnergy(system, debug_seed, gpu_idx, lam_val):
     if barostat.val:
         Integrator_OpenMM.setPressure(pressure.val)
         Integrator_OpenMM.setMCBarostat(barostat.val)
+        if barostat_membrane.val:
+            Integrator_OpenMM.setMCBarostatMembrane(barostat_membrane.val)
         Integrator_OpenMM.setMCBarostatFrequency(barostat_frequency.val)
 
     # Choose a random seed for Sire if a debugging seed hasn't been set.


### PR DESCRIPTION
This PR adds support for the OpenMM [MonteCarloMembraneBarostat](http://docs.openmm.org/7.0.0/api-c++/generated/OpenMM.MonteCarloMembraneBarostat.html), which closes #276. The functionality was patched in using the relevant commits from the PR to add the same functionality on the Cresset fork found [here](https://github.com/cresset-group/sire/pull/1). (Note that their PR specifically mentions PME, but it works for non-PME too.)

Note that there are _no_ tests for this new functionality and it is taken with the caveats mentioned by Cresset, i.e. zero surface tension, XY isotropic, and Z free. I have confirmed that all BioSimSpace tests still pass.

Other than any last minute bugfixes, this will be the last PR before the 2024.4.0 release.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [n]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]