### PR TITLE
Fix issue #287

### DIFF
--- a/corelib/src/libs/SireIO/sdf.cpp
+++ b/corelib/src/libs/SireIO/sdf.cpp
@@ -235,11 +235,11 @@ namespace SireIO
                 case 0:
                     return 0;
                 case 1:
-                    return 1;
+                    return 3;
                 case 2:
                     return 2;
                 case 3:
-                    return 3;
+                    return 1;
                 case 4:
                     return 0;
                 case 5:

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -17,6 +17,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 ------------------------------------------------------------------------------------------
 
 * Please add an item to this CHANGELOG for any new features or bug fixes when creating a PR.
+* Allow user to force fresh inference of stereochemistry when converting to RDKit format.
+* Fix setting of positive formal charge when reading SDF files.
 
 `2024.4.0 <https://github.com/openbiosim/sire/compare/2024.3.1...2024.4.0>`__ - Feb 2025
 ----------------------------------------------------------------------------------------

--- a/tests/convert/test_rdkit.py
+++ b/tests/convert/test_rdkit.py
@@ -118,7 +118,6 @@ def test_rdkit_returns_null():
     "rdkit" not in sr.convert.supported_formats(),
     reason="rdkit support is not available",
 )
-@pytest.mark.xfail(reason="SMILES now mismatches since SDF stereochemistry is preserved")
 def test_rdkit_infer_bonds(ejm55_sdf, ejm55_gro):
     sdf = ejm55_sdf[0].molecule()
     gro = ejm55_gro["not (protein or water)"].molecule()

--- a/tests/io/test_sdf.py
+++ b/tests/io/test_sdf.py
@@ -8,25 +8,36 @@ def test_cis_or_trans():
     mols = sr.load_test_files("cis_trans_double_bond.sdf")
 
 
-def test_positive_charge():
+def test_charge():
     """
-    Make sure that we correctly set postive atomic formal charges on
-    read, then re-convert to the correct SDF format on write.
+    Make sure that the SDF formal charge field is parsed correctly.
     """
-    mol = sr.load_test_files("positive_charge.sdf")[0]
+    mol = sr.load_test_files("charge.sdf")[0]
 
     from math import isclose
 
     import tempfile
 
-    # Make sure that the charge is set correctly.
-    # A value of 3 in the file should be converted to a charge of 1.
-    assert isclose(mol.charge().value(), 1.0)
+    # SDF format has a weird mapping for formal charge. Here the keys are
+    # the SDF value, and the values are the formal charge.
+    mapping = {
+        7: -3,
+        6: -2,
+        5: -1,
+        0: 0,
+        3: 1,
+        2: 2,
+        1: 3,
+    }
+
+    # Make sure the charges are parsed correctly.
+    for c0, c1 in zip(mol.property("formal_charge").to_list(), mapping.values()):
+        assert isclose(c0.value(), c1)
 
     # Write back to file.
     with tempfile.NamedTemporaryFile(suffix=".sdf") as f:
         sr.save(mol, f.name)
 
-        # Read back in and check that the charge is still 1.
-        mol = sr.load(f.name)[0]
-        assert isclose(mol.charge().value(), 1.0)
+        # Read back in and check that the charges are still correct.
+        for c0, c1 in zip(mol.property("formal_charge").to_list(), mapping.values()):
+            assert isclose(c0.value(), c1)

--- a/tests/io/test_sdf.py
+++ b/tests/io/test_sdf.py
@@ -6,3 +6,27 @@ def test_cis_or_trans():
     Make sure that we can read an SDF file containing a cis or trans double bond.
     """
     mols = sr.load_test_files("cis_trans_double_bond.sdf")
+
+
+def test_positive_charge():
+    """
+    Make sure that we correctly set postive atomic formal charges on
+    read, then re-convert to the correct SDF format on write.
+    """
+    mol = sr.load_test_files("positive_charge.sdf")[0]
+
+    from math import isclose
+
+    import tempfile
+
+    # Make sure that the charge is set correctly.
+    # A value of 3 in the file should be converted to a charge of 1.
+    assert isclose(mol.charge().value(), 1.0)
+
+    # Write back to file.
+    with tempfile.NamedTemporaryFile(suffix=".sdf") as f:
+        sr.save(mol, f.name)
+
+        # Read back in and check that the charge is still 1.
+        mol = sr.load(f.name)[0]
+        assert isclose(mol.charge().value(), 1.0)

--- a/wrapper/Convert/SireRDKit/sire_rdkit.cpp
+++ b/wrapper/Convert/SireRDKit/sire_rdkit.cpp
@@ -646,11 +646,8 @@ namespace SireRDKit
 
             a->setAtomicNum(element.nProtons());
 
-            if (force_stereo_inference)
-            {
-                // don't automatically add hydrogens
-                a->setNoImplicit(true);
-            }
+            // don't automatically add hydrogens
+            a->setNoImplicit(true);
 
             elements.append(element);
 
@@ -789,8 +786,10 @@ namespace SireRDKit
         molecule.updatePropertyCache(false);
 
         if (atoms.count() > 1 and (not has_bond_info or force_stereo_inference))
+        {
             // we need to infer the bond information
             infer_bond_info(molecule);
+        }
 
         // try each sanitisation step in turn, skipping failed
         try

--- a/wrapper/Convert/SireRDKit/sire_rdkit.cpp
+++ b/wrapper/Convert/SireRDKit/sire_rdkit.cpp
@@ -715,18 +715,15 @@ namespace SireRDKit
             RDKit::Bond::BondType bondtype = RDKit::Bond::SINGLE;
             RDKit::Bond::BondStereo stereo = RDKit::Bond::STEREONONE;
 
-            if (not force_stereo_inference)
+            try
             {
-                try
-                {
-                    bondtype = string_to_bondtype(bond.property(map["order"]).asA<SireMol::BondOrder>().toRDKit());
+                bondtype = string_to_bondtype(bond.property(map["order"]).asA<SireMol::BondOrder>().toRDKit());
 
-                    // one bond has bond info, so assume that all do
-                    has_bond_info = true;
-                }
-                catch (...)
-                {
-                }
+                // one bond has bond info, so assume that all do
+                has_bond_info = true;
+            }
+            catch (...)
+            {
             }
 
             try
@@ -791,7 +788,7 @@ namespace SireRDKit
         molecule.commitBatchEdit();
         molecule.updatePropertyCache(false);
 
-        if (atoms.count() > 1 and (not has_bond_info))
+        if (atoms.count() > 1 and (not has_bond_info or force_stereo_inference))
             // we need to infer the bond information
             infer_bond_info(molecule);
 


### PR DESCRIPTION
This PR closes #287 by adding a map option to force the fresh inference of stereochemistry when converting to RDKit format. Previously there was a bug which meant that the code _always_ took this pathway, meaning that it didn't always preserve what was in the original SDF file. This new approach allows the user to take _both_ approaches, then compare the result in RDKit, i.e. they can see if the information in the file agrees with what the inference suggests.

The PR also closes #289 where the `formal_charge` property of an atom was set incorrectly for certain positive charges. This is because the value in the SDF file isn't the actual charge, e.g:

| Formal charge | SDF value |
|--------------------|------------------|
| -3 |  7 |
| -2 | 6 |
| -1 | 5 |
| 0 | 0 |
| 1 | 3 |
| 2 | 2 |
| 3 | 1 |

For example, a value of 3 in the file meant that an atom had +3 charge, not +1. This was ultimately the source of several BioSimSpace parameterisation issues, e.g. like the one posted [here](https://github.com/OpenBioSim/biosimspace/issues/370). While I had correctly fixed the conversion of the formal charge property _back_ to the SDF field, I hadn't noticed the same bug was present when setting the property in the first place. This means that all parameterisation starting from SDF since BioSimSpace 2024.3.0 will have been incorrect if there was an atom with +1 charge (SDF value 3). As such, it might be worth testing some know systems to see if anything has changed.

The fix to the formal charge has meant that we can re-enable an XFAILED RDKIt SMARTS inference test that was disabled following the previous edits. Those meant that it no longer passed, but the formal charge was the underlying culprit.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]