### PR TITLE
Fix issue #292

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -19,6 +19,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Please add an item to this CHANGELOG for any new features or bug fixes when creating a PR.
 * Allow user to force fresh inference of stereochemistry when converting to RDKit format.
 * Fix setting of positive formal charge when reading SDF files.
+* Only use ``atom->setNoImplicit(True)`` inside custom RDKit sterochemistry inference function.
 
 `2024.4.0 <https://github.com/openbiosim/sire/compare/2024.3.1...2024.4.0>`__ - Feb 2025
 ----------------------------------------------------------------------------------------

--- a/tests/convert/test_rdkit.py
+++ b/tests/convert/test_rdkit.py
@@ -118,7 +118,9 @@ def test_rdkit_returns_null():
     "rdkit" not in sr.convert.supported_formats(),
     reason="rdkit support is not available",
 )
-@pytest.mark.xfail(reason="SMILES now mismatches since SDF stereochemistry is preserved")
+@pytest.mark.xfail(
+    reason="SMILES now mismatches since SDF stereochemistry is preserved"
+)
 def test_rdkit_infer_bonds(ejm55_sdf, ejm55_gro):
     sdf = ejm55_sdf[0].molecule()
     gro = ejm55_gro["not (protein or water)"].molecule()
@@ -163,3 +165,20 @@ def test_rdkit_preserve_info(ala_mols, ejm55_gro):
 
             assert res0.name() == res1.name()
             assert res0.number() == res1.number()
+
+
+@pytest.mark.skipif(
+    "rdkit" not in sr.convert.supported_formats(),
+    reason="rdkit support is not available",
+)
+def test_rdkit_force_infer():
+    mol = sr.load_test_files("missing_cyanide_bond.sdf")[0]
+
+    rdmol = sr.convert.to(mol, "rdkit", map={"force_stereo_inference": False})
+    rdmol_infer = sr.convert.to(mol, "rdkit", map={"force_stereo_inference": True})
+
+    bond = rdmol.GetBonds()[0].GetBondType().name
+    bond_infer = rdmol_infer.GetBonds()[0].GetBondType().name
+
+    assert bond == "SINGLE"
+    assert bond_infer == "TRIPLE"

--- a/tests/convert/test_rdkit.py
+++ b/tests/convert/test_rdkit.py
@@ -118,9 +118,6 @@ def test_rdkit_returns_null():
     "rdkit" not in sr.convert.supported_formats(),
     reason="rdkit support is not available",
 )
-@pytest.mark.xfail(
-    reason="SMILES now mismatches since SDF stereochemistry is preserved"
-)
 def test_rdkit_infer_bonds(ejm55_sdf, ejm55_gro):
     sdf = ejm55_sdf[0].molecule()
     gro = ejm55_gro["not (protein or water)"].molecule()

--- a/tests/convert/test_rdkit.py
+++ b/tests/convert/test_rdkit.py
@@ -118,19 +118,15 @@ def test_rdkit_returns_null():
     "rdkit" not in sr.convert.supported_formats(),
     reason="rdkit support is not available",
 )
+@pytest.mark.xfail(reason="SMILES now mismatches since SDF stereochemistry is preserved")
 def test_rdkit_infer_bonds(ejm55_sdf, ejm55_gro):
     sdf = ejm55_sdf[0].molecule()
     gro = ejm55_gro["not (protein or water)"].molecule()
-
-    from rdkit import Chem
 
     assert sdf.smiles() == gro.smiles()
 
     match_sdf = sdf["smarts [NX3][CX3](=[OX1])[#6]"]
     match_gro = gro["smarts [NX3][CX3](=[OX1])[#6]"]
-
-    print(match_sdf)
-    print(match_gro)
 
     assert len(match_sdf) == 1
     assert len(match_gro) == 1

--- a/wrapper/Convert/SireRDKit/sire_rdkit.cpp
+++ b/wrapper/Convert/SireRDKit/sire_rdkit.cpp
@@ -792,74 +792,11 @@ namespace SireRDKit
             infer_bond_info(molecule);
         }
 
-        // try each sanitisation step in turn, skipping failed
+        // sanitze the molecule.
         try
         {
-            RDKit::MolOps::cleanUp(molecule);
-        }
-        catch (...)
-        {
-        }
+            RDKit::MolOps::sanitizeMol(molecule);
 
-        try
-        {
-            molecule.updatePropertyCache();
-        }
-        catch (...)
-        {
-        }
-
-        try
-        {
-            RDKit::MolOps::symmetrizeSSSR(molecule);
-        }
-        catch (...)
-        {
-        }
-
-        try
-        {
-            RDKit::MolOps::Kekulize(molecule);
-        }
-        catch (...)
-        {
-        }
-
-        try
-        {
-            RDKit::MolOps::assignRadicals(molecule);
-        }
-        catch (...)
-        {
-        }
-
-        try
-        {
-            RDKit::MolOps::setAromaticity(molecule);
-        }
-        catch (...)
-        {
-        }
-
-        try
-        {
-            RDKit::MolOps::setConjugation(molecule);
-        }
-        catch (...)
-        {
-        }
-
-        try
-        {
-            RDKit::MolOps::setHybridization(molecule);
-        }
-        catch (...)
-        {
-        }
-
-        try
-        {
-            RDKit::MolOps::cleanupChirality(molecule);
         }
         catch (...)
         {

--- a/wrapper/Convert/SireRDKit/sire_rdkit.cpp
+++ b/wrapper/Convert/SireRDKit/sire_rdkit.cpp
@@ -411,6 +411,7 @@ namespace SireRDKit
         {
             if (atom->getAtomicNum() > 1)
             {
+                atom->setNoImplicit(true);
                 atoms.append(std::make_pair(get_nb_unpaired_electrons(*atom),
                                             atom));
             }
@@ -645,10 +646,6 @@ namespace SireRDKit
             const auto element = atom.property<SireMol::Element>(map["element"]);
 
             a->setAtomicNum(element.nProtons());
-
-            // don't automatically add hydrogens
-            if (force_stereo_inference)
-                a->setNoImplicit(true);
 
             elements.append(element);
 

--- a/wrapper/Convert/SireRDKit/sire_rdkit.cpp
+++ b/wrapper/Convert/SireRDKit/sire_rdkit.cpp
@@ -647,7 +647,8 @@ namespace SireRDKit
             a->setAtomicNum(element.nProtons());
 
             // don't automatically add hydrogens
-            a->setNoImplicit(true);
+            if (force_stereo_inference)
+                a->setNoImplicit(true);
 
             elements.append(element);
 


### PR DESCRIPTION
This PR closes #292, i.e. fixes the issues caused by the previous RDKIt "fix". The issue here is that we must only disable implicit hydrogens when using the customised MDAnalysis inference routine. If used for a general conversion, the use of this option is inconsistent with what RDKit does, e.g. on SDF read, which leads to incorrect stereochemistry when applying the standard sanitization routines. 

Additionally, I've switched to just calling the standard RDKit sanitization function since we were missing a few steps. Given all the issues, I want to be as self-consistent as possible. We can separate the stages in future if we find further problems, or provide options to use a sub-set of the routines if needed.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]