### PR TITLE
Fix issues #296, #297, and #298

### DIFF
--- a/corelib/src/libs/SireIO/amberrst7.cpp
+++ b/corelib/src/libs/SireIO/amberrst7.cpp
@@ -357,6 +357,15 @@ void AmberRst7::parse(const PropertyMap &map)
         // we have already validated that there are enough lines
         const QString &line = l[linenum];
 
+        if (natoms <= 2 and line.trimmed().isEmpty())
+        {
+            // if there are only two atoms, then the final line might not be reserved
+            // for velocities
+            vels.clear();
+
+            return;
+        }
+
         if (line.length() < column + 36)
         {
             errors.append(QObject::tr("Cannot read the velocities for the atom at index %1 as "

--- a/corelib/src/libs/SireIO/sdf.cpp
+++ b/corelib/src/libs/SireIO/sdf.cpp
@@ -1898,6 +1898,9 @@ MolEditor SDF::getMolecule(int imol, const PropertyMap &map) const
         mol.setProperty(map["sdf_counts"], SireBase::wrap(sdf_counts));
     }
 
+    // set the name of the molecule
+    mol.rename(MolName(sdfmol.name));
+
     return mol.setProperty(map["coordinates"], coords)
         .setProperty(map["formal_charge"], charges)
         .setProperty(map["element"], elements)

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -21,6 +21,9 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Fix setting of positive formal charge when reading SDF files.
 * Only use ``atom->setNoImplicit(True)`` inside custom RDKit sterochemistry inference function.
 * Fix redistribution of excess QM charge and make it the default behaviour.
+* Preserve molecule name when reading from SDF format and on conversion to RDKit.
+* Handle missing velocity data for ``AMBER`` RST7 files with only a few atoms.
+* Preserve SDF metadata when converting to ``RDKIt`` format.
 
 `2024.4.0 <https://github.com/openbiosim/sire/compare/2024.3.1...2024.4.0>`__ - Feb 2025
 ----------------------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -243,3 +243,8 @@ def openmm_platform():
 @pytest.fixture(scope="session")
 def thrombin_complex():
     return sr.load_test_files("thrombin.top", "thrombin.rst7")
+
+
+@pytest.fixture(scope="session")
+def tagged_sdf():
+    return sr.load_test_files("sdf_tags.sdf")[0]

--- a/tests/convert/test_rdkit.py
+++ b/tests/convert/test_rdkit.py
@@ -179,3 +179,34 @@ def test_rdkit_force_infer():
 
     assert bond == "SINGLE"
     assert bond_infer == "TRIPLE"
+
+
+@pytest.mark.skipif(
+    "rdkit" not in sr.convert.supported_formats(),
+    reason="rdkit support is not available",
+)
+def test_rdkit_sdf_tags(tagged_sdf):
+
+    # store the sdf data property
+    sdf_data = tagged_sdf.property("sdf_data")
+
+    # convert to rdkit
+    rdmol = sr.convert.to_rdkit(tagged_sdf)
+
+    # convert back to sire
+    mol = sr.convert.to_sire(rdmol)
+
+    # get the rdf data property
+    rdkit_data = mol.property("rdkit_data")
+
+    # check that the data is the same
+    for prop in sdf_data.keys():
+        assert prop in rdkit_data.keys()
+        assert sdf_data[prop] == rdkit_data[prop]
+
+    # convert back to rdkit
+    rdmol2 = sr.convert.to_rdkit(mol)
+
+    # check that the data is the same on the rdkit molecule
+    for prop in rdmol.GetPropNames():
+        assert rdmol.GetProp(prop) == rdmol2.GetProp(prop)

--- a/tests/io/test_sdf.py
+++ b/tests/io/test_sdf.py
@@ -41,3 +41,10 @@ def test_charge():
         # Read back in and check that the charges are still correct.
         for c0, c1 in zip(mol.property("formal_charge").to_list(), mapping.values()):
             assert isclose(c0.value(), c1)
+
+
+def test_name(tagged_sdf):
+    """
+    Make sure that the molecule takes its name from the SDF title field.
+    """
+    assert tagged_sdf.name().value() == tagged_sdf.property("name").value()

--- a/wrapper/Convert/SireRDKit/sire_rdkit.cpp
+++ b/wrapper/Convert/SireRDKit/sire_rdkit.cpp
@@ -628,7 +628,11 @@ namespace SireRDKit
                     QString string;
                     for (int i=0; i<string_array.size(); i++)
                     {
-                        string.append(string_array[i] + "\n");
+                        string.append(string_array[i]);
+                        if (i < string_array.size() - 1)
+                        {
+                            string.append("\n");
+                        }
                     }
 
                     molecule.setProp<std::string>(tag.toStdString(), string.toStdString());
@@ -1065,10 +1069,12 @@ namespace SireRDKit
 
         for (const auto &prop : mol->getPropList())
         {
-            if (prop == "_Name")
+            const auto sire_prop = QString::fromStdString(prop);
+
+            // skip internal properties
+            if (sire_prop.startsWith("_"))
                 continue;
 
-            const auto sire_prop = QString::fromStdString(prop);
             const auto value = QString::fromStdString(mol->getProp<std::string>(prop));
             const auto list = value.split("\n");
 

--- a/wrapper/Convert/SireRDKit/sire_rdkit.cpp
+++ b/wrapper/Convert/SireRDKit/sire_rdkit.cpp
@@ -659,7 +659,11 @@ namespace SireRDKit
                     QString string;
                     for (int i=0; i<string_array.size(); i++)
                     {
-                        string.append(string_array[i] + "\n");
+                        string.append(string_array[i]);
+                        if (i < string_array.size() - 1)
+                        {
+                            string.append("\n");
+                        }
                     }
 
                     molecule.setProp<std::string>(tag.toStdString(), string.toStdString());

--- a/wrapper/Convert/SireRDKit/sire_rdkit.cpp
+++ b/wrapper/Convert/SireRDKit/sire_rdkit.cpp
@@ -598,16 +598,7 @@ namespace SireRDKit
         molecule.beginBatchEdit();
 
         // set the name of the molecule
-        std::string name;
-        if (mol.hasProperty("name"))
-        {
-            name = mol.property("name").asAString().toStdString();
-        }
-        else
-        {
-            name = mol.name().value().toStdString();
-        }
-        molecule.setProp<std::string>("_Name", name);
+        molecule.setProp<std::string>("_Name", mol.name().value().toStdString());
 
         // set any SDF tags as properties
         std::string sdf_tag;

--- a/wrapper/Convert/SireRDKit/sire_rdkit.cpp
+++ b/wrapper/Convert/SireRDKit/sire_rdkit.cpp
@@ -597,7 +597,16 @@ namespace SireRDKit
         RDKit::RWMol molecule;
         molecule.beginBatchEdit();
 
-        molecule.setProp<std::string>("_Name", mol.name().value().toStdString());
+        std::string name;
+        if (mol.hasProperty("name"))
+        {
+            name = mol.property("name").asAString().toStdString();
+        }
+        else
+        {
+            name = mol.name().value().toStdString();
+        }
+        molecule.setProp<std::string>("_Name", name);
 
         const auto atoms = mol.atoms();
 
@@ -793,7 +802,6 @@ namespace SireRDKit
         try
         {
             RDKit::MolOps::sanitizeMol(molecule);
-
         }
         catch (...)
         {

--- a/wrapper/Convert/SireRDKit/sire_rdkit.cpp
+++ b/wrapper/Convert/SireRDKit/sire_rdkit.cpp
@@ -597,6 +597,7 @@ namespace SireRDKit
         RDKit::RWMol molecule;
         molecule.beginBatchEdit();
 
+        // set the name of the molecule
         std::string name;
         if (mol.hasProperty("name"))
         {
@@ -607,6 +608,33 @@ namespace SireRDKit
             name = mol.name().value().toStdString();
         }
         molecule.setProp<std::string>("_Name", name);
+
+        // set any SDF tags as properties
+        std::string sdf_tag;
+        if (mol.hasProperty("sdf_data"))
+        {
+            const auto sdf_data = mol.property("sdf_data").asA<SireBase::Properties>();
+
+            for (const auto &tag : sdf_data.propertyKeys())
+            {
+                try
+                {
+                    molecule.setProp<std::string>(tag.toStdString(), sdf_data.property(tag).asAString().toStdString());
+                }
+                catch (...)
+                {
+                    const auto string_array = sdf_data.property(tag).asA<SireBase::StringArrayProperty>();
+
+                    QString string;
+                    for (int i=0; i<string_array.size(); i++)
+                    {
+                        string.append(string_array[i] + "\n");
+                    }
+
+                    molecule.setProp<std::string>(tag.toStdString(), string.toStdString());
+                }
+            }
+        }
 
         const auto atoms = mol.atoms();
 


### PR DESCRIPTION
This PR closes #296 by setting and SDF tags as properties of the RDKit molecule during conversion. (The SDF metada is stored internally in Sire as a `sdf_data` property on molecule.) On conversion back to Sire, all non-internal properties of a RDKit molecule are now stored as an `rdkit_data` property. We can't write back to `sdf_data`, since the RDKit molecule doesn't tag where the properties come from, e.g. were they set when loading from SDF, or otherwise, so there is no clean separation of what data came from where. A user _could_ allow these tags to be used when writing to SDF by using the property map, e.g. by remapping `sdf_data` to `rdkit_data`. In any case, the main use case here is the ability to convert an SDF molecule to RDKit, then later write to SDF using RDKit and retain all of the tags in the original file, which this does.

The PR also closes #297 by setting the `MolName` of any molecule loaded from SDF to the name in that file. Currently it takes a default molecule name of `MOL`. There is also a `name` molecular property that is set, but CI failures made me realise that this can also be used for other information, e..g. the `neopentane-methane` merged system appeared to have some kind of atom selection as the `name` property.

```python
In [1]: import sire as sr

In [2]: mols = sr.load_test_files("neo_meth_scratch.bss")


In [3]: mols[0].property("name0")
Out[3]:
SireMol::AtomStringProperty( size=17
0: C1
1: C2
2: C3
3: C4
4: C5
...
12: H13
13: H14
14: H15
15: H16
16: H17
)
```

The PR also closes #298 by adding special handling for velocity records when the number of atoms in an AMBER RST7 file is 2 or less. If so, then the velocity line could be blank if no data is present. (There is a check to see how many lines should be exist if velocities are present, which this passes, but the line contains no data.) I'm not sure what parser is adding a blank line at the end, but it is part of the Exs pipeline.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]