### PR TITLE
Fix issue #301

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -24,6 +24,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Preserve molecule name when reading from SDF format and on conversion to RDKit.
 * Handle missing velocity data for ``AMBER`` RST7 files with only a few atoms.
 * Preserve SDF metadata when converting to ``RDKIt`` format.
+* Fixed unbound local variable when simulation lambda value is not in ``lambda_windows`` array.
 
 `2024.4.0 <https://github.com/openbiosim/sire/compare/2024.3.1...2024.4.0>`__ - Feb 2025
 ----------------------------------------------------------------------------------------

--- a/src/sire/mol/_dynamics.py
+++ b/src/sire/mol/_dynamics.py
@@ -437,15 +437,18 @@ class DynamicsData:
                     # lambda windows list
                     try:
                         lambda_index = lambda_windows.index(sim_lambda_value)
+                        has_lambda_index = True
                     except:
-                        num_energy_neighbours = num_lambda_windows
-                        lambda_index = i
+                        has_lambda_index = False
 
                     for i, (lambda_value, rest2_scale) in enumerate(
                         zip(lambda_windows, rest2_scale_factors)
                     ):
                         if lambda_value != sim_lambda_value:
-                            if abs(lambda_index - i) <= num_energy_neighbours:
+                            if (
+                                not has_lambda_index
+                                or abs(lambda_index - i) <= num_energy_neighbours
+                            ):
                                 self._omm_mols.set_lambda(
                                     lambda_value,
                                     rest2_scale=rest2_scale,


### PR DESCRIPTION
This PR closes issue #301 by fixing the unbound local variable exception. The logic here is meant to handle the case where the simulation lambda value, i.e. the value of the dynamics object, is not in the `lambda_windows` array, which means that you can't use the truncated energy neighbour approach. Previously I was using a loop index that didn't exist, but now use a boolean to check whether the value is present in the array.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

