### PR TITLE
Fix InvalidMatchSpec error when installing packages using setup.py.

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -25,6 +25,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Handle missing velocity data for ``AMBER`` RST7 files with only a few atoms.
 * Preserve SDF metadata when converting to ``RDKIt`` format.
 * Fixed unbound local variable when simulation lambda value is not in ``lambda_windows`` array.
+* Fix InvalidMatchSpec error when installing packages using setup.py.
 
 `2024.4.0 <https://github.com/openbiosim/sire/compare/2024.3.1...2024.4.0>`__ - Feb 2025
 ----------------------------------------------------------------------------------------

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -335,7 +335,7 @@ top of :mod:`sire`, then you should install using;
 
 .. code-block:: bash
 
-   $ python --install-bss-deps install
+   $ python setup.py --install-bss-deps install
 
 This will use ``conda`` to download and install all of
 BioSimSpace's dependencies as well. This ensures that incompatible versions

--- a/setup.py
+++ b/setup.py
@@ -399,7 +399,7 @@ def conda_install(
             continue
 
         # remove duplicates
-        dep = f'"{dependency}"'
+        dep = f'{dependency}'
 
         if dep not in deps:
             deps.append(dep)


### PR DESCRIPTION
No published issue related to this.

In `setup.py`, within the `conda_install` function, `dep = f'"{dependency}"'` leads to an conda error when installing a package with requied version, such as `gemmi>=0.6.4`:  `InvalidMatchSpec: Invalid spec '"gemmi>=0.6.4"': Invalid version '0.6.4"': invalid character(s)`   (*conda version:  25.1.1)
  
To Reproduce: Create a new env and run `python setup.py install_requires`, or simply: `'conda' 'install' '"gemmi>=0.6.4"'` (How setup.py install package).
  
The setup.py print:`Installing packages using: /xxx/bin/conda install "gemmi>=0.6.4"`, but it actually using:`'/xxx/bin/conda' 'install' '"gemmi>=0.6.4"'`

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods, @lohedges

## Any additional context of information?

Also updated the installation command in the documentation.
