### PR TITLE
Fix issue #304 and #305

### DIFF
--- a/corelib/src/libs/SireIO/grotop.cpp
+++ b/corelib/src/libs/SireIO/grotop.cpp
@@ -6444,7 +6444,7 @@ QStringList GroTop::processDirectives(const QMap<int, QString> &taglocs, const Q
                 {
 
                     // could be residue_numberChain_name
-                    const QRegularExpression re("(\\d+)([\\w\\d]*)");
+                    const QRegularExpression re("(\\-?\\d+)([\\w\\d]*)");
 
                     auto m = re.match(words[2]);
 

--- a/corelib/src/libs/SireMol/residentifier.cpp
+++ b/corelib/src/libs/SireMol/residentifier.cpp
@@ -436,7 +436,7 @@ ResNum::ResNum() : SireID::Number(), ResID()
 {
 }
 
-ResNum::ResNum(quint32 num) : SireID::Number(num), ResID()
+ResNum::ResNum(qint32 num) : SireID::Number(num), ResID()
 {
 }
 

--- a/corelib/src/libs/SireMol/resnum.h
+++ b/corelib/src/libs/SireMol/resnum.h
@@ -59,7 +59,7 @@ namespace SireMol
     public:
         ResNum();
 
-        explicit ResNum(quint32 num);
+        explicit ResNum(qint32 num);
 
         ResNum(const ResNum &other);
 

--- a/corelib/src/libs/SireMove/openmmfrenergydt.cpp
+++ b/corelib/src/libs/SireMove/openmmfrenergydt.cpp
@@ -1252,7 +1252,14 @@ void OpenMMFrEnergyDT::integrate(IntegratorWorkspace &workspace, const Symbol &n
         // TriclinicBox.
         else if (ptr_sys.property(space_property).isA<TriclinicBox>())
         {
-            const TriclinicBox &space = ptr_sys.property(space_property).asA<TriclinicBox>();
+            TriclinicBox space = ptr_sys.property(space_property).asA<TriclinicBox>();
+
+            // Make sure the box is in reduced form. This is necessary since SOMD reads
+            // the box vectors from fixed precision AMBER RST7 files. The OpenMM C++ API
+            // checks the that the vectors are reduced to "exact" numerical precision,
+            // which may no longer be the case due to rounding errors from the precision
+            // loss.
+            space.reduce();
 
             // Get the three triclinic box vectors.
             const auto v0 = space.vector0();

--- a/corelib/src/libs/SireMove/openmmfrenergyst.cpp
+++ b/corelib/src/libs/SireMove/openmmfrenergyst.cpp
@@ -3475,7 +3475,14 @@ void OpenMMFrEnergyST::createContext(IntegratorWorkspace &workspace, SireUnits::
         // TriclinicBox.
         else if (ptr_sys.property(space_property).isA<TriclinicBox>())
         {
-            const TriclinicBox &space = ptr_sys.property(space_property).asA<TriclinicBox>();
+            TriclinicBox space = ptr_sys.property(space_property).asA<TriclinicBox>();
+
+            // Make sure the box is in reduced form. This is necessary since SOMD reads
+            // the box vectors from fixed precision AMBER RST7 files. The OpenMM C++ API
+            // checks the that the vectors are reduced to "exact" numerical precision,
+            // which may no longer be the case due to rounding errors from the precision
+            // loss.
+            space.reduce();
 
             // Get the three triclinic box vectors.
             const auto v0 = space.vector0();

--- a/corelib/src/libs/SireMove/openmmmdintegrator.cpp
+++ b/corelib/src/libs/SireMove/openmmmdintegrator.cpp
@@ -1181,7 +1181,14 @@ void OpenMMMDIntegrator::createContext(IntegratorWorkspace &workspace, SireUnits
         // TriclinicBox.
         else if (ptr_sys.property(space_property).isA<TriclinicBox>())
         {
-            const TriclinicBox &space = ptr_sys.property(space_property).asA<TriclinicBox>();
+            TriclinicBox space = ptr_sys.property(space_property).asA<TriclinicBox>();
+
+            // Make sure the box is in reduced form. This is necessary since SOMD reads
+            // the box vectors from fixed precision AMBER RST7 files. The OpenMM C++ API
+            // checks the that the vectors are reduced to "exact" numerical precision,
+            // which may no longer be the case due to rounding errors from the precision
+            // loss.
+            space.reduce();
 
             // Get the three triclinic box vectors.
             const auto v0 = space.vector0();

--- a/corelib/src/libs/SireMove/openmmpmefep.cpp
+++ b/corelib/src/libs/SireMove/openmmpmefep.cpp
@@ -2981,10 +2981,16 @@ void OpenMMPMEFEP::createContext(IntegratorWorkspace &workspace, SireUnits::Dime
     // TriclinicBox
     else if (ptr_sys.property(space_property).isA<TriclinicBox>())
     {
-        const TriclinicBox &space = ptr_sys.property(space_property).asA<TriclinicBox>();
+		TriclinicBox space = ptr_sys.property(space_property).asA<TriclinicBox>();
+
+        // Make sure the box is in reduced form. This is necessary since SOMD reads
+        // the box vectors from fixed precision AMBER RST7 files. The OpenMM C++ API
+        // checks the that the vectors are reduced to "exact" numerical precision,
+        // which may no longer be the case due to rounding errors from the precision
+        // loss.
+        space.reduce();
 
         // Get the three triclinic box vectors.
-        // FIXME: not good practice of using auto here
         const auto v0 = space.vector0();
         const auto v1 = space.vector1();
         const auto v2 = space.vector2();

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -25,6 +25,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Handle missing velocity data for ``AMBER`` RST7 files with only a few atoms.
 * Preserve SDF metadata when converting to ``RDKIt`` format.
 * Fixed unbound local variable when simulation lambda value is not in ``lambda_windows`` array.
+* Allow negative residue numbers.
+* Make sure box vectors are in reduced form before setting via the ``OpenMM`` C++ API.
 
 `2024.4.0 <https://github.com/openbiosim/sire/compare/2024.3.1...2024.4.0>`__ - Feb 2025
 ----------------------------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -383,6 +383,9 @@ def conda_install(
         dependencies_to_skip = []
 
     for dependency in dependencies:
+	# remove any quotes from the dependency
+        dependency = dependency.replace("\"", "")
+
         if dependency == "python" or is_installed(dependency, conda_exe):
             # no need to install again
             continue
@@ -399,10 +402,8 @@ def conda_install(
             continue
 
         # remove duplicates
-        dep = f'"{dependency}"'
-
-        if dep not in deps:
-            deps.append(dep)
+        if dependency not in deps:
+            deps.append(dependency)
 
     dependencies = deps
 
@@ -463,6 +464,23 @@ def install_requires(install_bss_reqs=False, install_emle_reqs=False, yes=True):
         except ImportError as e:
             print("\n\n[ERROR] ** You need to install pip-requirements-parser")
             print("Run `conda install -c conda-forge pip-requirements-parser\n\n")
+            raise e
+
+    try:
+        import pkg_resources
+    except Exception:
+        # this didn't import - we are missing setuptools
+        print("Installing setuptools")
+        conda_install(
+            ["setuptools"],
+            install_bss_reqs,
+            install_emle_reqs=False,
+            yes=yes)
+        try:
+            import pkg_resources
+        except Exception:
+            print("\n\n[ERROR] ** You need to install setuptools")
+            print("Run 'conda install -c conda-forge setuptools\n\n")
             raise e
 
     reqs = parse_requirements("requirements_host.txt")

--- a/wrapper/Mol/ResNum.pypp.cpp
+++ b/wrapper/Mol/ResNum.pypp.cpp
@@ -71,7 +71,7 @@ void register_ResNum_class(){
         typedef bp::class_< SireMol::ResNum, bp::bases< SireMol::ResID, SireID::ID, SireID::Number > > ResNum_exposer_t;
         ResNum_exposer_t ResNum_exposer = ResNum_exposer_t( "ResNum", "This ID number is used to identify a CutGroup by the user-supplied\nnumber\n\nAuthor: Christopher Woods\n", bp::init< >("") );
         bp::scope ResNum_scope( ResNum_exposer );
-        ResNum_exposer.def( bp::init< quint32 >(( bp::arg("num") ), "") );
+        ResNum_exposer.def( bp::init< qint32 >(( bp::arg("num") ), "") );
         ResNum_exposer.def( bp::init< SireMol::ResNum const & >(( bp::arg("other") ), "") );
         { //::SireMol::ResNum::hash
         


### PR DESCRIPTION
This PR closes #304 by adding support for negative residue numbers. The existing tests appear to be unaffected by this change, but we might need to handle parser-specific issues as they arise. While I have added the ability to load and set negative residue numbers for the GroTop parser, I've not done this for any others. It also closes #305 by re-reducing triclinic box vectors prior to setting them via the OpenMM C++ API to avoid rounding issues due to loss of precision when reading from fixed-width format AMBER files. Finally, this closes #306 by using the alternative approach to fix the conda quotes issue from the `feature_cmap` branch.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

