### PR TITLE
Fix issue #319

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -33,6 +33,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Added CMAP support when reading / writing AMBER and GROMACS topology files. The parameters are in the ``cmap`` property.
 * Fixed compile issues for MacOS Sequoia.
 * Upgraded minimum cmake supported version to 3.5.
+* Reset dynamics step counter when a crash occurs so that energies and frames are save with the correct time stamp.
 
 `2024.4.0 <https://github.com/openbiosim/sire/compare/2024.3.1...2024.4.0>`__ - Feb 2025
 ----------------------------------------------------------------------------------------

--- a/src/sire/mol/_dynamics.py
+++ b/src/sire/mol/_dynamics.py
@@ -1396,6 +1396,7 @@ class DynamicsData:
             self._clear_state()
             self._rebuild_and_minimise()
             orig_args["auto_fix_minimise"] = False
+            self._current_step = 0
             self.run(**orig_args)
             return
 


### PR DESCRIPTION
This PR fixes #319 by resetting the internal step counter of the dynamics object when a NaN crash occurs. Previously this was not reset, so that the time stamp for energy and trajectory frames would get out of sync following a crash. This problem is amplified when running repex since OpenMM state is swapped between replicas, meaning the internal clock for a replica could get changed following an exchange.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

Tagging @akalpokas 