### PR TITLE
Fix #319 take 2

### DIFF
--- a/corelib/src/libs/SireMaths/energytrajectory.cpp
+++ b/corelib/src/libs/SireMaths/energytrajectory.cpp
@@ -28,6 +28,8 @@
 
 #include "energytrajectory.h"
 
+#include "SireBase/console.h"
+
 #include "SireUnits/units.h"
 
 #include "SireID/index.h"
@@ -316,6 +318,9 @@ void EnergyTrajectory::set(const GeneralUnit &time,
 
         else if (t == time_values[idx - 1])
         {
+            SireBase::Console::warning(QObject::tr(
+                "EnergyTrajectory::set: time %1 already exists in the trajectory. "
+                "Overwriting existing values.").arg(t.toString()));
             must_create = false;
             idx = idx - 1;
             break;

--- a/corelib/src/libs/SireMaths/energytrajectory.cpp
+++ b/corelib/src/libs/SireMaths/energytrajectory.cpp
@@ -243,6 +243,9 @@ void EnergyTrajectory::set(const GeneralUnit &time,
 
     auto t = Time(time);
 
+    // round the time to 5 decimal places
+    auto t_round = qRound(t.value() * 100000.0) / 100000.0;
+
     for (auto it = energies.constBegin(); it != energies.constEnd(); ++it)
     {
         // make sure all of the values are valid
@@ -313,10 +316,10 @@ void EnergyTrajectory::set(const GeneralUnit &time,
 
     while (idx > 0)
     {
-        if (t > time_values[idx - 1])
+        if (t_round > time_values[idx - 1])
             break;
 
-        else if (t == time_values[idx - 1])
+        else if (t_round == time_values[idx - 1])
         {
             SireBase::Console::warning(QObject::tr(
                 "EnergyTrajectory::set: time %1 already exists in the trajectory. "
@@ -331,7 +334,7 @@ void EnergyTrajectory::set(const GeneralUnit &time,
 
     if (idx >= time_values.count())
     {
-        time_values.append(t.value());
+        time_values.insert(idx, t_round);
 
         for (auto it = this->energy_values.begin();
              it != this->energy_values.end(); ++it)
@@ -347,7 +350,7 @@ void EnergyTrajectory::set(const GeneralUnit &time,
     }
     else if (must_create)
     {
-        time_values.insert(idx, t.value());
+        time_values.insert(idx, t_round);
 
         for (auto it = this->energy_values.begin();
              it != this->energy_values.end(); ++it)

--- a/corelib/src/libs/SireMaths/energytrajectory.cpp
+++ b/corelib/src/libs/SireMaths/energytrajectory.cpp
@@ -243,8 +243,8 @@ void EnergyTrajectory::set(const GeneralUnit &time,
 
     auto t = Time(time);
 
-    // round the time to 4 decimal places
-    auto t_round = qRound(t.value() * 10000.0) / 10000.0;
+    // round the time to 5 decimal places
+    auto t_round = qRound(t.value() * 100000.0) / 100000.0;
 
     for (auto it = energies.constBegin(); it != energies.constEnd(); ++it)
     {

--- a/corelib/src/libs/SireMaths/energytrajectory.cpp
+++ b/corelib/src/libs/SireMaths/energytrajectory.cpp
@@ -243,8 +243,8 @@ void EnergyTrajectory::set(const GeneralUnit &time,
 
     auto t = Time(time);
 
-    // round the time to 5 decimal places
-    auto t_round = qRound(t.value() * 100000.0) / 100000.0;
+    // round the time to 4 decimal places
+    auto t_round = qRound(t.value() * 10000.0) / 10000.0;
 
     for (auto it = energies.constBegin(); it != energies.constEnd(); ++it)
     {

--- a/corelib/src/libs/SireMaths/energytrajectory.cpp
+++ b/corelib/src/libs/SireMaths/energytrajectory.cpp
@@ -243,9 +243,6 @@ void EnergyTrajectory::set(const GeneralUnit &time,
 
     auto t = Time(time);
 
-    // round the time to 5 decimal places
-    auto t_round = qRound(t.value() * 100000.0) / 100000.0;
-
     for (auto it = energies.constBegin(); it != energies.constEnd(); ++it)
     {
         // make sure all of the values are valid
@@ -316,14 +313,15 @@ void EnergyTrajectory::set(const GeneralUnit &time,
 
     while (idx > 0)
     {
-        if (t_round > time_values[idx - 1])
+        if (t > time_values[idx - 1])
             break;
 
-        else if (t_round == time_values[idx - 1])
+        else if (t == time_values[idx - 1])
         {
             SireBase::Console::warning(QObject::tr(
                 "EnergyTrajectory::set: time %1 already exists in the trajectory. "
                 "Overwriting existing values.").arg(t.toString()));
+
             must_create = false;
             idx = idx - 1;
             break;
@@ -334,7 +332,7 @@ void EnergyTrajectory::set(const GeneralUnit &time,
 
     if (idx >= time_values.count())
     {
-        time_values.insert(idx, t_round);
+        time_values.append(t.value());
 
         for (auto it = this->energy_values.begin();
              it != this->energy_values.end(); ++it)
@@ -350,7 +348,7 @@ void EnergyTrajectory::set(const GeneralUnit &time,
     }
     else if (must_create)
     {
-        time_values.insert(idx, t_round);
+        time_values.insert(idx, t.value());
 
         for (auto it = this->energy_values.begin();
              it != this->energy_values.end(); ++it)

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -30,10 +30,12 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Make sure box vectors are in reduced form before setting via the ``OpenMM`` C++ API.
 * Add isobaric and grand canonical terms to reduced potential.
 * Keep kappa term fixed during decoupling schedules.
-* Added CMAP support when reading / writing AMBER and GROMACS topology files. The parameters are in the ``cmap`` property.
+* Added CMAP support when reading / writing AMBER and GROMACS topology files. The parameters
+  are in the ``cmap`` property.
 * Fixed compile issues for MacOS Sequoia.
 * Upgraded minimum cmake supported version to 3.5.
-* Reset dynamics step counter when a crash occurs so that energies and frames are save with the correct time stamp.
+* Reset dynamics step counters and internal clock when a crash occurs so that energies
+  and frames are save with the correct time stamp.
 
 `2024.4.0 <https://github.com/openbiosim/sire/compare/2024.3.1...2024.4.0>`__ - Feb 2025
 ----------------------------------------------------------------------------------------

--- a/tests/io/test_ambercmap.py
+++ b/tests/io/test_ambercmap.py
@@ -54,7 +54,10 @@ def test_amber_cmap(tmpdir, amber_cmap):
 
     with open(f[0], "r") as f1:
         with open(f2[0], "r") as f2:
-            assert f1.read() == f2.read()
+            for i, (line1, line2) in enumerate(zip(f1, f2)):
+                # skip the first line since it includes a timestamp
+                if i > 0:
+                    assert line1 == line2
 
 
 def test_amber_cmap_grotop(tmpdir, amber_cmap):


### PR DESCRIPTION
This PR closes #319 by additionally resetting the internal clock when an OpenMM NaN crash is caught. Previously only the step counter was reset, but this led to incorrect time stamps for subsequent energy and trajectory frames since the clock was reset to zero, rather than the start time of the last dynamics block.

I've also updated the energy trajectory code to store keys in rounded form to avoid issues from numerical drift when times are updating over a long trajectory. The code now outputs a warning whenever keys are overwritten.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
