### PR TITLE
Fix issue #329

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -17,6 +17,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 
 * Please add an item to this CHANGELOG for any new features or bug fixes when creating a PR.
 * Add end-state coordinates properties to decoupled and annihilated molecules.
+* Map the end state coordinates property when constructing an ``AmberParams`` object when
+  creating a molecule from a ``SOMD`` perturbation file.
 
 `2025.1.0 <https://github.com/openbiosim/sire/compare/2024.4.2...2025.1.0>`__ - June 2025
 -----------------------------------------------------------------------------------------

--- a/src/sire/morph/_pertfile.py
+++ b/src/sire/morph/_pertfile.py
@@ -281,6 +281,7 @@ def create_from_pertfile(mol, pertfile, map=None):
     from ..legacy.MM import AmberParams
 
     map0 = {
+        "coordinates": "coordinates0",
         "charge": "charge0",
         "LJ": "LJ0",
         "ambertype": "ambertype0",
@@ -293,6 +294,7 @@ def create_from_pertfile(mol, pertfile, map=None):
     params0 = AmberParams(mol, map0)
 
     map1 = {
+        "coordinates": "coordinates1",
         "charge": "charge1",
         "LJ": "LJ1",
         "ambertype": "ambertype1",


### PR DESCRIPTION
This PR closes #329 by mapping the end-state coordinates properties when constructing the `AmberParams` objects.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]