### PR TITLE
Fix issue #335 and #337

### DIFF
--- a/corelib/CMakeLists.txt
+++ b/corelib/CMakeLists.txt
@@ -370,10 +370,17 @@ else()
   CHECK_CXX_COMPILER_FLAG( "-std=c++17" SIRE_HAS_CPP_17 )
 endif()
 
+if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
+  CHECK_CXX_COMPILER_FLAG( "/std:c++20" SIRE_HAS_CPP_20 )
+else()
+  CHECK_CXX_COMPILER_FLAG( "-std=c++20" SIRE_HAS_CPP_20 )
+endif()
+
 save_sire_variable( "SIRE_HAS_CPP_LIB" "${SIRE_HAS_CPP_LIB}" )
 
 save_sire_variable( "SIRE_HAS_CPP_14" "${SIRE_HAS_CPP_14}" )
 save_sire_variable( "SIRE_HAS_CPP_17" "${SIRE_HAS_CPP_17}" )
+save_sire_variable( "SIRE_HAS_CPP_20" "${SIRE_HAS_CPP_20}" )
 
 option( SIRE_SKIP_LIBC++ "Force Sire to ignore libc++ (e.g. in case of broken clang on linux" OFF )
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -21,6 +21,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
   creating a molecule from a ``SOMD`` perturbation file.
 * Fix evaluation of custom force energies from OpenMM XML files by correctly looping over
   interaction groups.
+* Switch to new Boost Conda package naming scheme for host requirements.
 
 `2025.1.0 <https://github.com/openbiosim/sire/compare/2024.4.2...2025.1.0>`__ - June 2025
 -----------------------------------------------------------------------------------------

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -22,6 +22,7 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Fix evaluation of custom force energies from OpenMM XML files by correctly looping over
   interaction groups.
 * Switch to new Boost Conda package naming scheme for host requirements.
+* Use C++20 standard for SireRDKit plugin.
 
 `2025.1.0 <https://github.com/openbiosim/sire/compare/2024.4.2...2025.1.0>`__ - June 2025
 -----------------------------------------------------------------------------------------

--- a/recipes/sire/conda_build_config.yaml
+++ b/recipes/sire/conda_build_config.yaml
@@ -15,7 +15,5 @@ cxx_compiler_version:
   - 12.3.0 # [linux]
 
 pin_run_as_build:
-  boost:
-    max_pin: x.x
   openmm:
     max_pin: x.x

--- a/requirements_bss.txt
+++ b/requirements_bss.txt
@@ -15,10 +15,6 @@ openmmtools >= 0.21.5
 ambertools >= 22 ; sys_platform != "win32"
 gromacs ; sys_platform != "win32" and platform_machine != "arm64"
 
-# kartograf on Windows pulls in an openfe that has an old / incompatble
-# ambertools
-kartograf >= 1.0.0 ; sys_platform != "win32"
-
 # The following are actual BioSimSpace run-time requirements. Please update
 # this list as new requirements are added.
 configargparse

--- a/requirements_host.txt
+++ b/requirements_host.txt
@@ -6,7 +6,7 @@ libboost-devel
 libboost-python-devel
 libcblas
 libnetcdf
-librdkit-dev
+librdkit-dev > 2024.09.6
 openmm >= 8.1
 pandas
 python

--- a/requirements_host.txt
+++ b/requirements_host.txt
@@ -1,8 +1,9 @@
 # Host requirements for Sire.
 
-boost
 gsl
 lazy_import
+libboost-devel
+libboost-python-devel
 libcblas
 libnetcdf
 librdkit-dev

--- a/requirements_run.txt
+++ b/requirements_run.txt
@@ -1,6 +1,5 @@
 # Runtime requirements for Sire.
 
-boost
 gsl
 lazy_import
 libnetcdf

--- a/wrapper/Convert/SireRDKit/CMakeLists.txt
+++ b/wrapper/Convert/SireRDKit/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 ##########################################
 
-if (SIRE_HAS_CPP_17)
+if (SIRE_HAS_CPP_20)
   # Find RDKit libraries
   find_package(RDKit)
 
@@ -24,7 +24,11 @@ if (SIRE_HAS_CPP_17)
       # RDKit needs this definition set on Windows
       add_definitions(-DWIN32)
       add_definitions(-DRDKIT_DYN_LINK)
+      add_compile_options("/std:c++20")
+    else()
+      add_compile_options(-std=c++20)
     endif()
+
 
     if (APPLE)
       # RDKit uses std::bad_any_cast, which isn't available by default


### PR DESCRIPTION
This PR closes #335 and closes #337 by switching to the new Boost package naming scheme. We now require `libboost-devel` and `libboost-python-devel` as host requirements. The change means that we are now compatible with newer versions of RDKit, which have also been built against the new Boost packages.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]