### PR TITLE
Fix issue #346

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -33,6 +33,10 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 
 * Added a feature for applying RMSD restraints using the OpenMM CustomCVForce/RMSDForce functionality.
 
+* Added a ``save_velocities`` kwarg to :func:`sire.save()` to allow a user to control whether
+  velocities are saved to the output file. This is useful when the magnitude of the velocities
+  overflows the output file format precision, or when the velocities are not needed
+
 `2025.1.0 <https://github.com/openbiosim/sire/compare/2024.4.2...2025.1.0>`__ - June 2025
 -----------------------------------------------------------------------------------------
 

--- a/src/sire/_load.py
+++ b/src/sire/_load.py
@@ -526,6 +526,7 @@ def save(
     molecules,
     filename: str,
     format: _Union[str, _List[str]] = None,
+    save_velocities: bool = True,
     show_warnings=True,
     silent: bool = False,
     directory: str = ".",
@@ -560,6 +561,9 @@ def save(
          If this doesn't have an extension, then it will be guessed
          based on the formats used to load the molecule originally.
          If it still isn't available, then PDB will be used.
+
+     save_velocities (bool):
+        Whether or not to save velocities.
 
       show_warnings (bool):
          Whether or not to write out any warnings that occur during save
@@ -596,6 +600,16 @@ def save(
         show_warnings = False
 
     m = {"parallel": parallel, "show_warnings": show_warnings}
+
+    if not isinstance(save_velocities, bool):
+        raise TypeError(
+            f"'save_velocities' must be of type bool, not {type(save_velocities)}"
+        )
+
+    # remap the velocity property to a null value so that velocities
+    # are not saved to file
+    if not save_velocities:
+        m["velocity"] = "null"
 
     for key in kwargs.keys():
         m[key] = kwargs[key]

--- a/tests/io/test_velocities.py
+++ b/tests/io/test_velocities.py
@@ -1,0 +1,20 @@
+import pytest
+import sire as sr
+
+
+@pytest.mark.parametrize("save_velocities", [True, False])
+def test_velocities(tmpdir, triclinic_protein, save_velocities):
+    mols = triclinic_protein
+
+    # write out a AMBER files file
+
+    d = tmpdir.mkdir("test_velocities")
+    f = sr.save(
+        mols, d.join("test"), format=["RST7", "PRM7"], save_velocities=save_velocities
+    )
+
+    # load the files back in
+    check = sr.load(f[0], f[1])
+
+    # check that the velocities are present if requested
+    assert check[0].has_property("velocity") == save_velocities


### PR DESCRIPTION
This PR closes #346 by allowing the user to control whether velocities are written to the output files. I appreciate that this could also class as a feature, but feel that there should be a way to control this since this commonly happens during equilibration pipelines for our FEP setup. (The exception should definitely be raised, but then there should be an easy way for the user to control whether or not velocities are needed.)

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y/n]
* I confirm that I have permission to release this code under the GPL3 license: [y]
