### PR TITLE
Fix issue #344

### DIFF
--- a/corelib/src/libs/SireIO/pdb2.cpp
+++ b/corelib/src/libs/SireIO/pdb2.cpp
@@ -2020,6 +2020,26 @@ void PDB2::addToSystem(System &system, const PropertyMap &map) const
     if (num_mols == 0)
         return;
 
+    // Use the CRYST1 record to add a space property if one isn't already present.
+    if (not system.propertyKeys().contains(map["space"].source()) and this->has_cryst1)
+    {
+        // If all the angles are close to 90 degrees, then create a PeriodicBox.
+        if (qFuzzyCompare(this->cell_alpha, 90.0) and qFuzzyCompare(this->cell_beta, 90.0) and
+            qFuzzyCompare(this->cell_gamma, 90.0))
+        {
+            // Create a PeriodicBox with the unit cell dimensions.
+            PeriodicBox box(Vector(this->cell_x, this->cell_y, this->cell_z));
+            system.setProperty(map["space"].source(), box);
+        }
+        else
+        {
+            // Create a triclinic box with the unit cell dimensions and angles.
+            TriclinicBox box(this->cell_x, this->cell_y, this->cell_z,
+                             this->cell_alpha*degree, this->cell_beta*degree, this->cell_gamma*degree);
+            system.setProperty(map["space"].source(), box);
+        }
+    }
+
     // A vector of the updated molecules.
     QVector<Molecule> mols(num_mols);
 

--- a/corelib/src/libs/SireIO/pdb2.h
+++ b/corelib/src/libs/SireIO/pdb2.h
@@ -297,6 +297,19 @@ namespace SireIO
         /** Additional atom velocity data. */
         QVector<SireMol::Velocity3D> velocities;
 
+        /** Whether a CRYST1 record was found in the file. */
+        bool has_cryst1;
+
+        /** Cell dimensions. */
+        double cell_x;
+        double cell_y;
+        double cell_z;
+
+        /** Cell angles. */
+        double cell_alpha;
+        double cell_beta;
+        double cell_gamma;
+
         /** Any warnings that were raised when reading the file. */
         QStringList parse_warnings;
     };

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -33,6 +33,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 
 * Added a feature for applying RMSD restraints using the OpenMM CustomCVForce/RMSDForce functionality.
 
+* Added support for reading and writing CRYST1 records in PDB files.
+
 `2025.1.0 <https://github.com/openbiosim/sire/compare/2024.4.2...2025.1.0>`__ - June 2025
 -----------------------------------------------------------------------------------------
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -35,6 +35,10 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 
 * Added support for reading and writing CRYST1 records in PDB files.
 
+* Added a ``save_velocities`` kwarg to :func:`sire.save()` to allow a user to control whether
+  velocities are saved to the output file. This is useful when the magnitude of the velocities
+  overflows the output file format precision, or when the velocities are not needed
+
 `2025.1.0 <https://github.com/openbiosim/sire/compare/2024.4.2...2025.1.0>`__ - June 2025
 -----------------------------------------------------------------------------------------
 

--- a/src/sire/_load.py
+++ b/src/sire/_load.py
@@ -526,6 +526,7 @@ def save(
     molecules,
     filename: str,
     format: _Union[str, _List[str]] = None,
+    save_velocities: bool = True,
     show_warnings=True,
     silent: bool = False,
     directory: str = ".",
@@ -560,6 +561,9 @@ def save(
          If this doesn't have an extension, then it will be guessed
          based on the formats used to load the molecule originally.
          If it still isn't available, then PDB will be used.
+
+     save_velocities (bool):
+        Whether or not to save velocities.
 
       show_warnings (bool):
          Whether or not to write out any warnings that occur during save
@@ -596,6 +600,16 @@ def save(
         show_warnings = False
 
     m = {"parallel": parallel, "show_warnings": show_warnings}
+
+    if not isinstance(save_velocities, bool):
+        raise TypeError(
+            f"'save_velocities' must be of type bool, not {type(save_velocities)}"
+        )
+
+    # remap the velocity property to a null value so that velocities
+    # are not saved to file
+    if not save_velocities:
+        m["velocity"] = "null"
 
     for key in kwargs.keys():
         m[key] = kwargs[key]

--- a/tests/io/test_pdb2.py
+++ b/tests/io/test_pdb2.py
@@ -1,0 +1,53 @@
+import pytest
+import sire as sr
+import tempfile
+
+def test_pdb_space():
+    """
+    Test that we can parse CRYST1 records in a PDB file and that they
+    are preserved when writing the file back out.
+    """
+
+    # Create a temporary working directory.
+    tmp_dir = tempfile.TemporaryDirectory()
+    tmp_path = tmp_dir.name
+    pdb_file = f"{tmp_path}/test.pdb"
+
+    # Load the test system.
+    mols = sr.load(
+        sr.expand(
+            sr.tutorial_url,
+            "cresset_triclinic_box.prm7",
+            "cresset_triclinic_box.rst7",
+        ),
+        directory=tmp_path,
+    )
+
+    # Get the space from the system.
+    space = mols.space()
+
+    # Write back to the temporary path.
+    sr.save(mols, pdb_file)
+
+    # Load the PDB file.
+    pdb_mols = sr.load(pdb_file)
+
+    # Get the space from the PDB molecules.
+    pdb_space = pdb_mols.space()
+
+    # Make sure the spaces are the same to the precision of the PDB format.
+    # Note that although the PDB uses 3dp for box dimensions, angles are only
+    # written to 2dp.
+
+    vec0 = space.vector0()
+    vec1 = space.vector1()
+    vec2 = space.vector2()
+    pdb_vec0 = pdb_space.vector0()
+    pdb_vec1 = pdb_space.vector1()
+    pdb_vec2 = pdb_space.vector2()
+
+    # X, Y, Z vector components should be the same.
+    for i in range(3):
+        assert vec0[i].value() == pytest.approx(pdb_vec0[i].value(), abs=1e-2)
+        assert vec1[i].value() == pytest.approx(pdb_vec1[i].value(), abs=1e-2)
+        assert vec2[i].value() == pytest.approx(pdb_vec2[i].value(), abs=1e-2)

--- a/tests/io/test_velocities.py
+++ b/tests/io/test_velocities.py
@@ -1,0 +1,20 @@
+import pytest
+import sire as sr
+
+
+@pytest.mark.parametrize("save_velocities", [True, False])
+def test_velocities(tmpdir, triclinic_protein, save_velocities):
+    mols = triclinic_protein
+
+    # write out a AMBER files file
+
+    d = tmpdir.mkdir("test_velocities")
+    f = sr.save(
+        mols, d.join("test"), format=["RST7", "PRM7"], save_velocities=save_velocities
+    )
+
+    # load the files back in
+    check = sr.load(f[0], f[1])
+
+    # check that the velocities are present if requested
+    assert check[0].has_property("velocity") == save_velocities


### PR DESCRIPTION
This PR closes #344 by adding support for parsing `CRYST1` records in PDB files. Depending on the box angles, these are converted to a `PeriodicBox` or `TriclinicBox` object, then stored as the `space` property of the system. On write, the `space` property is converted back to an appropriate `CRYST1` record.

A unit test checks for round-trip self-consistency for a standard Cresset tricnlic box. The test assumes 2dp accuracy in the box vectors, since the PDB format stores the `CRYST1` angles to 2dp.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]