### PR TITLE
Fix issue #351

### DIFF
--- a/src/sire/qm/_utils.py
+++ b/src/sire/qm/_utils.py
@@ -337,7 +337,13 @@ def _get_link_atoms(mols, qm_mol_to_atoms, map):
         qm_idxs = [atom.index() for atom in qm_atoms]
 
         # Create a connectivity object.
-        connectivity = _Mol.Connectivity(qm_mol, _Mol.CovalentBondHunter(), map)
+        connectivity = _Mol.Connectivity(qm_mol.info())
+        editor = connectivity.edit()
+
+        # Connect atoms according to the bonding from the force field.
+        for bond in qm_mol.property(map["bond"]).potentials():
+            editor.connect(bond.atom0(), bond.atom1())
+        connectivity = editor.commit()
 
         # Dictionary to store the MM1 atoms.
         mm1_atoms = {}


### PR DESCRIPTION
This PR closes #351 by using the bonds from the force field to define the connectivity when searching for link atoms. This is covered by an existing test in `tests/qm/test_qm.py`.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

