### PR TITLE
Fix issue #358

### DIFF
--- a/corelib/src/libs/SireIO/grotop.cpp
+++ b/corelib/src/libs/SireIO/grotop.cpp
@@ -2662,11 +2662,56 @@ QStringList GroMolType::settlesLines(bool is_lambda1) const
     }
     else if (nAtoms(is_lambda1) == 4)
     {
+        // lambda function to check whether a four point water model
+        // is OPC water, which is determined by the virtual site charge
+        // value being < -1.1
+        auto is_opc = [this, is_lambda1]() -> bool {
+            if (is_lambda1)
+            {
+                for (const auto &atm : atms1)
+                {
+                    if (atm.mass().value() < 1.0) // virtual site
+                    {
+                        if (atm.charge().value() < -1.1)
+                            return true;
+                        else
+                            return false;
+                    }
+                }
+            }
+            else
+            {
+                for (const auto &atm : atms0)
+                {
+                    if (atm.mass().value() < 1.0) // virtual site
+                    {
+                        if (atm.charge().value() < -1.1)
+                            return true;
+                        else
+                            return false;
+                    }
+                }
+            }
+
+            return false;
+        };
+
         // TIP4P/OPC
         lines.append("1   2   3   4");
         lines.append("2   1   3   4");
         lines.append("3   1   2   4");
         lines.append("4   1   2   3");
+
+        // Add virtual site information.
+        lines.append("");
+        lines.append("[ virtual_sites3 ]");
+        lines.append("; Vsite from                    funct   a               b");
+
+        // Check for OPC water.
+        if (is_opc())
+            lines.append("4       1       2       3       1       0.1477224       0.1477224");
+        else
+            lines.append("4       1       2       3       1       0.128012065     0.128012065");
     }
     else if (nAtoms(is_lambda1) == 5)
     {
@@ -2676,6 +2721,13 @@ QStringList GroMolType::settlesLines(bool is_lambda1) const
         lines.append("3   1   2   4   5");
         lines.append("4   1   2   3   5");
         lines.append("5   1   2   3   4");
+
+        // Add virtual site information.
+        lines.append("");
+        lines.append("[ virtual_sites3 ]");
+        lines.append("; Vsite from                    funct   a               b               c");
+        lines.append("4      1       2       3       4        -0.344908262    -0.34490826     -6.4437903493");
+        lines.append("5      1       2       3       4        -0.344908262    -0.34490826     6.4437903493");
     }
 
     return lines;

--- a/corelib/src/libs/SireIO/grotop.cpp
+++ b/corelib/src/libs/SireIO/grotop.cpp
@@ -2551,13 +2551,12 @@ bool GroMolType::isWater(bool is_lambda1) const
                         if (nhyd > 2)
                             return false;
                     }
-                    else
-                        // not an oxygen or hydrogen
-                        return false;
                 }
 
-                // this is a water :-)
-                return true;
+                if (noxy == 1 and nhyd == 2)
+                    return true;
+                else
+                    return false;
             }
             else
             {
@@ -2584,13 +2583,12 @@ bool GroMolType::isWater(bool is_lambda1) const
                         if (nhyd > 2)
                             return false;
                     }
-                    else
-                        // not an oxygen or hydrogen
-                        return false;
                 }
 
-                // this is a water :-)
-                return true;
+                if (noxy == 1 and nhyd == 2)
+                    return true;
+                else
+                    return false;
             }
         }
     }

--- a/corelib/src/libs/SireIO/grotop.cpp
+++ b/corelib/src/libs/SireIO/grotop.cpp
@@ -2652,9 +2652,31 @@ QStringList GroMolType::settlesLines(bool is_lambda1) const
 
     lines.append("");
     lines.append("[ exclusions ]");
-    lines.append("1   2   3");
-    lines.append("2   1   3");
-    lines.append("3   1   2");
+
+    if (nAtoms(is_lambda1) == 3)
+    {
+        // TIP3P or SPC
+        lines.append("1   2   3");
+        lines.append("2   1   3");
+        lines.append("3   1   2");
+    }
+    else if (nAtoms(is_lambda1) == 4)
+    {
+        // TIP4P/OPC
+        lines.append("1   2   3   4");
+        lines.append("2   1   3   4");
+        lines.append("3   1   2   4");
+        lines.append("4   1   2   3");
+    }
+    else if (nAtoms(is_lambda1) == 5)
+    {
+        // TIP5P
+        lines.append("1   2   3   4   5");
+        lines.append("2   1   3   4   5");
+        lines.append("3   1   2   4   5");
+        lines.append("4   1   2   3   5");
+        lines.append("5   1   2   3   4");
+    }
 
     return lines;
 }

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -41,6 +41,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 
 * Use force field bonding when working out connectivity for QM link atoms.
 
+* Fix handling of 4- and 5-point water models when writing GROMACS topology files.
+
 `2025.1.0 <https://github.com/openbiosim/sire/compare/2024.4.2...2025.1.0>`__ - June 2025
 -----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR closes #358 by fixing the handling for detecting writing 4- and 5-point water models in the `GroTop` parser. Previously, despite stating otherwise, the code only correctly handled 3-point models and incorrectly assumed that all water models to be written would be AMBER-style, i.e. including explicit HH _and_ OH bonds in the force field, which would be used to determine the values to use in the `[ settles ]` section. For GROMACS, there is no explicit OH bond in any model, so this logic breaks down, meaning the default TIP3P parameters would be used for _all_ models. The fix also includes the manual addition of the correct `[ virtual_sites3 ]` records for each model, which are taken from the GROMACS water templates that are included with a GROMACS install and used for solvation with BioSimSpace. A unit test confirms that the correct records are written for each water model.

A quick summary:

* 4- and 5-point waters are now detected as water topologies in the parser.
* Correct settles records are added for 4- and 5-point waters.
* Exclusions are correctly written for 4- and 5-point waters.
* Virtual site records are now written for 4- and 5-point waters.

In addition to this, I'll check some GROMACS simulations using these water models via BioSimSpace and will update if there are any issues.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

