### PR TITLE
Add support for OpenMM MonteCarloMembraneBarostat

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -29,6 +29,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 
 * Added :func:`Sire::IO::setCoordinates` function to set atom coordinates of an entire system.
 
+* Add support for ``openmm.MonteCarloMembraneBarostat`` in Sire-to-OpenMM conversion.
+
 `2025.2.0 <https://github.com/openbiosim/sire/compare/2025.1.0...2025.2.0>`__ - October 2025
 --------------------------------------------------------------------------------------------
 

--- a/doc/source/cheatsheet/openmm.rst
+++ b/doc/source/cheatsheet/openmm.rst
@@ -199,6 +199,9 @@ Available keys and allowable values are listed below.
 | space                        | Space in which the simulation should be conducted, e.g.  |
 |                              | `sr.vol.Cartesian`                                       |
 +------------------------------+----------------------------------------------------------+
+| surface_tension              | Surface tension for membrane simulations at constant     |
+|                              | pressure, e.g. ``0.05*sr.units.bar*sr.units.nanometer``  |
++------------------------------+----------------------------------------------------------+
 | swap_end_states              | Whether to swap the end states of a perturbable molecule |
 |                              | (i.e. treat the perturbed state as the reference state   |
 |                              | and vice versa). This defaults to False.                 |

--- a/src/sire/mol/__init__.py
+++ b/src/sire/mol/__init__.py
@@ -1567,6 +1567,7 @@ def _dynamics(
     ignore_perturbations=None,
     temperature=None,
     pressure=None,
+    surface_tension=None,
     rest2_scale=None,
     rest2_selection=None,
     vacuum=None,
@@ -1687,6 +1688,10 @@ def _dynamics(
         The pressure at which to run the simulation. A
         microcanonical (NVE) or canonical (NVT) simulation will be
         run if the pressure is not set.
+
+    surface_tension: surface_tension
+        The surface tension to use if running a NPT simulation with
+        a membrane barostat.
 
     rest2_scale: float
         The scaling factor to apply when running a REST2 simulation
@@ -1877,6 +1882,10 @@ def _dynamics(
     if pressure is not None:
         pressure = u(pressure)
         map.set("pressure", pressure)
+
+    if surface_tension is not None:
+        surface_tension = u(surface_tension)
+        map.set("surface_tension", surface_tension)
 
     if rest2_scale is not None:
         map.set("rest2_scale", rest2_scale)

--- a/wrapper/Convert/SireOpenMM/_sommcontext.py
+++ b/wrapper/Convert/SireOpenMM/_sommcontext.py
@@ -309,6 +309,12 @@ class SOMMContext(_Context):
         """
         raise NotImplementedError("We can't yet set the pressure")
 
+    def set_surface_tension(self, surface_tension):
+        """
+        Set the target surface tension for the dynamics.
+        """
+        raise NotImplementedError("We can't yet set the surface tension")
+
     def get_potential_energy(self, to_sire_units: bool = True):
         """
         Calculate and return the potential energy of the system

--- a/wrapper/Convert/__init__.py
+++ b/wrapper/Convert/__init__.py
@@ -223,6 +223,12 @@ try:
 
         friction = friction.to(1.0 / picosecond) / openmm.unit.picosecond
 
+        if map.specified("surface_tension"):
+            surface_tension = map["surface_tension"].value()
+            surface_tension = surface_tension.to("bar * nanometer")
+        else:
+            surface_tension = None
+
         use_andersen = False
         temperature = None
 
@@ -354,7 +360,19 @@ try:
 
             pressure = ensemble.pressure().to(atm) * openmm.unit.atmosphere
 
-            barostat = openmm.MonteCarloBarostat(pressure, temperature, barostat_freq)
+            if surface_tension is not None:
+                barostat = openmm.MonteCarloMembraneBarostat(
+                    pressure,
+                    surface_tension,
+                    temperature,
+                    openmm.MonteCarloMembraneBarostat.XYIsotropic,
+                    openmm.MonteCarloMembraneBarostat.ZFree,
+                    barostat_freq,
+                )
+            else:
+                barostat = openmm.MonteCarloBarostat(
+                    pressure, temperature, barostat_freq
+                )
 
             system.addForce(barostat)
 


### PR DESCRIPTION
This PR adds support for using the OpenMM MonteCarloMembraneBarostat with Sire dynamics via the `surface_tension` kwarg or map option. The default settings match those used for SOMD1. Currently the only tunable parameter is the surface tension, which should be fine for the majority of use cases. The functionality will be wrapped in SOMD2 by simply exposing the new dynamics kwarg. By default, this will be `None`, so a user will need to explicitly set a value to use a membrane barostat (along with a pressure and temperature too).

Closes #313.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
