### PR TITLE
Add support for dynamics crash reports

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -31,6 +31,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 
 * Add support for ``openmm.MonteCarloMembraneBarostat`` in Sire-to-OpenMM conversion.
 
+* Added support for saving crash reports during Sire dynamics runs.
+
 `2025.2.0 <https://github.com/openbiosim/sire/compare/2025.1.0...2025.2.0>`__ - October 2025
 --------------------------------------------------------------------------------------------
 

--- a/src/sire/mol/_dynamics.py
+++ b/src/sire/mol/_dynamics.py
@@ -972,6 +972,45 @@ class DynamicsData:
             self._gcmc_sampler._set_water_state(self._omm_mols)
             self._gcmc_sampler.pop()
 
+        if self._save_crash_report:
+            import openmm
+            import numpy as np
+            from copy import deepcopy
+            from uuid import uuid4
+
+            # Create a unique identifier for this crash report.
+            crash_id = str(uuid4())[:8]
+
+            # Get the current context and system.
+            context = self._omm_mols
+            system = deepcopy(context.getSystem())
+
+            # Add each force to a unique group.
+            for i, f in enumerate(system.getForces()):
+                f.setForceGroup(i)
+
+            # Create a new context.
+            new_context = openmm.Context(system, deepcopy(context.getIntegrator()))
+            new_context.setPositions(context.getState(getPositions=True).getPositions())
+
+            # Write the  energies for each force group.
+            with open(f"crash_{crash_id}.log", "w") as f:
+                f.write(f"Current lambda: {str(self.get_lambda())}\n")
+                for i, force in enumerate(system.getForces()):
+                    state = new_context.getState(getEnergy=True, groups={i})
+                    f.write(f"{force.getName()}, {state.getPotentialEnergy()}\n")
+
+            # Save the serialised system.
+            with open(f"system_{crash_id}.xml", "w") as f:
+                f.write(openmm.XmlSerializer.serialize(system))
+
+            # Save the positions.
+            positions = (
+                new_context.getState(getPositions=True).getPositions(asNumpy=True)
+                / openmm.unit.nanometer
+            )
+            np.savetxt(f"positions_{crash_id}.txt", positions)
+
         self.run_minimisation()
 
     def run(
@@ -990,6 +1029,7 @@ class DynamicsData:
         null_energy: str = None,
         excess_chemical_potential: float = None,
         num_waters: int = None,
+        save_crash_report: bool = False,
     ):
         if self.is_null():
             return
@@ -1009,6 +1049,7 @@ class DynamicsData:
             "null_energy": null_energy,
             "excess_chemical_potential": excess_chemical_potential,
             "num_waters": num_waters,
+            "save_crash_report": save_crash_report,
         }
 
         from concurrent.futures import ThreadPoolExecutor
@@ -1047,6 +1088,13 @@ class DynamicsData:
                 num_waters = int(num_waters)
             except:
                 raise ValueError("'num_waters' must be an integer")
+
+        if save_crash_report is not None:
+            if not isinstance(save_crash_report, bool):
+                raise ValueError("'save_crash_report' must be True or False")
+            self._save_crash_report = save_crash_report
+        else:
+            self._save_crash_report = False
 
         try:
             steps_to_run = int(time.to(picosecond) / self.timestep().to(picosecond))
@@ -1649,6 +1697,7 @@ class Dynamics:
         null_energy: str = None,
         excess_chemical_potential: str = None,
         num_waters: int = None,
+        save_crash_report: bool = False,
     ):
         """
         Perform dynamics on the molecules.
@@ -1722,6 +1771,13 @@ class Dynamics:
             Whether to save the energy on exit, regardless of whether
             the energy frequency has been reached.
 
+        save_crash_report: bool
+            Whether to save a crash report if the dynamics fails due to an
+            instability. This will save a named log file containing the energy
+            for each force, an XML file containing the OpenMM system at the
+            start of the dynamics block, and a NumPy text file containing
+            the atomic positions at the start of the dynamics block.
+
         auto_fix_minimise: bool
             Whether or not to automatically run minimisation if the
             trajectory exits with an error in the first few steps.
@@ -1768,6 +1824,14 @@ class Dynamics:
                 else:
                     save_velocities = False
 
+            if save_crash_report is None:
+                if self._d._map.specified("save_crash_report"):
+                    save_crash_report = (
+                        self._d._map["save_crash_report"].value().as_bool()
+                    )
+                else:
+                    save_crash_report = False
+
             self._d.run(
                 time=time,
                 save_frequency=save_frequency,
@@ -1778,6 +1842,7 @@ class Dynamics:
                 save_velocities=save_velocities,
                 save_frame_on_exit=save_frame_on_exit,
                 save_energy_on_exit=save_energy_on_exit,
+                save_crash_report=save_crash_report,
                 auto_fix_minimise=auto_fix_minimise,
                 num_energy_neighbours=num_energy_neighbours,
                 null_energy=null_energy,


### PR DESCRIPTION
This PR adds supports for saving crash reports during Sire dynamics runs using the `save_crash_report` kwarg when calling `dynamics.run()`. If specified, the following files will be saved during a crash:

* A log file with current lambda and energy contribution from each force.
* An XML file containing the OpenMM system.
* A NumPy text file containing the atomic positions.

All files correspond to the system at the _start_ of the dynamics block, not the crash, which might not be available. This allows a user to replay a crash. Files are given a UUID name that is consistent across files, e.g. `crash_UUID.log`, `system_UUID.xml`, and `positions_UUID.txt`. I'm not sure whether we should allow the user to pass a name, or create the UUID for the dynamics object itself, then increment some file index, e.g. if there are multiple crashes along a trajectory. This probably isn't that important, since this is really intended to only be turned on when debugging unstable simulations to capture examples of soft-crashes. Happy to take suggestions, though.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]