### PR TITLE
Use SOMD2 logger for dynamics warnings

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -21,6 +21,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 
 * Fix ``delta`` parameter in soft-core Coulomb potential.
 
+* When possible, use the ``SOMD2`` logger for dynamics warnings.
+
 `2025.3.0 <https://github.com/openbiosim/sire/compare/2025.2.0...2025.3.0>`__ - November 2025
 ---------------------------------------------------------------------------------------------
 

--- a/src/sire/mol/_dynamics.py
+++ b/src/sire/mol/_dynamics.py
@@ -304,6 +304,14 @@ class DynamicsData:
         else:
             self._pressure = None
 
+        # Try importing the SOMD2 logger.
+        try:
+            from somd2 import _logger as somd2_logger
+
+            self._somd2_logger = somd2_logger
+        except:
+            self._somd2_logger = None
+
     def is_null(self):
         return self._sire_mols is None
 
@@ -953,13 +961,18 @@ class DynamicsData:
 
         from ..utils import Console
 
-        Console.warning(
+        msg = (
             "Something went wrong when running dynamics. The system will be "
             "minimised, and then dynamics will be attempted again. If an "
             "error still occurs, then it is likely that the step size is too "
             "large, the molecules are over-constrained, or there is something "
-            "more fundemental going wrong..."
+            "more fundamental going wrong..."
         )
+
+        if self._somd2_logger is not None:
+            self._somd2_logger.warning(msg)
+        else:
+            Console.warning(msg)
 
         # rebuild the molecules
         from ..convert import to


### PR DESCRIPTION
This PR adds support for preferential use of the `somd2` logger for dynamics warnings. This means that warnings are correctly logged to both stderr and file via `somd2`.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]