### PR TITLE
Fix run_constrained key

### DIFF
--- a/actions/generate_recipe.py
+++ b/actions/generate_recipe.py
@@ -337,7 +337,7 @@ def generate_recipe(data, features, git_remote, git_branch, git_version, git_num
     lines.extend(deps_to_yaml_lines(run_deps, indent=4))
 
     # Run constraints
-    lines.append("  run_constraints:")
+    lines.append("  run_constrained:")
     lines.append("    - ${{ pin_compatible('gemmi', upper_bound='x.x.x') }}")
     lines.append("    - ${{ pin_compatible('openmm', upper_bound='x.x') }}")
     lines.append("    - ${{ pin_compatible('rdkit', upper_bound='x.x.x') }}")


### PR DESCRIPTION
This PR fixes an invalid conda key that appeared in the switch to `rattler-build`. The key should be `run_constrained` rather than `run_constraints`. Weirdly, the resulting `info.json` files appear to be correct, so perhaps this was an alias. I'll fix for consistency anyway so that we aren't relying on any undocumented behaviour.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]