### PR TITLE
Fix duplicate registration of metatypes

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -17,6 +17,11 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 
 * Please add an item to this CHANGELOG for any new features or bug fixes when creating a PR.
 
+* Fixed duplicate converter registrations in the Python wrappers for OpenMM-related classes,
+  which caused ``RuntimeWarning: to-Python converter already registered`` warnings at import
+  time. Also fixed the autogeneration script (``scanheaders.py``) to deduplicate metatypes
+  so the issue does not recur when wrappers are regenerated.
+
 * Fixed a bug in the AMBER prmtop writer where CMAP atom indices were calculated
   incorrectly for systems containing more than one molecule with CMAP terms (e.g.
   multi-chain glycoproteins).

--- a/wrapper/AutoGenerate/scanheaders.py
+++ b/wrapper/AutoGenerate/scanheaders.py
@@ -124,7 +124,8 @@ class HeaderInfo:
         if classname in skip_metatypes:
             return
 
-        self._metatypes.append(classname)
+        if classname not in self._metatypes:
+            self._metatypes.append(classname)
 
     def addAlias(self, classname, alias):
         self._aliases[classname] = alias

--- a/wrapper/Convert/SireOpenMM/SireOpenMM_properties.cpp
+++ b/wrapper/Convert/SireOpenMM/SireOpenMM_properties.cpp
@@ -11,5 +11,4 @@
 void register_SireOpenMM_properties()
 {
     register_property_container< SireOpenMM::QMEnginePtr, SireOpenMM::QMEngine >();
-    register_property_container< SireOpenMM::QMEnginePtr, SireOpenMM::QMEngine >();
 }

--- a/wrapper/Convert/SireOpenMM/SireOpenMM_registrars.cpp
+++ b/wrapper/Convert/SireOpenMM/SireOpenMM_registrars.cpp
@@ -15,16 +15,10 @@ void register_SireOpenMM_objects()
 {
 
     ObjectRegistry::registerConverterFor< SireOpenMM::NullQMEngine >();
-    ObjectRegistry::registerConverterFor< SireOpenMM::NullQMEngine >();
-    ObjectRegistry::registerConverterFor< SireOpenMM::PyQMCallback >();
-    ObjectRegistry::registerConverterFor< SireOpenMM::PyQMForce >();
-    ObjectRegistry::registerConverterFor< SireOpenMM::PyQMEngine >();
     ObjectRegistry::registerConverterFor< SireOpenMM::PyQMCallback >();
     ObjectRegistry::registerConverterFor< SireOpenMM::PyQMForce >();
     ObjectRegistry::registerConverterFor< SireOpenMM::PyQMEngine >();
     ObjectRegistry::registerConverterFor< SireOpenMM::LambdaLever >();
-    ObjectRegistry::registerConverterFor< SireOpenMM::LambdaLever >();
-    ObjectRegistry::registerConverterFor< SireOpenMM::PerturbableOpenMMMolecule >();
     ObjectRegistry::registerConverterFor< SireOpenMM::PerturbableOpenMMMolecule >();
     ObjectRegistry::registerConverterFor< SireOpenMM::TorchQMForce >();
     ObjectRegistry::registerConverterFor< SireOpenMM::TorchQMEngine >();

--- a/wrapper/Move/SireMove_registrars.cpp
+++ b/wrapper/Move/SireMove_registrars.cpp
@@ -67,7 +67,6 @@ void register_SireMove_objects()
     ObjectRegistry::registerConverterFor< SireMove::SimPacket >();
     ObjectRegistry::registerConverterFor< SireMove::WeightedMoves >();
     ObjectRegistry::registerConverterFor< SireMove::OpenMMMDIntegrator >();
-    ObjectRegistry::registerConverterFor< SireMove::OpenMMMDIntegrator >();
     ObjectRegistry::registerConverterFor< SireMove::ZMatMove >();
     ObjectRegistry::registerConverterFor< SireMove::Replicas >();
     ObjectRegistry::registerConverterFor< SireMove::MTSMC >();
@@ -78,7 +77,6 @@ void register_SireMove_objects()
     ObjectRegistry::registerConverterFor< SireMove::SameSupraSubMoves >();
     ObjectRegistry::registerConverterFor< SireMove::PrefSampler >();
     ObjectRegistry::registerConverterFor< SireMove::VelocityVerlet >();
-    ObjectRegistry::registerConverterFor< SireMove::OpenMMPMEFEP >();
     ObjectRegistry::registerConverterFor< SireMove::OpenMMPMEFEP >();
     ObjectRegistry::registerConverterFor< SireMove::SupraSystem >();
     ObjectRegistry::registerConverterFor< SireMove::RBWorkspace >();
@@ -97,7 +95,6 @@ void register_SireMove_objects()
     ObjectRegistry::registerConverterFor< SireMove::NullInserter >();
     ObjectRegistry::registerConverterFor< SireMove::UniformInserter >();
     ObjectRegistry::registerConverterFor< SireMove::DLMRigidBody >();
-    ObjectRegistry::registerConverterFor< SireMove::OpenMMFrEnergyST >();
     ObjectRegistry::registerConverterFor< SireMove::OpenMMFrEnergyST >();
     ObjectRegistry::registerConverterFor< SireMove::NullIntegratorWorkspace >();
     ObjectRegistry::registerConverterFor< SireMove::AtomicVelocityWorkspace >();
@@ -122,7 +119,6 @@ void register_SireMove_objects()
     ObjectRegistry::registerConverterFor< SireMove::RigidBodyMC >();
     ObjectRegistry::registerConverterFor< SireMove::Ensemble >();
     ObjectRegistry::registerConverterFor< SireMove::TitrationMove >();
-    ObjectRegistry::registerConverterFor< SireMove::OpenMMFrEnergyDT >();
     ObjectRegistry::registerConverterFor< SireMove::OpenMMFrEnergyDT >();
     ObjectRegistry::registerConverterFor< SireMove::NullSupraSubMove >();
     ObjectRegistry::registerConverterFor< SireMove::SameMoves >();


### PR DESCRIPTION
This PR fixes duplicate converter registrations in the Python wrappers for OpenMM-related classes, which caused ``RuntimeWarning: to-Python converter already registered`` warnings at import time. The autogeneration script (``scanheaders.py``) has also been updated to deduplicate metatypes so the issue does not recur when wrappers are regenerated.


* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]