### PR TITLE
sire.legacy.IO.setCoordinates now takes System by value to avoid mutating the input

### DIFF
--- a/corelib/src/libs/SireIO/biosimspace.cpp
+++ b/corelib/src/libs/SireIO/biosimspace.cpp
@@ -1691,7 +1691,7 @@ namespace SireIO
         return ion;
     }
 
-    System setCoordinates(System &system, const QVector<QVector<float>> &coordinates, const bool is_lambda1, const PropertyMap &map)
+    System setCoordinates(System system, const QVector<QVector<float>> &coordinates, const bool is_lambda1, const PropertyMap &map)
     {
         // Make sure that the number of coordinates matches the number of atoms.
         if (system.nAtoms() != coordinates.size())

--- a/corelib/src/libs/SireIO/biosimspace.h
+++ b/corelib/src/libs/SireIO/biosimspace.h
@@ -374,7 +374,7 @@ namespace SireIO
             The system with updated coordinates.
      */
     SIREIO_EXPORT SireSystem::System setCoordinates(
-        SireSystem::System &system, const QVector<QVector<float>> &coordinates,
+        SireSystem::System system, const QVector<QVector<float>> &coordinates,
         const bool is_lambda1 = false, const PropertyMap &map = PropertyMap());
 
     Vector cross(const Vector &v0, const Vector &v1);

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -41,6 +41,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 * Added support for Direct Morse Replacement (DMR) feature in ``sire.restraints.morse_potential``
   which is enabled by default.
 
+* Don't mutate input system in the ``sire.legacy.IO.setCoordinates`` function.
+
 `2025.4.0 <https://github.com/openbiosim/sire/compare/2025.3.0...2025.4.0>`__ - February 2026
 ---------------------------------------------------------------------------------------------
 

--- a/wrapper/IO/_IO_free_functions.pypp.cpp
+++ b/wrapper/IO/_IO_free_functions.pypp.cpp
@@ -814,7 +814,7 @@ void register_free_functions(){
 
     { //::SireIO::setCoordinates
     
-        typedef ::SireSystem::System ( *setCoordinates_function_type )( ::SireSystem::System &,::QVector<QVector<float>> const &,bool const,::SireBase::PropertyMap const & );
+        typedef ::SireSystem::System ( *setCoordinates_function_type )( ::SireSystem::System,::QVector<QVector<float>> const &,bool const,::SireBase::PropertyMap const & );
         setCoordinates_function_type setCoordinates_function_value( &::SireIO::setCoordinates );
         
         bp::def( 


### PR DESCRIPTION
This PR switches to using pass by value to ensure that the input system isn't mutated when using `sire.legacy.IO.setCoordinates`. This wasn't an issue in practice, since the functionality was wrapped by BioSimSpace, but it means that the function now operates in the intended Pythonic way when used directly.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
