### PR TITLE
Fix issue #419

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -43,6 +43,8 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 
 * Don't mutate input system in the ``sire.legacy.IO.setCoordinates`` function.
 
+* Store OpenMM state at start of a dynamics run to use for crash recovery.
+
 `2025.4.0 <https://github.com/openbiosim/sire/compare/2025.3.0...2025.4.0>`__ - February 2026
 ---------------------------------------------------------------------------------------------
 

--- a/src/sire/mol/_dynamics.py
+++ b/src/sire/mol/_dynamics.py
@@ -186,6 +186,9 @@ class DynamicsData:
             # if the dynamics object is coupled to a sampler.
             self._gcmc_sampler = None
 
+            # Pre-run OpenMM state snapshot used for crash recovery.
+            self._pre_run_state = None
+
             # Check for a REST2 scaling factor.
             if map.specified("rest2_scale"):
                 try:
@@ -1005,12 +1008,20 @@ class DynamicsData:
         else:
             Console.warning(msg)
 
-        # rebuild the molecules
-        from ..convert import to
+        # Reset the context to the pre-run state snapshot. This was captured
+        # immediately before dynamics.run() was called so it contains consistent
+        # positions, velocities, and box vectors. If no snapshot is available
+        # (e.g. very first run call), fall back to rebuilding the context from
+        # _sire_mols.
+        if self._pre_run_state is not None:
+            self._omm_mols.setState(self._pre_run_state)
+            self._pre_run_state = None
+        else:
+            from ..convert import to
 
-        self._omm_mols = to(self._sire_mols, "openmm", map=self._map)
+            self._omm_mols = to(self._sire_mols, "openmm", map=self._map)
 
-        # reset the water state
+        # Reset the GCMC water state.
         if self._gcmc_sampler is not None:
             self._gcmc_sampler.push()
             self._gcmc_sampler._set_water_state(self._omm_mols)
@@ -1056,6 +1067,11 @@ class DynamicsData:
             np.savetxt(f"positions_{crash_id}.txt", positions)
 
         self.run_minimisation()
+
+        # Randomise velocities after minimisation. The restored velocities may
+        # be inconsistent with the minimised geometry, which could cause a
+        # secondary instability at the start of the retry dynamics.
+        self.randomise_velocities()
 
     def run(
         self,
@@ -1314,6 +1330,13 @@ class DynamicsData:
         from datetime import datetime
         from math import isnan
 
+        # Capture a pre-run state snapshot for crash recovery if one
+        # hasn't already been set by an external tool, e.g. SOMD2.
+        if self._pre_run_state is None:
+            self._pre_run_state = self._omm_mols.getState(
+                getPositions=True, getVelocities=True
+            )
+
         try:
             with ProgressBar(total=steps_to_run, text="dynamics") as progress:
                 progress.set_speed_unit("steps / s")
@@ -1500,6 +1523,9 @@ class DynamicsData:
                     state_has_cv=state_has_cv,
                     nsteps_completed=nsteps_before_run + completed,
                 )
+
+            # Discard the pre-run snapshot so it is not reused.
+            self._pre_run_state = None
 
         except NeedsMinimiseError:
             from openmm.unit import picosecond

--- a/src/sire/mol/_dynamics.py
+++ b/src/sire/mol/_dynamics.py
@@ -1330,9 +1330,10 @@ class DynamicsData:
         from datetime import datetime
         from math import isnan
 
-        # Capture a pre-run state snapshot for crash recovery if one
-        # hasn't already been set by an external tool, e.g. SOMD2.
-        if self._pre_run_state is None:
+        # Capture a pre-run state snapshot for crash recovery if one hasn't
+        # already been set externally. Only needed when auto_fix_minimise is
+        # enabled, since the snapshot is only consumed by _rebuild_and_minimise.
+        if auto_fix_minimise and self._pre_run_state is None:
             self._pre_run_state = self._omm_mols.getState(
                 getPositions=True, getVelocities=True
             )
@@ -1524,8 +1525,9 @@ class DynamicsData:
                     nsteps_completed=nsteps_before_run + completed,
                 )
 
-            # Discard the pre-run snapshot so it is not reused.
-            self._pre_run_state = None
+            # Discard the pre-run snapshot so it is not reused stale.
+            if auto_fix_minimise:
+                self._pre_run_state = None
 
         except NeedsMinimiseError:
             from openmm.unit import picosecond


### PR DESCRIPTION
This PR closes #419 by storing a snapshot of the current OpenMM state at the start of the `dynamics.run()` block, which is then used for crash recovery. The state can be set externally, i.e. by `somd2`, to avoid the overhead. (`somd2` stores the state each cycle during repex anyway.) 

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]