### PR TITLE
Fix out-of-bounds molidx searches silently returning the last molecule

### DIFF
--- a/corelib/src/libs/SireMol/molid.cpp
+++ b/corelib/src/libs/SireMol/molid.cpp
@@ -266,6 +266,8 @@ QList<MolNum> MolIdx::map(const Molecules &molecules) const
             molnums.append(it.key());
             break;
         }
+
+        --i;
     }
 
     BOOST_ASSERT(not molnums.isEmpty());

--- a/corelib/src/libs/SireSearch/idengine.cpp
+++ b/corelib/src/libs/SireSearch/idengine.cpp
@@ -31,8 +31,8 @@
 #include "SireBase/booleanproperty.h"
 #include "SireBase/parallel.h"
 
-#include "SireMol/atomelements.h"
 #include "SireMol/atomcoords.h"
+#include "SireMol/atomelements.h"
 #include "SireMol/core.h"
 #include "SireMol/iswater.h"
 
@@ -1155,8 +1155,62 @@ SelectResult IDIndexEngine::searchMolIdx(const SelectResult &mols, const SelectR
 {
     QList<Molecule> matches;
 
-    int idx = 0;
     int count = context.listCount();
+
+    if (_is_single_value(this->vals))
+    {
+        // For a single index value, apply Python-style negative-index mapping
+        // and do a strict bounds check. Out-of-bounds returns no match,
+        // consistent with residx/atomidx behaviour.
+        // We read the raw start value from RangeValue directly, bypassing the
+        // _to_single_value helper which maps against INT_MAX and corrupts
+        // negative indices.
+        auto rv = boost::get<RangeValue>(this->vals[0]);
+
+        if (not rv.start)
+            return SelectResult(matches);
+
+        int v = *rv.start;
+
+        if (v < 0)
+            v = count + v;
+
+        if (v < 0 or v >= count)
+            return SelectResult(matches);
+
+        int idx = 0;
+
+        for (const auto &mol : context)
+        {
+            if (idx == v)
+            {
+                if (&mols == &context)
+                {
+                    matches.append(mol->molecule());
+                }
+                else
+                {
+                    const auto molnum = mol->data().number();
+
+                    for (const auto &m : mols)
+                    {
+                        if (m->data().number() == molnum)
+                        {
+                            matches.append(m->molecule());
+                            break;
+                        }
+                    }
+                }
+                break;
+            }
+
+            idx += 1;
+        }
+
+        return SelectResult(matches);
+    }
+
+    int idx = 0;
 
     for (const auto &mol : context)
     {

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -58,6 +58,10 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
 
 * Map the end-state ``element`` property when performing hydrogen mass repartitioning on perturbable molecules.
 
+* Fixed out-of-bounds ``molidx`` searches silently returning the last molecule instead of
+  raising a ``KeyError``. Out-of-bounds positive and negative single-index values now
+  behave consistently with ``residx`` and ``atomidx``.
+
 `2025.4.0 <https://github.com/openbiosim/sire/compare/2025.3.0...2025.4.0>`__ - February 2026
 ---------------------------------------------------------------------------------------------
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+[lint]
+ignore = ["E402"]
+
+[lint.per-file-ignores]
+"tests/**" = ["F841"]

--- a/tests/mol/test_complex_indexing.py
+++ b/tests/mol/test_complex_indexing.py
@@ -442,7 +442,7 @@ def test_search_terms(ala_mols):
     check_mass = mols[0][0].mass().value()
 
     atoms = mols[0][
-        f"atom mass >= {check_mass-0.001} and atom mass <= {check_mass+0.001}"
+        f"atom mass >= {check_mass - 0.001} and atom mass <= {check_mass + 0.001}"
     ]
 
     assert len(atoms) > 0
@@ -460,7 +460,7 @@ def test_search_terms(ala_mols):
     check_charge = mols[0][1].charge().value()
 
     atoms = mols[0][
-        f"atom charge >= {check_charge-0.001} and atom charge <= {check_charge+0.001}"
+        f"atom charge >= {check_charge - 0.001} and atom charge <= {check_charge + 0.001}"
     ]
 
     assert len(atoms) > 0
@@ -527,8 +527,6 @@ def test_in_searches(ala_mols):
 def test_with_searches(ala_mols):
     mols = ala_mols
 
-    import sire as sr
-
     for mol in mols["molecules with count(atoms) >= 3"]:
         assert mol.num_atoms() >= 3
 
@@ -593,3 +591,29 @@ def test_count_searches(ala_mols):
 
     mol = mols["molecules with count(residues) == 3"]
     assert mol.num_residues() == 3
+
+
+def test_oob_molidx(ala_mols):
+    """
+    Regression test for issue #286: out-of-bounds molidx should raise KeyError,
+    not silently return the last molecule.
+    """
+    mols = ala_mols
+
+    n = mols.num_molecules()
+
+    # Valid boundary indices should work
+    assert mols["molidx 0"] == mols[0]
+    assert mols[f"molidx {n - 1}"] == mols[-1]
+    assert mols["molidx -1"] == mols[-1]
+
+    # Out-of-bounds positive index must raise KeyError
+    with pytest.raises(KeyError):
+        mols[f"molidx {n}"]
+
+    with pytest.raises(KeyError):
+        mols["molidx 10000"]
+
+    # Out-of-bounds negative index must raise KeyError
+    with pytest.raises(KeyError):
+        mols[f"molidx -{n + 1}"]


### PR DESCRIPTION
This PR closes #286, fixing a bug where out-of-bounds `molidx` searches silently returned the last molecule instead of raising a `KeyError`. The root cause was in `IDIndexEngine::searchMolIdx()`: unlike `searchIdx<T>` (used for atoms, residues, etc.), it had no single-value fast path and instead fell through to a `match()` call that used `slice.begin(count, true)` with `auto_fix=true`, silently clamping any out-of-bounds index to the last valid position. The fix adds a `_is_single_value` fast path to `searchMolIdx` that reads the raw index directly from `RangeValue::start` (bypassing the `_to_single_value` helper, which corrupts negative indices by mapping them against `INT_MAX`) and applies strict Python-style bounds checking. Negative indices within range (e.g. -1) continue to work correctly, while out-of-bounds values in either direction now return no match, consistent with residx and atomidx behaviour. A secondary bug in `MolIdx::map(const Molecules &)` where the loop counter i was never decremented is also fixed. A regression test is included.

Debugged with assistance from Claude Code Opus 4.6.

@chryswoods: Just want to address you concerns about different container types and use case. In the C++ layer we have `MolIdx::map(const Molecules&)`, where `Molecules` is a `QHash<MolNum, ViewsOfMol>`, so has no stable iteration order. I think this isn't an issue for user-facing code, since it goes through another pathway, but good to check. The comment referencing `static map()` in the issue thread, this pathway isn't touched by this fix, so was a red-herring, i.e. that's used for ranges and comparisons only. For the additional bug fix: I don't think this was ever an issue since this low-level overload probably wasn't used by any callers.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
