### PR TITLE
Fix mergeIntrascale using per-state connectivity

### DIFF
--- a/corelib/src/libs/SireIO/biosimspace.cpp
+++ b/corelib/src/libs/SireIO/biosimspace.cpp
@@ -1760,76 +1760,58 @@ namespace SireIO
 
     SireBase::PropertyList mergeIntrascale(const CLJNBPairs &nb0,
                                            const CLJNBPairs &nb1,
-                                           const MoleculeInfoData &merged_info,
+                                           const Connectivity &conn0,
+                                           const Connectivity &conn1,
+                                           const CLJScaleFactor &sf14,
                                            const QHash<AtomIdx, AtomIdx> &mol0_merged_mapping,
                                            const QHash<AtomIdx, AtomIdx> &mol1_merged_mapping)
     {
-        // Helper lambda: copy scaling factors from 'nb' to 'nb_merged' according
-        // to the provided mapping. Takes nb_merged by reference to avoid copies.
-        // When copy_all is true, ALL pairs between mapped atoms are written
-        // (including the default (1,1)), so that the correct end-state values
-        // always overwrite any values set by a prior ghost-topology pass.
-        // When copy_all is false, only non-(1,1) pairs are written (sufficient
-        // for the first/ghost pass, where unset pairs default to (1,1) anyway).
-        auto copyIntrascale = [&](const CLJNBPairs &nb, CLJNBPairs &nb_merged,
-                                  const QHash<AtomIdx, AtomIdx> &mapping,
-                                  bool copy_all = false)
+        // Build base CLJNBPairs from the per-state merged connectivity. This
+        // correctly captures bonded distances (1-2, 1-3, 1-4) in the merged
+        // atom space, including paths that only exist in one end state (e.g.
+        // the ring-closure bond for ring-breaking perturbations).
+        CLJNBPairs intra0(conn0, sf14);
+        CLJNBPairs intra1(conn1, sf14);
+
+        // Override with per-pair values from the individual molecule intrascales.
+        // For standard AMBER molecules these are identical to the connectivity-
+        // derived values and the override is a no-op. For force fields with
+        // non-default per-pair scale factors (e.g. GLYCAM funct=2 with (1,1)
+        // instead of global sf14 for certain 1-4 pairs) the override replaces
+        // the global-sf14 value set by the base construction with the correct
+        // per-pair value.
+        auto overrideIntrascale = [&](const CLJNBPairs &nb, CLJNBPairs &nb_merged,
+                                      const QHash<AtomIdx, AtomIdx> &mapping)
         {
             const int n = nb.nAtoms();
 
             for (int i = 0; i < n; ++i)
             {
                 const AtomIdx ai(i);
-
-                // Get the index of this atom in the merged system.
                 const AtomIdx merged_ai = mapping.value(ai, AtomIdx(-1));
 
-                // If this atom hasn't been mapped to the merged system, then we
-                // can skip it, as any scaling factors involving this atom will
-                // just use the default.
                 if (merged_ai == AtomIdx(-1))
                     continue;
 
                 for (int j = i; j < n; ++j)
                 {
                     const AtomIdx aj(j);
+                    const AtomIdx merged_aj = mapping.value(aj, AtomIdx(-1));
 
-                    // Get the scaling factor for this pair of atoms.
-                    const CLJScaleFactor sf = nb.get(ai, aj);
+                    if (merged_aj == AtomIdx(-1))
+                        continue;
 
-                    // Copy if this is a non-default scaling factor, or if
-                    // copy_all is set (second pass: must overwrite ghost-topology
-                    // values even when the correct end-state value is (1,1)).
-                    if (copy_all or sf.coulomb() != 1.0 or sf.lj() != 1.0)
-                    {
-                        // Get the index of the second atom in the merged system.
-                        const AtomIdx merged_aj = mapping.value(aj, AtomIdx(-1));
+                    const CLJScaleFactor nb_sf = nb.get(ai, aj);
+                    const CLJScaleFactor base_sf = nb_merged.get(merged_ai, merged_aj);
 
-                        // Only set the scaling factor if both atoms have been
-                        // mapped to the merged system. If one of the atoms
-                        // hasn't been mapped, then we can just use the default.
-                        if (merged_aj != AtomIdx(-1))
-                            nb_merged.set(merged_ai, merged_aj, sf);
-                    }
+                    if (nb_sf.coulomb() != base_sf.coulomb() or nb_sf.lj() != base_sf.lj())
+                        nb_merged.set(merged_ai, merged_aj, nb_sf);
                 }
             }
         };
 
-        // Create the intrascale objects for the merged end-states.
-        CLJNBPairs intra0(merged_info);
-        CLJNBPairs intra1(merged_info);
-
-        // Copy scaling factors from the original intrascale objects to the
-        // merged intrascale objects. For each end state, the ghost molecule's
-        // topology is written first (non-default pairs only), then the correct
-        // end-state topology overwrites with copy_all=true so that (1,1) pairs
-        // are also written. This handles ring-breaking perturbations where a
-        // pair that is excluded/1-4 in one state becomes fully interacting (1,1)
-        // in the other state and must not be left at the ghost state's value.
-        copyIntrascale(nb1, intra0, mol1_merged_mapping);
-        copyIntrascale(nb0, intra0, mol0_merged_mapping, true);
-        copyIntrascale(nb0, intra1, mol0_merged_mapping);
-        copyIntrascale(nb1, intra1, mol1_merged_mapping, true);
+        overrideIntrascale(nb0, intra0, mol0_merged_mapping);
+        overrideIntrascale(nb1, intra1, mol1_merged_mapping);
 
         // Assemble the intrascale objects into a property list to return.
         SireBase::PropertyList ret;

--- a/corelib/src/libs/SireIO/biosimspace.h
+++ b/corelib/src/libs/SireIO/biosimspace.h
@@ -41,6 +41,7 @@
 #include "SireMM/cljnbpairs.h"
 
 #include "SireMol/atomidxmapping.h"
+#include "SireMol/connectivity.h"
 #include "SireMol/moleculeinfodata.h"
 #include "SireMol/select.h"
 
@@ -411,7 +412,9 @@ namespace SireIO
     SIREIO_EXPORT SireBase::PropertyList mergeIntrascale(
         const SireMM::CLJNBPairs &nb0,
         const SireMM::CLJNBPairs &nb1,
-        const SireMol::MoleculeInfoData &merged_info,
+        const SireMol::Connectivity &conn0,
+        const SireMol::Connectivity &conn1,
+        const SireMM::CLJScaleFactor &sf14,
         const QHash<SireMol::AtomIdx, SireMol::AtomIdx> &mol0_merged_mapping,
         const QHash<SireMol::AtomIdx, SireMol::AtomIdx> &mol1_merged_mapping);
 

--- a/wrapper/IO/_IO_free_functions.pypp.cpp
+++ b/wrapper/IO/_IO_free_functions.pypp.cpp
@@ -2,8 +2,8 @@
 
 // (C) Christopher Woods, GPL >= 3 License
 
-#include "boost/python.hpp"
 #include "_IO_free_functions.pypp.hpp"
+#include "boost/python.hpp"
 
 namespace bp = boost::python;
 
@@ -628,295 +628,212 @@ namespace bp = boost::python;
 
 #include "biosimspace.h"
 
-void register_free_functions(){
+void register_free_functions()
+{
 
     { //::SireIO::createChlorineIon
-    
-        typedef ::SireMol::Molecule ( *createChlorineIon_function_type )( ::SireMaths::Vector const &,::QString const,::SireBase::PropertyMap const & );
-        createChlorineIon_function_type createChlorineIon_function_value( &::SireIO::createChlorineIon );
-        
-        bp::def( 
-            "createChlorineIon"
-            , createChlorineIon_function_value
-            , ( bp::arg("coords"), bp::arg("model"), bp::arg("map")=SireBase::PropertyMap() )
-            , "Create a chlorine ion at the specified position.\nPar:am position\nThe position of the chlorine ion.\n\nPar:am model\nThe name of the water model.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: chlorine\nThe chlorine ion.\n" );
-    
+
+        typedef ::SireMol::Molecule (*createChlorineIon_function_type)(::SireMaths::Vector const &, ::QString const, ::SireBase::PropertyMap const &);
+        createChlorineIon_function_type createChlorineIon_function_value(&::SireIO::createChlorineIon);
+
+        bp::def(
+            "createChlorineIon", createChlorineIon_function_value, (bp::arg("coords"), bp::arg("model"), bp::arg("map") = SireBase::PropertyMap()), "Create a chlorine ion at the specified position.\nPar:am position\nThe position of the chlorine ion.\n\nPar:am model\nThe name of the water model.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: chlorine\nThe chlorine ion.\n");
     }
 
     { //::SireIO::createSodiumIon
-    
-        typedef ::SireMol::Molecule ( *createSodiumIon_function_type )( ::SireMaths::Vector const &,::QString const,::SireBase::PropertyMap const & );
-        createSodiumIon_function_type createSodiumIon_function_value( &::SireIO::createSodiumIon );
-        
-        bp::def( 
-            "createSodiumIon"
-            , createSodiumIon_function_value
-            , ( bp::arg("coords"), bp::arg("model"), bp::arg("map")=SireBase::PropertyMap() )
-            , "Create a sodium ion at the specified position.\nPar:am position\nThe position of the sodium ion.\n\nPar:am model\nThe name of the water model.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: sodium\nThe sodium ion.\n" );
-    
+
+        typedef ::SireMol::Molecule (*createSodiumIon_function_type)(::SireMaths::Vector const &, ::QString const, ::SireBase::PropertyMap const &);
+        createSodiumIon_function_type createSodiumIon_function_value(&::SireIO::createSodiumIon);
+
+        bp::def(
+            "createSodiumIon", createSodiumIon_function_value, (bp::arg("coords"), bp::arg("model"), bp::arg("map") = SireBase::PropertyMap()), "Create a sodium ion at the specified position.\nPar:am position\nThe position of the sodium ion.\n\nPar:am model\nThe name of the water model.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: sodium\nThe sodium ion.\n");
     }
 
     { //::SireIO::getCoordsArray
-    
-        typedef ::QVector< float > ( *getCoordsArray_function_type )( ::SireMol::MoleculeView const &,::SireUnits::Dimension::Length const &,::SireBase::PropertyMap const & );
-        getCoordsArray_function_type getCoordsArray_function_value( &::SireIO::getCoordsArray );
-        
-        bp::def( 
-            "getCoordsArray"
-            , getCoordsArray_function_value
-            , ( bp::arg("mol"), bp::arg("to_unit"), bp::arg("map") )
-            , "" );
-    
+
+        typedef ::QVector<float> (*getCoordsArray_function_type)(::SireMol::MoleculeView const &, ::SireUnits::Dimension::Length const &, ::SireBase::PropertyMap const &);
+        getCoordsArray_function_type getCoordsArray_function_value(&::SireIO::getCoordsArray);
+
+        bp::def(
+            "getCoordsArray", getCoordsArray_function_value, (bp::arg("mol"), bp::arg("to_unit"), bp::arg("map")), "");
     }
 
     { //::SireIO::getCoordsArray
-    
-        typedef ::QVector< float > ( *getCoordsArray_function_type )( ::SireMol::MoleculeGroup const &,::SireUnits::Dimension::Length const &,::SireBase::PropertyMap const & );
-        getCoordsArray_function_type getCoordsArray_function_value( &::SireIO::getCoordsArray );
-        
-        bp::def( 
-            "getCoordsArray"
-            , getCoordsArray_function_value
-            , ( bp::arg("mols"), bp::arg("to_unit"), bp::arg("map") )
-            , "" );
-    
+
+        typedef ::QVector<float> (*getCoordsArray_function_type)(::SireMol::MoleculeGroup const &, ::SireUnits::Dimension::Length const &, ::SireBase::PropertyMap const &);
+        getCoordsArray_function_type getCoordsArray_function_value(&::SireIO::getCoordsArray);
+
+        bp::def(
+            "getCoordsArray", getCoordsArray_function_value, (bp::arg("mols"), bp::arg("to_unit"), bp::arg("map")), "");
     }
 
     { //::SireIO::getCoordsArray
-    
-        typedef ::QVector< float > ( *getCoordsArray_function_type )( ::SireSystem::System const &,::SireUnits::Dimension::Length const &,::SireBase::PropertyMap const & );
-        getCoordsArray_function_type getCoordsArray_function_value( &::SireIO::getCoordsArray );
-        
-        bp::def( 
-            "getCoordsArray"
-            , getCoordsArray_function_value
-            , ( bp::arg("system"), bp::arg("to_unit"), bp::arg("map") )
-            , "" );
-    
+
+        typedef ::QVector<float> (*getCoordsArray_function_type)(::SireSystem::System const &, ::SireUnits::Dimension::Length const &, ::SireBase::PropertyMap const &);
+        getCoordsArray_function_type getCoordsArray_function_value(&::SireIO::getCoordsArray);
+
+        bp::def(
+            "getCoordsArray", getCoordsArray_function_value, (bp::arg("system"), bp::arg("to_unit"), bp::arg("map")), "");
     }
 
     { //::SireIO::isAmberWater
-    
-        typedef bool ( *isAmberWater_function_type )( ::SireMol::Molecule const &,::SireBase::PropertyMap const & );
-        isAmberWater_function_type isAmberWater_function_value( &::SireIO::isAmberWater );
-        
-        bp::def( 
-            "isAmberWater"
-            , isAmberWater_function_value
-            , ( bp::arg("molecule"), bp::arg("map")=SireBase::PropertyMap() )
-            , "Test whether the passed water molecule matches standard AMBER\nformat water topologies.\n\nPar:am molecule\nThe molecule to test.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: is_water\nWhether the molecule is an AMBER format water.\n" );
-    
+
+        typedef bool (*isAmberWater_function_type)(::SireMol::Molecule const &, ::SireBase::PropertyMap const &);
+        isAmberWater_function_type isAmberWater_function_value(&::SireIO::isAmberWater);
+
+        bp::def(
+            "isAmberWater", isAmberWater_function_value, (bp::arg("molecule"), bp::arg("map") = SireBase::PropertyMap()), "Test whether the passed water molecule matches standard AMBER\nformat water topologies.\n\nPar:am molecule\nThe molecule to test.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: is_water\nWhether the molecule is an AMBER format water.\n");
     }
 
     { //::SireIO::isGromacsWater
-    
-        typedef bool ( *isGromacsWater_function_type )( ::SireMol::Molecule const &,::SireBase::PropertyMap const & );
-        isGromacsWater_function_type isGromacsWater_function_value( &::SireIO::isGromacsWater );
-        
-        bp::def( 
-            "isGromacsWater"
-            , isGromacsWater_function_value
-            , ( bp::arg("molecule"), bp::arg("map")=SireBase::PropertyMap() )
-            , "Test whether the passed water molecule matches standard GROMACS\nformat water topologies.\n\nPar:am molecule\nThe molecule to test.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: is_water\nWhether the molecule is a GROMACS format water.\n" );
-    
+
+        typedef bool (*isGromacsWater_function_type)(::SireMol::Molecule const &, ::SireBase::PropertyMap const &);
+        isGromacsWater_function_type isGromacsWater_function_value(&::SireIO::isGromacsWater);
+
+        bp::def(
+            "isGromacsWater", isGromacsWater_function_value, (bp::arg("molecule"), bp::arg("map") = SireBase::PropertyMap()), "Test whether the passed water molecule matches standard GROMACS\nformat water topologies.\n\nPar:am molecule\nThe molecule to test.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: is_water\nWhether the molecule is a GROMACS format water.\n");
     }
 
     { //::SireIO::isWater
-    
-        typedef bool ( *isWater_function_type )( ::SireMol::Molecule const &,::SireBase::PropertyMap const & );
-        isWater_function_type isWater_function_value( &::SireIO::isWater );
-        
-        bp::def( 
-            "isWater"
-            , isWater_function_value
-            , ( bp::arg("molecule"), bp::arg("map")=SireBase::PropertyMap() )
-            , "Test whether the passed water molecule matches standard water\ntopologies.\n\nPar:am molecule\nThe molecule to test.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: is_water\nWhether the molecule is a water.\n" );
-    
+
+        typedef bool (*isWater_function_type)(::SireMol::Molecule const &, ::SireBase::PropertyMap const &);
+        isWater_function_type isWater_function_value(&::SireIO::isWater);
+
+        bp::def(
+            "isWater", isWater_function_value, (bp::arg("molecule"), bp::arg("map") = SireBase::PropertyMap()), "Test whether the passed water molecule matches standard water\ntopologies.\n\nPar:am molecule\nThe molecule to test.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: is_water\nWhether the molecule is a water.\n");
     }
 
     { //::SireIO::removeProperty
-    
-        typedef ::SireSystem::System ( *removeProperty_function_type )( ::SireSystem::System &,::QString const & );
-        removeProperty_function_type removeProperty_function_value( &::SireIO::removeProperty );
-        
-        bp::def( 
-            "removeProperty"
-            , removeProperty_function_value
-            , ( bp::arg("system"), bp::arg("property") )
-            , "Remove a named property from all molecules in a system.\n\nPar:am system\nThe molecular system of interest.\n\nPar:am property\nThe name of the property to be removed.\n\nRetval: system\nThe system with renumbered constituents.\n" );
-    
+
+        typedef ::SireSystem::System (*removeProperty_function_type)(::SireSystem::System &, ::QString const &);
+        removeProperty_function_type removeProperty_function_value(&::SireIO::removeProperty);
+
+        bp::def(
+            "removeProperty", removeProperty_function_value, (bp::arg("system"), bp::arg("property")), "Remove a named property from all molecules in a system.\n\nPar:am system\nThe molecular system of interest.\n\nPar:am property\nThe name of the property to be removed.\n\nRetval: system\nThe system with renumbered constituents.\n");
     }
 
     { //::SireIO::renumberConstituents
-    
-        typedef ::SireSystem::System ( *renumberConstituents_function_type )( ::SireSystem::System const &,unsigned int );
-        renumberConstituents_function_type renumberConstituents_function_value( &::SireIO::renumberConstituents );
-        
-        bp::def( 
-            "renumberConstituents"
-            , renumberConstituents_function_value
-            , ( bp::arg("system"), bp::arg("mol_offset")=(unsigned int)(0) )
-            , "Renumber the constituents of a system (residues and atoms) so that\nthey are unique and are in ascending order.\n\nPar:am system\nThe molecular system of interest.\n\nPar:am mol_offset\nThe index of the molecule at which to begin renumbering.\n\nRetval: system\nThe system with renumbered constituents.\n" );
-    
+
+        typedef ::SireSystem::System (*renumberConstituents_function_type)(::SireSystem::System const &, unsigned int);
+        renumberConstituents_function_type renumberConstituents_function_value(&::SireIO::renumberConstituents);
+
+        bp::def(
+            "renumberConstituents", renumberConstituents_function_value, (bp::arg("system"), bp::arg("mol_offset") = (unsigned int)(0)), "Renumber the constituents of a system (residues and atoms) so that\nthey are unique and are in ascending order.\n\nPar:am system\nThe molecular system of interest.\n\nPar:am mol_offset\nThe index of the molecule at which to begin renumbering.\n\nRetval: system\nThe system with renumbered constituents.\n");
     }
 
     { //::SireIO::repartitionHydrogenMass
-    
-        typedef ::SireSystem::System ( *repartitionHydrogenMass_function_type )( ::SireSystem::System const &,double const,unsigned int const,::SireBase::PropertyMap const & );
-        repartitionHydrogenMass_function_type repartitionHydrogenMass_function_value( &::SireIO::repartitionHydrogenMass );
-        
-        bp::def( 
-            "repartitionHydrogenMass"
-            , repartitionHydrogenMass_function_value
-            , ( bp::arg("system"), bp::arg("factor")=4, bp::arg("water")=(unsigned int const)(0), bp::arg("map")=SireBase::PropertyMap() )
-            , "Redistribute mass of heavy atoms connected to bonded hydrogens into\nthe hydrogen atoms. This allows use of larger simulation integration\ntime steps without encountering instabilities related to high-frequency\nhydrogen motion.\n\nPar:am system\nThe molecular system of interest.\n\nPar:am factor\nThe repartitioning scale factor. Hydrogen masses are scaled by\nthis amount.\n\nPar:am water\nWhether to repartiotion masses for water molecules:\n0 = yes, 1 = no, 2 = only water molecules.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: system\nThe system with repartitioned hydrogen mass.\n" );
-    
+
+        typedef ::SireSystem::System (*repartitionHydrogenMass_function_type)(::SireSystem::System const &, double const, unsigned int const, ::SireBase::PropertyMap const &);
+        repartitionHydrogenMass_function_type repartitionHydrogenMass_function_value(&::SireIO::repartitionHydrogenMass);
+
+        bp::def(
+            "repartitionHydrogenMass", repartitionHydrogenMass_function_value, (bp::arg("system"), bp::arg("factor") = 4, bp::arg("water") = (unsigned int const)(0), bp::arg("map") = SireBase::PropertyMap()), "Redistribute mass of heavy atoms connected to bonded hydrogens into\nthe hydrogen atoms. This allows use of larger simulation integration\ntime steps without encountering instabilities related to high-frequency\nhydrogen motion.\n\nPar:am system\nThe molecular system of interest.\n\nPar:am factor\nThe repartitioning scale factor. Hydrogen masses are scaled by\nthis amount.\n\nPar:am water\nWhether to repartiotion masses for water molecules:\n0 = yes, 1 = no, 2 = only water molecules.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: system\nThe system with repartitioned hydrogen mass.\n");
     }
 
     { //::SireIO::repartitionHydrogenMass
-    
-        typedef ::SireMol::Molecule ( *repartitionHydrogenMass_function_type )( ::SireMol::Molecule &,double const,unsigned int const,::SireBase::PropertyMap const & );
-        repartitionHydrogenMass_function_type repartitionHydrogenMass_function_value( &::SireIO::repartitionHydrogenMass );
-        
-        bp::def( 
-            "repartitionHydrogenMass"
-            , repartitionHydrogenMass_function_value
-            , ( bp::arg("molecule"), bp::arg("factor")=4, bp::arg("water")=(unsigned int const)(0), bp::arg("map")=SireBase::PropertyMap() )
-            , "Redistribute mass of heavy atoms connected to bonded hydrogens into\nthe hydrogen atoms. This allows use of larger simulation integration\ntime steps without encountering instabilities related to high-frequency\nhydrogen motion.\n\nPar:am molecule\nThe molecule of interest.\n\nPar:am factor\nThe repartitioning scale factor. Hydrogen masses are scaled by\nthis amount.\n\nPar:am water\nWhether to repartiotion masses for water molecules:\n0 = yes, 1 = no, 2 = only water molecules.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: system\nThe system with repartitioned hydrogen mass.\n" );
-    
+
+        typedef ::SireMol::Molecule (*repartitionHydrogenMass_function_type)(::SireMol::Molecule &, double const, unsigned int const, ::SireBase::PropertyMap const &);
+        repartitionHydrogenMass_function_type repartitionHydrogenMass_function_value(&::SireIO::repartitionHydrogenMass);
+
+        bp::def(
+            "repartitionHydrogenMass", repartitionHydrogenMass_function_value, (bp::arg("molecule"), bp::arg("factor") = 4, bp::arg("water") = (unsigned int const)(0), bp::arg("map") = SireBase::PropertyMap()), "Redistribute mass of heavy atoms connected to bonded hydrogens into\nthe hydrogen atoms. This allows use of larger simulation integration\ntime steps without encountering instabilities related to high-frequency\nhydrogen motion.\n\nPar:am molecule\nThe molecule of interest.\n\nPar:am factor\nThe repartitioning scale factor. Hydrogen masses are scaled by\nthis amount.\n\nPar:am water\nWhether to repartiotion masses for water molecules:\n0 = yes, 1 = no, 2 = only water molecules.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: system\nThe system with repartitioned hydrogen mass.\n");
     }
 
     { //::SireIO::setAmberWater
-    
-        typedef ::SireSystem::System ( *setAmberWater_function_type )( ::SireSystem::System const &,::QString const &,::SireBase::PropertyMap const & );
-        setAmberWater_function_type setAmberWater_function_value( &::SireIO::setAmberWater );
-        
-        bp::def( 
-            "setAmberWater"
-            , setAmberWater_function_value
-            , ( bp::arg("system"), bp::arg("model"), bp::arg("map")=SireBase::PropertyMap() )
-            , "Set all water molecules in the passed system to the appropriate AMBER\nformat topology.\n\nPar:am system\nThe molecular system of interest.\n\nPar:am model\nThe name of the water model.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: system\nThe system with updated water topology.\n" );
-    
+
+        typedef ::SireSystem::System (*setAmberWater_function_type)(::SireSystem::System const &, ::QString const &, ::SireBase::PropertyMap const &);
+        setAmberWater_function_type setAmberWater_function_value(&::SireIO::setAmberWater);
+
+        bp::def(
+            "setAmberWater", setAmberWater_function_value, (bp::arg("system"), bp::arg("model"), bp::arg("map") = SireBase::PropertyMap()), "Set all water molecules in the passed system to the appropriate AMBER\nformat topology.\n\nPar:am system\nThe molecular system of interest.\n\nPar:am model\nThe name of the water model.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: system\nThe system with updated water topology.\n");
     }
 
     { //::SireIO::setAmberWater
-    
-        typedef ::SireMol::SelectResult ( *setAmberWater_function_type )( ::SireMol::SelectResult const &,::QString const &,::SireBase::PropertyMap const & );
-        setAmberWater_function_type setAmberWater_function_value( &::SireIO::setAmberWater );
-        
-        bp::def( 
-            "setAmberWater"
-            , setAmberWater_function_value
-            , ( bp::arg("molecules"), bp::arg("model"), bp::arg("map")=SireBase::PropertyMap() )
-            , "Set all water molecules in the passed system to the appropriate AMBER\nformat topology.\n\nPar:am system\nThe molecular system of interest.\n\nPar:am model\nThe name of the water model.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: system\nThe system with updated water topology.\n" );
-    
+
+        typedef ::SireMol::SelectResult (*setAmberWater_function_type)(::SireMol::SelectResult const &, ::QString const &, ::SireBase::PropertyMap const &);
+        setAmberWater_function_type setAmberWater_function_value(&::SireIO::setAmberWater);
+
+        bp::def(
+            "setAmberWater", setAmberWater_function_value, (bp::arg("molecules"), bp::arg("model"), bp::arg("map") = SireBase::PropertyMap()), "Set all water molecules in the passed system to the appropriate AMBER\nformat topology.\n\nPar:am system\nThe molecular system of interest.\n\nPar:am model\nThe name of the water model.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: system\nThe system with updated water topology.\n");
     }
 
     { //::SireIO::setCoordinates
-    
-        typedef ::SireSystem::System ( *setCoordinates_function_type )( ::SireSystem::System,::QVector<QVector<float>> const &,bool const,::SireBase::PropertyMap const & );
-        setCoordinates_function_type setCoordinates_function_value( &::SireIO::setCoordinates );
-        
-        bp::def( 
-            "setCoordinates"
-            , setCoordinates_function_value
-            , ( bp::arg("system"), bp::arg("coordinates"), bp::arg("is_lambda1")=(bool const)(false), bp::arg("map")=SireBase::PropertyMap() )
-            , "Set the coordinates of the entire system.\nPar:am system\nThe molecular system of interest.\n\nPar:am coordinates\nThe new coordinates for the system.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: system\nThe system with updated coordinates.\n" );
-    
+
+        typedef ::SireSystem::System (*setCoordinates_function_type)(::SireSystem::System, ::QVector<QVector<float>> const &, bool const, ::SireBase::PropertyMap const &);
+        setCoordinates_function_type setCoordinates_function_value(&::SireIO::setCoordinates);
+
+        bp::def(
+            "setCoordinates", setCoordinates_function_value, (bp::arg("system"), bp::arg("coordinates"), bp::arg("is_lambda1") = (bool const)(false), bp::arg("map") = SireBase::PropertyMap()), "Set the coordinates of the entire system.\nPar:am system\nThe molecular system of interest.\n\nPar:am coordinates\nThe new coordinates for the system.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: system\nThe system with updated coordinates.\n");
     }
 
     { //::SireIO::setGromacsWater
-    
-        typedef ::SireSystem::System ( *setGromacsWater_function_type )( ::SireSystem::System const &,::QString const &,::SireBase::PropertyMap const &,bool );
-        setGromacsWater_function_type setGromacsWater_function_value( &::SireIO::setGromacsWater );
-        
-        bp::def( 
-            "setGromacsWater"
-            , setGromacsWater_function_value
-            , ( bp::arg("system"), bp::arg("model"), bp::arg("map")=SireBase::PropertyMap(), bp::arg("is_crystal")=(bool)(false) )
-            , "Set all water molecules in the passed system to the appropriate GROMACS\nformat topology.\n\nPar:am system\nThe molecular system of interest.\n\nPar:am model\nThe name of the water model.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nPar:am is_crystal\nWhether this is a crystal water molecule. If true, then the molecule\nand residue name will be set to XTL rather than SOL.\n\nRetval: system\nThe system with updated water topology.\n" );
-    
+
+        typedef ::SireSystem::System (*setGromacsWater_function_type)(::SireSystem::System const &, ::QString const &, ::SireBase::PropertyMap const &, bool);
+        setGromacsWater_function_type setGromacsWater_function_value(&::SireIO::setGromacsWater);
+
+        bp::def(
+            "setGromacsWater", setGromacsWater_function_value, (bp::arg("system"), bp::arg("model"), bp::arg("map") = SireBase::PropertyMap(), bp::arg("is_crystal") = (bool)(false)), "Set all water molecules in the passed system to the appropriate GROMACS\nformat topology.\n\nPar:am system\nThe molecular system of interest.\n\nPar:am model\nThe name of the water model.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nPar:am is_crystal\nWhether this is a crystal water molecule. If true, then the molecule\nand residue name will be set to XTL rather than SOL.\n\nRetval: system\nThe system with updated water topology.\n");
     }
 
     { //::SireIO::setGromacsWater
-    
-        typedef ::SireMol::SelectResult ( *setGromacsWater_function_type )( ::SireMol::SelectResult const &,::QString const &,::SireBase::PropertyMap const & );
-        setGromacsWater_function_type setGromacsWater_function_value( &::SireIO::setGromacsWater );
-        
-        bp::def( 
-            "setGromacsWater"
-            , setGromacsWater_function_value
-            , ( bp::arg("molecules"), bp::arg("model"), bp::arg("map")=SireBase::PropertyMap() )
-            , "Set all water molecules in the passed system to the appropriate GROMACS\nformat topology.\n\nPar:am system\nThe molecular system of interest.\n\nPar:am model\nThe name of the water model.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: system\nThe system with updated water topology.\n\n" );
-    
+
+        typedef ::SireMol::SelectResult (*setGromacsWater_function_type)(::SireMol::SelectResult const &, ::QString const &, ::SireBase::PropertyMap const &);
+        setGromacsWater_function_type setGromacsWater_function_value(&::SireIO::setGromacsWater);
+
+        bp::def(
+            "setGromacsWater", setGromacsWater_function_value, (bp::arg("molecules"), bp::arg("model"), bp::arg("map") = SireBase::PropertyMap()), "Set all water molecules in the passed system to the appropriate GROMACS\nformat topology.\n\nPar:am system\nThe molecular system of interest.\n\nPar:am model\nThe name of the water model.\n\nPar:am map\nA dictionary of user-defined molecular property names.\n\nRetval: system\nThe system with updated water topology.\n\n");
     }
 
     { //::SireIO::updateAndPreserveOrder
-    
-        typedef ::SireSystem::System ( *updateAndPreserveOrder_function_type )( ::SireSystem::System const &,::SireMol::Molecule const &,unsigned int );
-        updateAndPreserveOrder_function_type updateAndPreserveOrder_function_value( &::SireIO::updateAndPreserveOrder );
-        
-        bp::def( 
-            "updateAndPreserveOrder"
-            , updateAndPreserveOrder_function_value
-            , ( bp::arg("system"), bp::arg("molecule"), bp::arg("index") )
-            , "Update a molecule in the system with a different UUID while\npreserving the molecular ordering. Normally we would need to\ndelete and re-add the molecule, which would place it at the\nend, even if the MolNum was unchanged.\n\nPar:am system\nThe molecular system of interest.\n\nPar:am molecule\nThe updated molecule.\n\nPar:am index\nThe index of the molecule in the system.\n\nRetval: system\nThe system with renumbered constituents.\n" );
-    
-    }
 
-    { //::SireIO::updateCoordinatesAndVelocities
-    
-        typedef ::boost::tuples::tuple< SireSystem::System, QHash< SireMol::MolIdx, SireMol::MolIdx >, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type > ( *updateCoordinatesAndVelocities_function_type )( ::SireSystem::System const &,::SireSystem::System const &,::QHash< SireMol::MolIdx, SireMol::MolIdx > const &,bool const,::SireBase::PropertyMap const &,::SireBase::PropertyMap const & );
-        updateCoordinatesAndVelocities_function_type updateCoordinatesAndVelocities_function_value( &::SireIO::updateCoordinatesAndVelocities );
-        
-        bp::def( 
-            "updateCoordinatesAndVelocities"
-            , updateCoordinatesAndVelocities_function_value
-            , ( bp::arg("system0"), bp::arg("system1"), bp::arg("molecule_mapping"), bp::arg("is_lambda1")=(bool const)(false), bp::arg("map0")=SireBase::PropertyMap(), bp::arg("map1")=SireBase::PropertyMap() )
-            , "Update the coordinates and velocities of system0 with those from\nsystem1.\nPar:am system0\nThe reference system.\nPar:am system1\nThe updated system, where molecules may not be in the same order.\nPar:am map0\nA dictionary of user-defined molecular property names for system0.\nPar:am map1\nA dictionary of user-defined molecular property names for system1.\nRetval: system, mapping\nThe system with updated coordinates and velocities and a mapping\nbetween the molecule indices in both systems.\n" );
-    
-    }
-
-    { //::SireIO::updateCoordinatesAndVelocities
-
-        typedef ::boost::tuples::tuple< SireSystem::System, QHash< SireMol::MolIdx, SireMol::MolIdx >, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type > ( *updateCoordinatesAndVelocities_function_type )( ::SireSystem::System const &,::SireSystem::System const &,::SireSystem::System const &,::QHash< SireMol::MolIdx, SireMol::MolIdx > const &,bool const,::SireBase::PropertyMap const &,::SireBase::PropertyMap const & );
-        updateCoordinatesAndVelocities_function_type updateCoordinatesAndVelocities_function_value( &::SireIO::updateCoordinatesAndVelocities );
+        typedef ::SireSystem::System (*updateAndPreserveOrder_function_type)(::SireSystem::System const &, ::SireMol::Molecule const &, unsigned int);
+        updateAndPreserveOrder_function_type updateAndPreserveOrder_function_value(&::SireIO::updateAndPreserveOrder);
 
         bp::def(
-            "updateCoordinatesAndVelocities"
-            , updateCoordinatesAndVelocities_function_value
-            , ( bp::arg("original_system"), bp::arg("renumbered_system"), bp::arg("updated_system"), bp::arg("molecule_mapping"), bp::arg("is_lambda1")=(bool const)(false), bp::arg("map0")=SireBase::PropertyMap(), bp::arg("map1")=SireBase::PropertyMap() )
-            , "Update the coordinates and velocities of original_system with those from\nupdated_system.\n\nPar:am system_original\nThe original system.\n\nPar:am system_renumbered\nThe original system, atoms and residues have been renumbered to be\nunique and in ascending order.\n\nPar:am system_updated\nThe updated system, where molecules may not be in the same order.\n\nPar:am map0\nA dictionary of user-defined molecular property names for system0.\n\nPar:am map1\nA dictionary of user-defined molecular property names for system1.\n\nRetval: system, mapping\nThe system with updated coordinates and velocities and a mapping\nbetween the molecule indices in both systems.\n" );
+            "updateAndPreserveOrder", updateAndPreserveOrder_function_value, (bp::arg("system"), bp::arg("molecule"), bp::arg("index")), "Update a molecule in the system with a different UUID while\npreserving the molecular ordering. Normally we would need to\ndelete and re-add the molecule, which would place it at the\nend, even if the MolNum was unchanged.\n\nPar:am system\nThe molecular system of interest.\n\nPar:am molecule\nThe updated molecule.\n\nPar:am index\nThe index of the molecule in the system.\n\nRetval: system\nThe system with renumbered constituents.\n");
+    }
 
+    { //::SireIO::updateCoordinatesAndVelocities
+
+        typedef ::boost::tuples::tuple<SireSystem::System, QHash<SireMol::MolIdx, SireMol::MolIdx>, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type> (*updateCoordinatesAndVelocities_function_type)(::SireSystem::System const &, ::SireSystem::System const &, ::QHash<SireMol::MolIdx, SireMol::MolIdx> const &, bool const, ::SireBase::PropertyMap const &, ::SireBase::PropertyMap const &);
+        updateCoordinatesAndVelocities_function_type updateCoordinatesAndVelocities_function_value(&::SireIO::updateCoordinatesAndVelocities);
+
+        bp::def(
+            "updateCoordinatesAndVelocities", updateCoordinatesAndVelocities_function_value, (bp::arg("system0"), bp::arg("system1"), bp::arg("molecule_mapping"), bp::arg("is_lambda1") = (bool const)(false), bp::arg("map0") = SireBase::PropertyMap(), bp::arg("map1") = SireBase::PropertyMap()), "Update the coordinates and velocities of system0 with those from\nsystem1.\nPar:am system0\nThe reference system.\nPar:am system1\nThe updated system, where molecules may not be in the same order.\nPar:am map0\nA dictionary of user-defined molecular property names for system0.\nPar:am map1\nA dictionary of user-defined molecular property names for system1.\nRetval: system, mapping\nThe system with updated coordinates and velocities and a mapping\nbetween the molecule indices in both systems.\n");
+    }
+
+    { //::SireIO::updateCoordinatesAndVelocities
+
+        typedef ::boost::tuples::tuple<SireSystem::System, QHash<SireMol::MolIdx, SireMol::MolIdx>, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type, boost::tuples::null_type> (*updateCoordinatesAndVelocities_function_type)(::SireSystem::System const &, ::SireSystem::System const &, ::SireSystem::System const &, ::QHash<SireMol::MolIdx, SireMol::MolIdx> const &, bool const, ::SireBase::PropertyMap const &, ::SireBase::PropertyMap const &);
+        updateCoordinatesAndVelocities_function_type updateCoordinatesAndVelocities_function_value(&::SireIO::updateCoordinatesAndVelocities);
+
+        bp::def(
+            "updateCoordinatesAndVelocities", updateCoordinatesAndVelocities_function_value, (bp::arg("original_system"), bp::arg("renumbered_system"), bp::arg("updated_system"), bp::arg("molecule_mapping"), bp::arg("is_lambda1") = (bool const)(false), bp::arg("map0") = SireBase::PropertyMap(), bp::arg("map1") = SireBase::PropertyMap()), "Update the coordinates and velocities of original_system with those from\nupdated_system.\n\nPar:am system_original\nThe original system.\n\nPar:am system_renumbered\nThe original system, atoms and residues have been renumbered to be\nunique and in ascending order.\n\nPar:am system_updated\nThe updated system, where molecules may not be in the same order.\n\nPar:am map0\nA dictionary of user-defined molecular property names for system0.\n\nPar:am map1\nA dictionary of user-defined molecular property names for system1.\n\nRetval: system, mapping\nThe system with updated coordinates and velocities and a mapping\nbetween the molecule indices in both systems.\n");
     }
 
     { //::SireIO::mergeIntrascale
 
-        typedef ::SireBase::PropertyList ( *mergeIntrascale_function_type )(
+        typedef ::SireBase::PropertyList (*mergeIntrascale_function_type)(
             ::SireMM::CLJNBPairs const &,
             ::SireMM::CLJNBPairs const &,
-            ::SireMol::MoleculeInfoData const &,
-            ::QHash< SireMol::AtomIdx, SireMol::AtomIdx > const &,
-            ::QHash< SireMol::AtomIdx, SireMol::AtomIdx > const & );
-        mergeIntrascale_function_type mergeIntrascale_function_value( &::SireIO::mergeIntrascale );
+            ::SireMol::Connectivity const &,
+            ::SireMol::Connectivity const &,
+            ::SireMM::CLJScaleFactor const &,
+            ::QHash<SireMol::AtomIdx, SireMol::AtomIdx> const &,
+            ::QHash<SireMol::AtomIdx, SireMol::AtomIdx> const &);
+        mergeIntrascale_function_type mergeIntrascale_function_value(&::SireIO::mergeIntrascale);
 
         bp::def(
-            "mergeIntrascale"
-            , mergeIntrascale_function_value
-            , ( bp::arg("nb0"), bp::arg("nb1"), bp::arg("merged_info"),
-                bp::arg("mol0_merged_mapping"), bp::arg("mol1_merged_mapping") )
-            , "Merge the CLJNBPairs (intrascale) of two molecules into the end-state\n"
-              "intrascales of a perturbable merged molecule.\n"
-              "\n"
-              "Uses a two-pass approach to correctly preserve actual per-pair scale factors\n"
-              "(including GLYCAM funct=2 overrides of 1.0/1.0) without relying on global\n"
-              "forcefield scale factors. For intrascale0, nb1 is copied first (so ghost\n"
-              "atoms from mol1 get correct exclusions), then nb0 overwrites (so mapped and\n"
-              "mol0-unique atoms get correct state-0 values). intrascale1 is built with the\n"
-              "same logic in reverse.\n"
-              "\n"
-              "Returns a PropertyList [intrascale0, intrascale1].\n" );
-
+            "mergeIntrascale", mergeIntrascale_function_value, (bp::arg("nb0"), bp::arg("nb1"), bp::arg("conn0"), bp::arg("conn1"), bp::arg("sf14"), bp::arg("mol0_merged_mapping"), bp::arg("mol1_merged_mapping")), "Merge the CLJNBPairs (intrascale) of two molecules into the end-state\n"
+                                                                                                                                                                                                                      "intrascales of a perturbable merged molecule.\n"
+                                                                                                                                                                                                                      "\n"
+                                                                                                                                                                                                                      "Builds each merged intrascale from the per-state merged connectivity\n"
+                                                                                                                                                                                                                      "(conn0/conn1) so that bonded distances — including paths created by\n"
+                                                                                                                                                                                                                      "ring-closure bonds — are correctly captured in the merged atom space.\n"
+                                                                                                                                                                                                                      "Per-pair scale factors from nb0/nb1 are then applied as overrides, so\n"
+                                                                                                                                                                                                                      "that non-default values (e.g. GLYCAM funct=2 (1,1) instead of global\n"
+                                                                                                                                                                                                                      "sf14) are preserved.\n"
+                                                                                                                                                                                                                      "\n"
+                                                                                                                                                                                                                      "Returns a PropertyList [intrascale0, intrascale1].\n");
     }
-
 }


### PR DESCRIPTION
Fixes a bug in `SireIO::mergeIntrascale` where the merged intrascale matrices were built by copying per-pair scale factors from the individual molecule `CLJNBPairs` objects (nb0/nb1) using atom index mappings. This failed for ring-breaking perturbations because the individual molecule `CLJNBPairs` are computed in each molecule's own atom numbering, so the ring-closure bond, which creates short bonded paths (1-4, excluded) in the merged topology, is not reflected in either molecule's own `CLJNBPairs`: in the ring molecule's space, the corresponding atom pair is simply far apart (≥1-5, fully interacting). The fix builds the base `CLJNBPairs` directly from the per-state merged connectivity objects (as in the old Python code) (conn0/conn1) using `CLJNBPairs(conn, sf14)`, which correctly captures all bonded distances in the merged atom space, then applies per-pair overrides from nb0/nb1 only where they differ from the base; preserving non-default scale factors such as GLYCAM funct=2 (1,1) overrides. The function signature changes to accept conn0, conn1, and sf14 in place of merged_info, with the call site in BioSimSpace updated accordingly.


* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]