### PR TITLE
Fix issue #437

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -62,6 +62,10 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
   raising a ``KeyError``. Out-of-bounds positive and negative single-index values now
   behave consistently with ``residx`` and ``atomidx``.
 
+* Reassign end-state mass and element properties in the ``sire.morph.create_from_pertfile``
+  to undo ``SOMD`` modifications.
+
+
 `2025.4.0 <https://github.com/openbiosim/sire/compare/2025.3.0...2025.4.0>`__ - February 2026
 ---------------------------------------------------------------------------------------------
 

--- a/src/sire/morph/_pertfile.py
+++ b/src/sire/morph/_pertfile.py
@@ -67,6 +67,7 @@ def create_from_pertfile(mol, pertfile, map=None):
     lj_prop = map["LJ"].source()
     typ_prop = map["ambertype"].source()
     elem_prop = map["element"].source()
+    mass_prop = map["mass"].source()
 
     c["charge0"] = c[chg_prop]
     c["charge1"] = c[chg_prop]
@@ -80,6 +81,9 @@ def create_from_pertfile(mol, pertfile, map=None):
     c["element0"] = c[elem_prop]
     c["element1"] = c[elem_prop]
 
+    c["mass0"] = c[mass_prop]
+    c["mass1"] = c[mass_prop]
+
     for atom in c.atoms():
         atomname = atom.name
 
@@ -90,7 +94,7 @@ def create_from_pertfile(mol, pertfile, map=None):
             lj1 = template.get_final_lj(atomname)
             typ0 = template.get_init_type(atomname)
             typ1 = template.get_final_type(atomname)
-        except Exception as e:
+        except Exception:
             continue
 
         atom["charge0"] = q0
@@ -102,7 +106,17 @@ def create_from_pertfile(mol, pertfile, map=None):
         atom["ambertype0"] = typ0
         atom["ambertype1"] = typ1
 
+        # IMPORTANT: The pert file will already include modifications to the element
+        # and mass properties of the end states, i.e. when perturbing, elements are
+        # set to the mass/eelement of the heaviest end state. As such, we need to
+        # infer the element from the ambertype, then reset the mass. This also
+        # removes any existing hydrogen mass repartitioning.
+
+        atom["element0"] = Element.biological_element(typ0)
         atom["element1"] = Element.biological_element(typ1)
+
+        atom["mass0"] = atom["element0"].mass()
+        atom["mass1"] = atom["element1"].mass()
 
     # now update all of the internals
     bond_prop = map["bond"].source()
@@ -259,7 +273,7 @@ def create_from_pertfile(mol, pertfile, map=None):
     c["improper1"] = impropers1
 
     # duplicate unperturbed properties
-    for prop in ["coordinates", "mass", "forcefield", "intrascale"]:
+    for prop in ["coordinates", "forcefield", "intrascale"]:
         orig_prop = map[prop].source()
         c[prop + "0"] = c[orig_prop]
         c[prop + "1"] = c[orig_prop]


### PR DESCRIPTION
This PR closes #437 by reassigning the end-state `mass` and `element` properties in `sire.morph.create_from_pertfile` based on inference using the end-state `ambertype` properties. This is needed in order to reverse the mass and element adjustments that are made on pert file writing, allowing for correct application of HMR by `somd2`. Without this, HMR is both incorrect (since masses are already non-standard) and asymmetric when perturbing hydrogens are present.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
