### PR TITLE
Decouple softcore LJ and Coulomb in ring-break CustomBondForce

### DIFF
--- a/wrapper/Convert/SireOpenMM/lambdalever.cpp
+++ b/wrapper/Convert/SireOpenMM/lambdalever.cpp
@@ -1334,24 +1334,30 @@ double LambdaLever::setLambda(OpenMM::Context &context,
     bool has_changed_dihff = false;
     bool has_changed_cmap = false;
 
-    // Pre-compute ring-break/make kappa values so the per-mol exception update
-    // loop and the later global-parameter block both use the same values.
-    const double rb_kappa = (ring_breaking_ff != nullptr)
-                                ? std::max(0.0, std::min(1.0, this->lambda_schedule.morph(
-                                                                  "ring-break", "kappa", 0.0, 1.0, lambda_value)))
-                                : 0.0;
+    // Pre-compute ring-break/make alpha and coul_kappa values so the per-mol
+    // exception update loop and the later global-parameter block both use the
+    // same values.
     const double rb_alpha = (ring_breaking_ff != nullptr)
                                 ? std::max(0.0, std::min(1.0, this->lambda_schedule.morph(
                                                                   "ring-break", "alpha", 1.0, 0.0, lambda_value)))
-                                : 1.0;
-    const double rm_kappa = (ring_making_ff != nullptr)
-                                ? std::max(0.0, std::min(1.0, this->lambda_schedule.morph(
-                                                                  "ring-make", "kappa", 1.0, 0.0, lambda_value)))
                                 : 1.0;
     const double rm_alpha = (ring_making_ff != nullptr)
                                 ? std::max(0.0, std::min(1.0, this->lambda_schedule.morph(
                                                                   "ring-make", "alpha", 0.0, 1.0, lambda_value)))
                                 : 0.0;
+
+    // coul_kappa levers decouple Coulomb onset from LJ onset: zero during
+    // potential_swap/restraints_off/ring_open, ramps 0→1 in morph only.
+    // This prevents spurious Coulomb attraction when atoms are still at
+    // covalent distances during the ring_open stage.
+    const double rb_coul_kappa = (ring_breaking_ff != nullptr)
+                                     ? std::max(0.0, std::min(1.0, this->lambda_schedule.morph(
+                                                                       "ring-break", "coul_kappa", 0.0, 1.0, lambda_value)))
+                                     : 0.0;
+    const double rm_coul_kappa = (ring_making_ff != nullptr)
+                                     ? std::max(0.0, std::min(1.0, this->lambda_schedule.morph(
+                                                                       "ring-make", "coul_kappa", 1.0, 0.0, lambda_value)))
+                                     : 1.0;
 
     // change the parameters for all of the perturbable molecules
     for (int i = 0; i < this->perturbable_mols.count(); ++i)
@@ -1754,11 +1760,12 @@ double LambdaLever::setLambda(OpenMM::Context &context,
             }
         }
 
-        // Update CLJ exceptions and per-bond q for ring-breaking pairs.
-        // The CLJ exception carries kappa*q_a0(λ)*q_a1(λ) for the hard Coulomb
-        // (including RF/PME long-range). The CustomBondForce per-bond q is kept
-        // in sync so its correction term (softcore - 1/r) uses the same charge
-        // product and cancels the hard contribution exactly at all kappa values.
+        // Update CLJ exceptions for ring-breaking pairs.
+        // The CLJ exception carries coul_kappa*q_a0*q_a1 for the hard Coulomb
+        // (including RF/PME long-range). coul_kappa is zero during
+        // potential_swap/restraints_off/ring_open and ramps 0→1 in morph only,
+        // so Coulomb only activates once the LJ softcore has already separated
+        // the atoms. The CustomBondForce handles softcore LJ only (no q param).
         if (cljff != nullptr and ring_breaking_ff != nullptr)
         {
             const auto rb_exc = perturbable_mol.getExceptionIndicies("ring-break");
@@ -1767,32 +1774,20 @@ double LambdaLever::setLambda(OpenMM::Context &context,
                 const int clj_idx = boost::get<0>(rb_exc[j]);
                 if (clj_idx < 0)
                     continue;
-                const int bond_idx = boost::get<1>(rb_exc[j]);
-                int a0, a1;
-                std::vector<double> bp;
-                ring_breaking_ff->getBondParameters(bond_idx, a0, a1, bp);
-                double q_a0, sig_a0, eps_a0;
-                double q_a1, sig_a1, eps_a1;
-                cljff->getParticleParameters(a0, q_a0, sig_a0, eps_a0);
-                cljff->getParticleParameters(a1, q_a1, sig_a1, eps_a1);
-                const double rb_new_charge = rb_kappa * q_a0 * q_a1;
                 int rb_ea0, rb_ea1;
                 double rb_old_charge, rb_old_sig, rb_old_eps;
                 cljff->getExceptionParameters(clj_idx, rb_ea0, rb_ea1,
                                               rb_old_charge, rb_old_sig, rb_old_eps);
+                double q_a0, sig_a0, eps_a0;
+                double q_a1, sig_a1, eps_a1;
+                cljff->getParticleParameters(rb_ea0, q_a0, sig_a0, eps_a0);
+                cljff->getParticleParameters(rb_ea1, q_a1, sig_a1, eps_a1);
+                const double rb_new_charge = rb_coul_kappa * q_a0 * q_a1;
                 if (rb_new_charge != rb_old_charge)
                 {
-                    cljff->setExceptionParameters(clj_idx, a0, a1,
+                    cljff->setExceptionParameters(clj_idx, rb_ea0, rb_ea1,
                                                   rb_new_charge, 1e-9, 1e-9);
                     has_changed_cljff = true;
-                }
-                // Keep per-bond q in sync with morphed particle charges.
-                const double q_product = (q_a0 * q_a1 == 0.0) ? 1e-9 : q_a0 * q_a1;
-                if (bp[0] != q_product)
-                {
-                    bp[0] = q_product;
-                    ring_breaking_ff->setBondParameters(bond_idx, a0, a1, bp);
-                    has_changed_ring_breaking_ff = true;
                 }
             }
         }
@@ -1805,32 +1800,20 @@ double LambdaLever::setLambda(OpenMM::Context &context,
                 const int clj_idx = boost::get<0>(rm_exc[j]);
                 if (clj_idx < 0)
                     continue;
-                const int bond_idx = boost::get<1>(rm_exc[j]);
-                int a0, a1;
-                std::vector<double> bp;
-                ring_making_ff->getBondParameters(bond_idx, a0, a1, bp);
-                double q_a0, sig_a0, eps_a0;
-                double q_a1, sig_a1, eps_a1;
-                cljff->getParticleParameters(a0, q_a0, sig_a0, eps_a0);
-                cljff->getParticleParameters(a1, q_a1, sig_a1, eps_a1);
-                const double rm_new_charge = rm_kappa * q_a0 * q_a1;
                 int rm_ea0, rm_ea1;
                 double rm_old_charge, rm_old_sig, rm_old_eps;
                 cljff->getExceptionParameters(clj_idx, rm_ea0, rm_ea1,
                                               rm_old_charge, rm_old_sig, rm_old_eps);
+                double q_a0, sig_a0, eps_a0;
+                double q_a1, sig_a1, eps_a1;
+                cljff->getParticleParameters(rm_ea0, q_a0, sig_a0, eps_a0);
+                cljff->getParticleParameters(rm_ea1, q_a1, sig_a1, eps_a1);
+                const double rm_new_charge = rm_coul_kappa * q_a0 * q_a1;
                 if (rm_new_charge != rm_old_charge)
                 {
-                    cljff->setExceptionParameters(clj_idx, a0, a1,
+                    cljff->setExceptionParameters(clj_idx, rm_ea0, rm_ea1,
                                                   rm_new_charge, 1e-9, 1e-9);
                     has_changed_cljff = true;
-                }
-                // Keep per-bond q in sync with morphed particle charges.
-                const double q_product = (q_a0 * q_a1 == 0.0) ? 1e-9 : q_a0 * q_a1;
-                if (bp[0] != q_product)
-                {
-                    bp[0] = q_product;
-                    ring_making_ff->setBondParameters(bond_idx, a0, a1, bp);
-                    has_changed_ring_making_ff = true;
                 }
             }
         }
@@ -2169,19 +2152,15 @@ double LambdaLever::setLambda(OpenMM::Context &context,
     if (ring_breaking_ff != nullptr)
     {
         has_changed_ring_breaking_ff |=
-            (rb_alpha != context.getParameter("ring_break_alpha") ||
-             rb_kappa != context.getParameter("ring_break_kappa"));
+            (rb_alpha != context.getParameter("ring_break_alpha"));
         context.setParameter("ring_break_alpha", rb_alpha);
-        context.setParameter("ring_break_kappa", rb_kappa);
     }
 
     if (ring_making_ff != nullptr)
     {
         has_changed_ring_making_ff |=
-            (rm_alpha != context.getParameter("ring_make_alpha") ||
-             rm_kappa != context.getParameter("ring_make_kappa"));
+            (rm_alpha != context.getParameter("ring_make_alpha"));
         context.setParameter("ring_make_alpha", rm_alpha);
-        context.setParameter("ring_make_kappa", rm_kappa);
     }
 
     if (ring_breaking_ff and has_changed_ring_breaking_ff)

--- a/wrapper/Convert/SireOpenMM/sire_to_openmm_system.cpp
+++ b/wrapper/Convert/SireOpenMM/sire_to_openmm_system.cpp
@@ -1466,107 +1466,89 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
         std::string rb_expression, rm_expression;
         const bool need_rb = any_ring_breaking or any_ring_making;
 
-        // The ring-break/make Coulomb follows the ghost-force correction pattern:
-        // the CLJ exception in NonbondedForce carries kappa*q_a0*q_a1, providing
-        // the full hard Coulomb (including RF/PME long-range) scaled by kappa.
-        // The CustomBondForce applies the short-range correction only:
-        //   kappa * C * q * (softcore(r) - 1/r)
-        // When alpha=0 this is zero (NonbondedForce provides everything); when
-        // alpha>0 the softcore replaces the hard 1/r term at short range.
-        // Using -1/r_safe (not -kappa/r_safe) ensures exact cancellation at all
-        // kappa values, not just at kappa=1.
+        // The ring-break/make CustomBondForce provides only the softcore LJ.
+        // Coulomb is handled separately: the CLJ exception in NonbondedForce
+        // carries coul_kappa*q_a0*q_a1, where coul_kappa is a dedicated schedule
+        // lever that is zero during potential_swap/restraints_off/ring_open and
+        // ramps 0→1 only during the morph stage (where atoms are already separated
+        // by the LJ softcore). Decoupling the Coulomb onset from the LJ onset
+        // avoids spurious attraction when the ring-break pair has opposite partial
+        // charges and the softcore LJ repulsion is still weak.
         if (need_rb and use_beutler_softening)
         {
             rb_expression = QString(
-                                "coul_nrg+lj_nrg;"
-                                "coul_nrg=ring_break_kappa*138.9354558466661*q*((1/sqrt((%1*ring_break_alpha)+r_safe^2))-(1/r_safe));"
+                                "lj_nrg;"
                                 "lj_nrg=(1-ring_break_alpha)*four_epsilon*sig6*(sig6-1);"
-                                "sig6=(sigma^6)/(%2*sigma^6*ring_break_alpha + r_safe^6);"
+                                "sig6=(sigma^6)/(%1*sigma^6*ring_break_alpha + r_safe^6);"
                                 "r_safe=max(r, 0.001);")
-                                .arg(shift_coulomb)
                                 .arg(beutler_alpha)
                                 .toStdString();
             rm_expression = QString(
-                                "coul_nrg+lj_nrg;"
-                                "coul_nrg=ring_make_kappa*138.9354558466661*q*((1/sqrt((%1*ring_make_alpha)+r_safe^2))-(1/r_safe));"
+                                "lj_nrg;"
                                 "lj_nrg=(1-ring_make_alpha)*four_epsilon*sig6*(sig6-1);"
-                                "sig6=(sigma^6)/(%2*sigma^6*ring_make_alpha + r_safe^6);"
+                                "sig6=(sigma^6)/(%1*sigma^6*ring_make_alpha + r_safe^6);"
                                 "r_safe=max(r, 0.001);")
-                                .arg(shift_coulomb)
                                 .arg(beutler_alpha)
                                 .toStdString();
         }
         else if (use_taylor_softening)
         {
             rb_expression = QString(
-                                "coul_nrg+lj_nrg;"
-                                "coul_nrg=ring_break_kappa*138.9354558466661*q*((1/sqrt((%1*ring_break_alpha)+r_safe^2))-(1/r_safe));"
+                                "lj_nrg;"
                                 "lj_nrg=four_epsilon*sig6*(sig6-1);"
-                                "sig6=(sigma^6)/(%2*sigma^6 + r_safe^6);"
+                                "sig6=(sigma^6)/(%1*sigma^6 + r_safe^6);"
                                 "r_safe=max(r, 0.001);")
-                                .arg(shift_coulomb)
                                 .arg(taylor_power_expression("ring_break_alpha", taylor_power))
                                 .toStdString();
             rm_expression = QString(
-                                "coul_nrg+lj_nrg;"
-                                "coul_nrg=ring_make_kappa*138.9354558466661*q*((1/sqrt((%1*ring_make_alpha)+r_safe^2))-(1/r_safe));"
+                                "lj_nrg;"
                                 "lj_nrg=four_epsilon*sig6*(sig6-1);"
-                                "sig6=(sigma^6)/(%2*sigma^6 + r_safe^6);"
+                                "sig6=(sigma^6)/(%1*sigma^6 + r_safe^6);"
                                 "r_safe=max(r, 0.001);")
-                                .arg(shift_coulomb)
                                 .arg(taylor_power_expression("ring_make_alpha", taylor_power))
                                 .toStdString();
         }
         else
         {
             rb_expression = QString(
-                                "coul_nrg+lj_nrg;"
-                                "coul_nrg=ring_break_kappa*138.9354558466661*q*((1/sqrt((%1*ring_break_alpha)+r_safe^2))-(1/r_safe));"
+                                "lj_nrg;"
                                 "lj_nrg=four_epsilon*sig6*(sig6-1);"
                                 "sig6=(sigma^6)/(((sigma*delta)+r_safe^2)^3);"
                                 "r_safe=max(r, 0.001);"
-                                "delta=%2*ring_break_alpha;")
-                                .arg(shift_coulomb)
+                                "delta=%1*ring_break_alpha;")
                                 .arg(shift_delta.to(SireUnits::nanometer))
                                 .toStdString();
             rm_expression = QString(
-                                "coul_nrg+lj_nrg;"
-                                "coul_nrg=ring_make_kappa*138.9354558466661*q*((1/sqrt((%1*ring_make_alpha)+r_safe^2))-(1/r_safe));"
+                                "lj_nrg;"
                                 "lj_nrg=four_epsilon*sig6*(sig6-1);"
                                 "sig6=(sigma^6)/(((sigma*delta)+r_safe^2)^3);"
                                 "r_safe=max(r, 0.001);"
-                                "delta=%2*ring_make_alpha;")
-                                .arg(shift_coulomb)
+                                "delta=%1*ring_make_alpha;")
                                 .arg(shift_delta.to(SireUnits::nanometer))
                                 .toStdString();
         }
 
         // ring_break_alpha=1 initially: fully soft at the bonded (ring-closed)
         // end state so the pair interaction grows from zero as lambda moves into
-        // the morph stage. ring_break_kappa=0 initially: no coulomb contribution
-        // at the bonded end (pair is excluded there).
+        // the morph stage. Coulomb is handled by the CLJ exception (coul_kappa
+        // lever), not per-bond parameters — only sigma and four_epsilon are needed.
         if (any_ring_breaking)
         {
             ring_breaking_ff = new OpenMM::CustomBondForce(rb_expression);
             ring_breaking_ff->setName("RingBreakingBondForce");
             ring_breaking_ff->addGlobalParameter("ring_break_alpha", 1.0);
-            ring_breaking_ff->addGlobalParameter("ring_break_kappa", 0.0);
-            ring_breaking_ff->addPerBondParameter("q");
             ring_breaking_ff->addPerBondParameter("sigma");
             ring_breaking_ff->addPerBondParameter("four_epsilon");
             ring_breaking_ff->setUsesPeriodicBoundaryConditions(false);
         }
 
         // ring_make_alpha=0 initially: hard at the nonbonded (ring-open) end
-        // so the pair interacts normally there. ring_make_kappa=1 initially:
-        // full coulomb at the nonbonded end.
+        // so the pair interacts normally there. Coulomb via CLJ exception only.
         if (any_ring_making)
         {
             ring_making_ff = new OpenMM::CustomBondForce(rm_expression);
             ring_making_ff->setName("RingMakingBondForce");
             ring_making_ff->addGlobalParameter("ring_make_alpha", 0.0);
-            ring_making_ff->addGlobalParameter("ring_make_kappa", 1.0);
-            ring_making_ff->addPerBondParameter("q");
             ring_making_ff->addPerBondParameter("sigma");
             ring_making_ff->addPerBondParameter("four_epsilon");
             ring_making_ff->setUsesPeriodicBoundaryConditions(false);
@@ -2683,20 +2665,19 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
 
                     if (is_ring_breaking and ring_breaking_ff != 0)
                     {
-                        // CLJ parameters from the nonbonded end state (λ=1,
+                        // LJ parameters from the nonbonded end state (λ=1,
                         // perturbed), where the bond is absent and the pair
-                        // interacts normally (full scale factors).
+                        // interacts normally. Coulomb is handled by the CLJ
+                        // exception via the coul_kappa lever in lambdalever.cpp,
+                        // not per-bond parameters.
                         auto pp = mol.perturbed->getException(
                             atom0, atom1, start_index, 1.0, 1.0);
                         std::vector<double> params_rb = {
-                            boost::get<2>(pp),
                             boost::get<3>(pp),
                             4.0 * boost::get<4>(pp)};
                         if (params_rb[0] == 0)
                             params_rb[0] = 1e-9;
-                        if (params_rb[1] == 0)
-                            params_rb[1] = 1e-9;
-                        // Initial kappa=0 for ring-break: charge starts at zero.
+                        // Initial coul_kappa=0 for ring-break: charge starts at zero.
                         // Use 1e-9 to prevent OpenMM from pruning the exception.
                         idx = cljff->addException(boost::get<0>(p), boost::get<1>(p),
                                                   1e-9, 1e-9, 1e-9, true);
@@ -2708,21 +2689,19 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
                     }
                     else if (is_ring_making and ring_making_ff != 0)
                     {
-                        // CLJ parameters from the nonbonded end state (λ=0,
-                        // reference), where the bond is absent.
+                        // LJ parameters from the nonbonded end state (λ=0,
+                        // reference), where the bond is absent. Coulomb is handled
+                        // by the CLJ exception via the coul_kappa lever.
                         auto pp = mol.getException(
                             atom0, atom1, start_index, 1.0, 1.0);
                         std::vector<double> params_rm = {
-                            boost::get<2>(pp),
                             boost::get<3>(pp),
                             4.0 * boost::get<4>(pp)};
                         if (params_rm[0] == 0)
                             params_rm[0] = 1e-9;
-                        if (params_rm[1] == 0)
-                            params_rm[1] = 1e-9;
-                        // Initial kappa=1 for ring-make: charge starts at the full
-                        // state0 charge product so NonbondedForce carries the correct
-                        // hard Coulomb from the very first energy evaluation.
+                        // Initial coul_kappa=1 for ring-make: charge starts at the
+                        // full state0 charge product so the CLJ exception carries the
+                        // correct hard Coulomb from the very first energy evaluation.
                         double init_charge = boost::get<2>(pp);
                         if (init_charge == 0)
                             init_charge = 1e-9;


### PR DESCRIPTION
This PR decouples the ring-break softcore LJ from the Coulomb term. In attempting to drive both via a softcore force you end up with a spurious attraction when the two atoms carry opposite sign, i.e. the Coulomb is stronger than the softcore LJ repulsion. This is tested via the SOMD unit test suite.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
