### PR TITLE
Guard against CustomVolumeForce absence

### DIFF
--- a/wrapper/Convert/SireOpenMM/CMakeLists.txt
+++ b/wrapper/Convert/SireOpenMM/CMakeLists.txt
@@ -30,6 +30,15 @@ if (${SIRE_USE_OPENMM})
     # We're only building against OpenMM 8.1+, so include CustomCPPForce support.
     add_definitions("-DSIRE_USE_CUSTOMCPPFORCE")
 
+    # CustomVolumeForce was introduced in OpenMM 8.3. Guard its use so that
+    # older versions can still build (LJ dispersion correction will be unavailable).
+    if(EXISTS "${OpenMM_INCLUDE_DIR}/openmm/CustomVolumeForce.h")
+        message(STATUS "OpenMM CustomVolumeForce found - LJ dispersion correction support enabled")
+        add_definitions("-DSIRE_USE_CUSTOMVOLUMEFORCE")
+    else()
+        message(STATUS "OpenMM CustomVolumeForce not found (requires OpenMM >= 8.3) - LJ dispersion correction support disabled")
+    endif()
+
     # Check to see if Torch support has been disabled.
     if (NOT DEFINED ENV{SIRE_NO_TORCH})
         find_package(Torch)

--- a/wrapper/Convert/SireOpenMM/lambdalever.cpp
+++ b/wrapper/Convert/SireOpenMM/lambdalever.cpp
@@ -2059,6 +2059,7 @@ double LambdaLever::setLambda(OpenMM::Context &context,
             ghost_nonghostff->updateParametersInContext(context);
     }
 
+#ifdef SIRE_USE_CUSTOMVOLUMEFORCE
     // Update the ghost LJ dispersion correction via the CustomVolumeForce.
     // At r > rc the soft-core shift is negligible, so the standard closed-form
     // LJ tail integral applies. Results are cached per lambda state.
@@ -2146,6 +2147,7 @@ double LambdaLever::setLambda(OpenMM::Context &context,
             "ghost-lrc", "lrc_scale", 1.0, 1.0, lambda_value);
         context.setParameter("lrc_scale", lrc_scale);
     }
+#endif // SIRE_USE_CUSTOMVOLUMEFORCE
 
     // Update ring-breaking/making softcore force global parameters using the
     // values pre-computed before the per-mol loop (rb_alpha/kappa, rm_alpha/kappa).
@@ -2169,6 +2171,7 @@ double LambdaLever::setLambda(OpenMM::Context &context,
     if (ring_making_ff and has_changed_ring_making_ff)
         ring_making_ff->updateParametersInContext(context);
 
+#ifdef SIRE_USE_CUSTOMVOLUMEFORCE
     // Update the NonbondedForce (background) LRC via its own CustomVolumeForce.
     // Ghost atoms have epsilon=0 in cljff so they contribute nothing naturally.
     auto background_lrc_ff = this->getForce<OpenMM::CustomVolumeForce>("background-lrc", system);
@@ -2234,6 +2237,7 @@ double LambdaLever::setLambda(OpenMM::Context &context,
 
         context.setParameter("lrc_background", lrc_coeff);
     }
+#endif // SIRE_USE_CUSTOMVOLUMEFORCE
 
     if (ghost_14ff and has_changed_ghost14ff)
         ghost_14ff->updateParametersInContext(context);

--- a/wrapper/Convert/SireOpenMM/lambdalever.h
+++ b/wrapper/Convert/SireOpenMM/lambdalever.h
@@ -259,11 +259,13 @@ namespace SireOpenMM
         return "OpenMM::CustomCVForce";
     }
 
+#ifdef SIRE_USE_CUSTOMVOLUMEFORCE
     template <>
     inline QString _get_typename<OpenMM::CustomVolumeForce>()
     {
         return "OpenMM::CustomVolumeForce";
     }
+#endif
 
     template <>
     inline QString _get_typename<SireOpenMM::QMForce>()

--- a/wrapper/Convert/SireOpenMM/sire_to_openmm_system.cpp
+++ b/wrapper/Convert/SireOpenMM/sire_to_openmm_system.cpp
@@ -40,6 +40,7 @@
 #include "SireMaths/maths.h"
 #include "SireMaths/vector.h"
 
+#include "SireBase/console.h"
 #include "SireBase/generalunitproperty.h"
 #include "SireBase/lengthproperty.h"
 #include "SireBase/parallel.h"
@@ -1179,12 +1180,22 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
     // all non-perturbable atoms
     OpenMM::NonbondedForce *cljff = new OpenMM::NonbondedForce();
 
+#ifdef SIRE_USE_CUSTOMVOLUMEFORCE
     bool use_dispersion_correction = false;
 
     if (map.specified("use_dispersion_correction"))
     {
         use_dispersion_correction = map["use_dispersion_correction"].value().asABoolean();
     }
+#else
+    if (map.specified("use_dispersion_correction"))
+    {
+        SireBase::Console::warning(QObject::tr(
+            "use_dispersion_correction is not supported because this version of "
+            "Sire was built against OpenMM < 8.3, which lacks CustomVolumeForce. "
+            "The option will be ignored."));
+    }
+#endif
 
     bool is_gcmc = false;
     int num_gcmc_waters = 0;
@@ -1715,6 +1726,7 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
         lambda_lever.setForceIndex("ghost/non-ghost", system.addForce(ghost_nonghostff));
         lambda_lever.setForceGroup("ghost/non-ghost", force_group_counter++);
 
+#ifdef SIRE_USE_CUSTOMVOLUMEFORCE
         // Analytic LJ LRC: E = lrc_coeff / V, updated each lambda step via
         // a cached closed-form sum over interaction-group pairs.
         if (use_dispersion_correction && ffinfo.hasCutoff() && ffinfo.space().isPeriodic())
@@ -1727,6 +1739,7 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
             lambda_lever.setForceIndex("ghost-lrc", system.addForce(ghost_lrc_ff));
             lambda_lever.setForceGroup("ghost-lrc", force_group_counter++);
         }
+#endif // SIRE_USE_CUSTOMVOLUMEFORCE
 
         ghost_14ff->setForceGroup(force_group_counter);
         lambda_lever.setForceIndex("ghost-14", system.addForce(ghost_14ff));
@@ -1747,6 +1760,7 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
         }
     }
 
+#ifdef SIRE_USE_CUSTOMVOLUMEFORCE
     // Analytic LRC for the NonbondedForce (all non-ghost atoms): E = lrc_background / V,
     // updated each lambda step via a cached closed-form class-pair sum.
     if (use_dispersion_correction && ffinfo.hasCutoff() && ffinfo.space().isPeriodic())
@@ -1774,6 +1788,7 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
         lambda_lever.setForceIndex("gcmc-lrc", system.addForce(gcmc_lrc_ff));
         lambda_lever.setForceGroup("gcmc-lrc", force_group_counter++);
     }
+#endif // SIRE_USE_CUSTOMVOLUMEFORCE
 
     // Stage 4 is complete. We now have all(*) of the forces we need to run
     // a perturbable simulation. (*) well, we will define the restraint
@@ -2346,6 +2361,7 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
         ghost_nonghostff->addInteractionGroup(ghost_atoms_set, non_ghost_atoms_set);
     }
 
+#ifdef SIRE_USE_CUSTOMVOLUMEFORCE
     // Register GCMC water atom indices with the lambda lever and pre-compute the
     // fixed LRC coefficients (lrc_w_solute and lrc_ww_half) for the gcmc-lrc force.
     if (is_gcmc && use_dispersion_correction && ffinfo.hasCutoff() && ffinfo.space().isPeriodic())
@@ -2467,6 +2483,7 @@ OpenMMMetaData SireOpenMM::sire_to_openmm_system(OpenMM::System &system,
             }
         }
     }
+#endif // SIRE_USE_CUSTOMVOLUMEFORCE
 
     // see if we want to remove COM motion
     const auto com_remove_prop = map["com_reset_frequency"];


### PR DESCRIPTION
This PR guards against the absence of the OpenMM CustomVolumeForce, which was only introduced in versions 8.3+.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
