### PR TITLE
Fix issue #472

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -88,6 +88,10 @@ organisation on `GitHub <https://github.com/openbiosim/sire>`__.
   ``NonbondedForce`` alone, i.e. without softening, and without the subtraction of the
   coulomb energy that the softcore replaces.
 
+* Fixed ``Dynamics.current_potential_energy()`` returning a stale value after a
+  dynamics block that didn't save energies, since the context's energy cache was
+  only invalidated when an energy was recorded.
+
 `2026.1.0 <https://github.com/openbiosim/sire/compare/2025.4.0...2026.1.0>`__ - June 2026
 -----------------------------------------------------------------------------------------
 

--- a/src/sire/mol/_dynamics.py
+++ b/src/sire/mol/_dynamics.py
@@ -445,6 +445,10 @@ class DynamicsData:
             self._omm_state = self._omm_mols.getState(getEnergy=True)
             self._omm_state_has_cv = (False, False)
 
+        # dynamics has advanced the positions without going through
+        # setPositions(), so the context's energy cache is stale
+        self._omm_mols.clear_energy_cache()
+
         current_time = (
             self._omm_state.getTime().value_in_unit(openmm.unit.nanosecond) * nanosecond
         )
@@ -511,10 +515,6 @@ class DynamicsData:
                 nrg_sim_lambda_value = nrg
 
                 if lambda_windows is not None:
-                    # Positions have just changed (dynamics completed), so
-                    # invalidate all cached per-group energies before the scan.
-                    self._omm_mols.clear_energy_cache()
-
                     # get the index of the simulation lambda value in the
                     # lambda windows list
                     try:
@@ -573,10 +573,6 @@ class DynamicsData:
             # Store the current energies.
             self._nrgs = nrgs
             self._nrgs_array = nrgs_array
-
-            # Repex synchronisation point: a peer replica may push new
-            # positions into this context, so the cache must be invalidated.
-            self._omm_mols.clear_energy_cache()
 
             # update the interpolation lambda value
             if self._is_interpolate:

--- a/tests/mol/test_dynamics.py
+++ b/tests/mol/test_dynamics.py
@@ -301,3 +301,42 @@ def test_clock_and_energy_trajectory_swap(ala_mols):
     for r in range(num_replicas):
         assert len(cache_nrgs[r]) == num_cycles
         assert cache_nrgs[r] == ref_nrgs[r]
+
+
+@pytest.mark.skipif(
+    "openmm" not in sr.convert.supported_formats(),
+    reason="openmm support is not available",
+)
+def test_energy_cache_cleared_after_dynamics(ala_mols):
+    """
+    The context's energy cache must be invalidated after every dynamics block,
+    not just one that saved energies. The integrator advances the positions
+    without going through setPositions(), so nothing else clears it.
+    """
+    import openmm
+
+    mols = ala_mols
+
+    d = mols.dynamics(timestep="1fs", temperature="300K", platform="Reference")
+
+    def direct():
+        return (
+            d.context()
+            .getState(getEnergy=True)
+            .getPotentialEnergy()
+            .value_in_unit(openmm.unit.kilocalorie_per_mole)
+        )
+
+    assert d.current_potential_energy().value() == pytest.approx(direct())
+
+    # A block that doesn't record an energy.
+    d.run("50fs")
+    assert d.current_potential_energy().value() == pytest.approx(direct())
+
+    # A block that does.
+    d.run("50fs", energy_frequency="10fs")
+    assert d.current_potential_energy().value() == pytest.approx(direct())
+
+    # A block that doesn't, again, now that a trajectory exists.
+    d.run("50fs")
+    assert d.current_potential_energy().value() == pytest.approx(direct())


### PR DESCRIPTION
This PR closes #472 by clearing the context energy cache after every dynamics block. This didn't affect SOMD2 since we run blocks at cycles of the `energy_frequency` and don't call `current_potential_energy()` directly anway. The PR also removes some (now) redundant code.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a changelog entry to the changelog (we will add a link to this PR as part of the review): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
